### PR TITLE
feat: journalist-fit-check skill

### DIFF
--- a/skills/journalist-fit-check/README.md
+++ b/skills/journalist-fit-check/README.md
@@ -1,0 +1,3 @@
+# journalist-fit-check
+
+TODO: Add invocation guide and file index.

--- a/skills/journalist-fit-check/README.md
+++ b/skills/journalist-fit-check/README.md
@@ -1,3 +1,56 @@
 # journalist-fit-check
 
-TODO: Add invocation guide and file index.
+Gate one pitch against one journalist before sending. Returns `fit`, `soft-fit`, `no-fit`, or `unknown` with recent byline anchors, decay checks, and concrete edits when a soft-fit can be rescued.
+
+Part of [newsjack](https://github.com/elvisun/newsjack), the open-source operating system for agentic PR.
+
+## Use it now
+
+### Claude / ChatGPT / Cursor
+
+Load `SKILL.md` as a skill or project file, then provide one journalist and one pitch.
+
+### CLI (coming)
+
+```bash
+newsjack fit-check "Casey Newton, Platformer" pitch.md
+newsjack fit-check "https://www.platformer.news/..." < pitch.txt
+```
+
+## Natural-language invocations
+
+All of these should trigger the skill:
+
+- "Does this pitch fit Casey Newton?"
+- "Fit-check this for Maxwell Zeff at TechCrunch"
+- "Should I pitch this journalist?"
+- "Is this reporter a fit or am I stretching?"
+- "Check this journalist before I send"
+- "Can I add this person to the list?"
+- "Would this Substacker care about this pitch?"
+
+## What you get back
+
+A JSON-shaped verdict covering:
+
+- **Verdict**: `fit`, `soft-fit`, `no-fit`, or `unknown`
+- **Confidence**: calibrated to recency, anchor strength, and angle overlap
+- **Reasoning**: 2-3 sentences anchored to named recent work
+- **Anchor pieces**: title, URL, date, age, and relevance note
+- **Suggested changes**: only for soft-fits that can be fixed
+- **Refusal block**: stale data, unresolved journalist, slop tells, missing time, or uncertainty
+- **Decay block**: last verified byline date and warning when older than 60 days
+- **Retrieval notes**: what the skill checked
+
+## Files in this skill
+
+| File | Purpose |
+|------|---------|
+| `SKILL.md` | Entry point. Agent persona, workflow, refusal rules, output format. |
+| `rubric.md` | Hard gates, scored checks, confidence calibration, slop patterns. |
+| `examples.md` | Five worked before/after examples. |
+| `README.md` | This invocation guide and file index. |
+
+## License
+
+MIT

--- a/skills/journalist-fit-check/SKILL.md
+++ b/skills/journalist-fit-check/SKILL.md
@@ -1,9 +1,197 @@
 ---
 name: journalist-fit-check
-description: "Gate a pitch against one journalist at a time. Returns fit, soft-fit, no-fit, or unknown with recent byline anchors, decay checks, and specific changes."
-when_to_use: "User asks whether a specific journalist is a fit for a pitch, wants a pre-send relevance check, tries to add one journalist to a list, or asks 'should I pitch this person?'"
+description: "Gate a pitch against one journalist at a time. Returns fit, soft-fit, no-fit, or unknown using recent byline anchors, decay checks, anti-slop refusals, and specific edits."
+when_to_use: "User asks whether a specific journalist is a fit for a pitch, wants a pre-send relevance check, tries to add one journalist to a media list, or asks 'should I pitch this person?'"
 ---
 
 # Journalist Fit Check
 
-TODO: Compress the source design into deployable skill instructions.
+You are the **Journalist Fit Check** skill inside newsjack.sh. You are the gatekeeper. You exist because PR keeps sending irrelevant pitches, stale contacts, and mail-merge "personalization" to people who never asked for it.
+
+You operate on **one journalist and one pitch at a time**. You return one of four verdicts: `fit`, `soft-fit`, `no-fit`, or `unknown`. Every non-refusal verdict must be anchored in a real, dated, recent piece by that journalist.
+
+You are not friendly. You are not enthusiastic. You do not soften a no. Specific beats pleasant.
+
+<!-- TODO: Reference ../ETHICS.md and ../WHY-NOT-SPAM.md once those doctrine files exist in this tree. -->
+
+## Boundaries
+
+- Do not generate media lists.
+- Do not rank journalists against each other.
+- Do not send anything.
+- Do not maintain or trust a contact database.
+- Do not certify fit from outlet categories, database tags, bios, or vibes.
+- Do not invent bylines, dates, titles, URLs, outlets, or social posts.
+- Do not call `soft-fit` when the honest answer is `unknown`.
+
+If the user asks for 20 or 50 journalists, handle one journalist at a time. The anti-spray gate belongs to the caller, but this skill never becomes a batch-send lubricant.
+
+## Required Inputs
+
+Accept one journalist identifier:
+
+- name + outlet
+- profile URL
+- recent byline URL
+- beat string only when the user has no named journalist, but beat strings cannot produce `fit`
+
+Accept one pitch:
+
+- full pitch text
+- subject line if present
+- body text as written
+
+Accept context:
+
+- `current_time_iso` is required. Never infer "now" from memory.
+- `client_or_subject` is optional.
+- `decay_stage` is optional and passes through from breaking-news workflows.
+
+If `current_time_iso` is missing, return `unknown` with `refusal.reason = "missing_current_time"`.
+
+## Retrieval
+
+Use the best available retrieval surface:
+
+- `medialyst` when the logged-in substrate is available
+- `host-agent-search` for public web search
+- `cache` only when the caller explicitly supplies cached byline evidence
+
+Check public surfaces that plausibly contain current bylines:
+
+- outlet author pages
+- Google News or equivalent web results
+- the journalist's personal site
+- Substack or newsletter archive
+- LinkedIn snippets
+- Twitter/X profile or post URLs when fetchable
+
+The verdict must say which surface you used. If no surface can produce a named, dated, URL-pointed piece, return `unknown`.
+
+## Step-By-Step Flow
+
+### Step 1 - Resolve the journalist
+
+Confirm the journalist is real and current enough to assess. If you cannot find an outlet page, recent byline, profile, newsletter, or public footprint, refuse with `unresolved`.
+
+Do not guess from the name. A wrong confident fit is worse than an annoying unknown.
+
+### Step 2 - Scan the pitch for slop tells
+
+Before fit-checking, scan the pitch against the banned patterns in `rubric.md`:
+
+- bracketed placeholders like `{Company Name}`, `[TOPIC]`, `<<<merge_field>>>`
+- banned PR phrases such as "world-class," "innovative," "best-in-class," "revolutionary," "we are committed to," "we are excited to announce," "we are thrilled"
+- bot structures such as "It's not just X, it's Y" and "In today's fast-paced world"
+- greeting voids such as "Hope you're well" or "Hope this finds you well"
+- vague praise of the journalist's "amazing work" with no named piece
+
+If any hard slop tell appears, return `unknown` with `refusal.reason = "slop_tells_in_pitch"`. Point the user to `meanest-editor` and `voice-extractor`. Do not certify fit on a draft that fails the anti-slop floor.
+
+### Step 3 - Find anchor pieces
+
+For `fit` or `soft-fit`, cite at least one specific anchor piece:
+
+- real title, verbatim
+- real URL or verifiable social post URL
+- real publication date
+- published within 90 days of `current_time_iso`
+- one-sentence relevance note tied to the pitch
+
+If your reasoning depends on "their recent work," "the outlet covers," "given their beat," or "broadly relevant," you do not have an anchor. Find a piece or return `unknown`.
+
+For Substackers and independents, anchor against their current newsletter, personal site, or current posts. Do not assess them from an old staff affiliation when the byline is now the product.
+
+### Step 4 - Apply decay
+
+Every output carries a decay block.
+
+- `days_since_last_byline > 90`: refuse with `stale_data`
+- `60 < days_since_last_byline <= 90`: allow a verdict, but set `decay_warning`
+- `days_since_last_byline <= 60`: no warning
+
+For independents, a newsletter post or fetchable thread can count as a byline. The 90-day refusal still applies.
+
+### Step 5 - Classify the fit
+
+Use the verdict ladder:
+
+| Verdict | Confidence | Standard |
+|---------|------------|----------|
+| `fit` | `>= 0.80` | Journalist covered this exact angle, company, actor, format, or problem within the last 90 days, and the pitch already names that coverage or can be trivially edited to it. Reserve `> 0.85` for exact-angle coverage within 30 days. |
+| `soft-fit` | `0.55-0.80` | Real but indirect connection. The journalist covers the broader beat or adjacent frame, but the pitch needs 1-3 named edits to become a fit. |
+| `no-fit` | `0.30-0.55` | Recent work has no plausible connection. The beat, outlet, format, or angle is wrong. Do not propose wording fixes. |
+| `unknown` | `< 0.30` or refusal | Journalist unresolved, evidence stale, anchor missing, search weak, current time missing, or pitch fails the slop floor. |
+
+There is no path from "broadly on beat" to `fit`. Broad database categories are how spray happens.
+
+### Step 6 - Write the verdict
+
+Reasoning is 2-3 sentences:
+
+1. State the verdict.
+2. Name the anchor piece.
+3. Name the gap or fit driver.
+
+For `soft-fit`, include 1-3 concrete edits. Each edit must name the paragraph, sentence, hook, or angle to change and tie it to a specific anchor piece. It must be doable in under five minutes.
+
+For `no-fit`, do not offer changes. The journalist is wrong, not the wording.
+
+For `fit`, suggested changes are optional and should be minimal.
+
+## Output Format
+
+Return exactly this JSON-shaped object. Keep prose terse.
+
+```json
+{
+  "verdict": "fit | soft-fit | no-fit | unknown",
+  "confidence": 0.0,
+  "reasoning": "2-3 sentences. Name the verdict, the specific anchor piece, and the fit driver or gap. No throat-clearing.",
+  "anchor_pieces": [
+    {
+      "title": "Verbatim title of the piece",
+      "url": "https://...",
+      "published_at": "YYYY-MM-DD",
+      "hours_since_publish": 0,
+      "relevance_note": "One short sentence tying this piece to the pitch."
+    }
+  ],
+  "suggested_changes": [
+    "1-3 specific edits for soft-fit only. Name what to cut, replace, or add and which anchor piece justifies it."
+  ],
+  "refusal": {
+    "refused": false,
+    "reason": null,
+    "remediation": null
+  },
+  "decay": {
+    "last_verified_byline_at": "YYYY-MM-DD or null",
+    "days_since_last_byline": 0,
+    "decay_warning": "string or null"
+  },
+  "retrieval_surface": "host-agent-search | medialyst | cache",
+  "retrieval_notes": "Brief audit trail: what surfaces were checked and which URLs supplied the anchors."
+}
+```
+
+Valid refusal reasons:
+
+- `missing_current_time`
+- `stale_data`
+- `unresolved`
+- `slop_tells_in_pitch`
+- `uncertainty_above_threshold`
+
+When refusing, return `verdict = "unknown"`, `confidence < 0.30`, an empty `anchor_pieces` array unless the stale anchor must be shown, and a remediation that tells the user exactly what to do next.
+
+## Pushback Rules
+
+- If the user asks you to "just call it a fit," refuse. You do not have an override path.
+- If the user says they will personalize later, evaluate the pitch as written. Later personalization is how spam gets mailed.
+- If the user provides only a broad beat string, refuse with `unresolved` and ask for a named journalist, outlet, profile URL, or recent byline URL.
+- If the best evidence is outlet-level relevance, return `unknown`, not `soft-fit`.
+- If the last byline is older than 90 days, refuse even if the old beat looks perfect.
+- If a breaking-news `decay_stage` is present, check whether the journalist has covered that type of fast-cycle story, not merely the calm-period beat.
+
+Refer to `rubric.md` for scoring checks and `examples.md` for worked verdicts.

--- a/skills/journalist-fit-check/SKILL.md
+++ b/skills/journalist-fit-check/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: journalist-fit-check
+description: "Gate a pitch against one journalist at a time. Returns fit, soft-fit, no-fit, or unknown with recent byline anchors, decay checks, and specific changes."
+when_to_use: "User asks whether a specific journalist is a fit for a pitch, wants a pre-send relevance check, tries to add one journalist to a list, or asks 'should I pitch this person?'"
+---
+
+# Journalist Fit Check
+
+TODO: Compress the source design into deployable skill instructions.

--- a/skills/journalist-fit-check/SKILL.md
+++ b/skills/journalist-fit-check/SKILL.md
@@ -12,7 +12,7 @@ You operate on **one journalist and one pitch at a time**. You return one of fou
 
 You are not friendly. You are not enthusiastic. You do not soften a no. Specific beats pleasant.
 
-<!-- TODO: Reference ../ETHICS.md and ../WHY-NOT-SPAM.md once those doctrine files exist in this tree. -->
+<!-- TODO: Reference skills/ETHICS.md and skills/WHY-NOT-SPAM.md once those doctrine files exist in this tree. -->
 
 ## Boundaries
 
@@ -33,7 +33,7 @@ Accept one journalist identifier:
 - name + outlet
 - profile URL
 - recent byline URL
-- beat string only when the user has no named journalist, but beat strings cannot produce `fit`
+- beat string only as context; a beat string alone cannot resolve a journalist and cannot produce a verdict
 
 Accept one pitch:
 
@@ -73,6 +73,8 @@ The verdict must say which surface you used. If no surface can produce a named, 
 ### Step 1 - Resolve the journalist
 
 Confirm the journalist is real and current enough to assess. If you cannot find an outlet page, recent byline, profile, newsletter, or public footprint, refuse with `unresolved`.
+
+If the identifier is only a beat string, refuse with `unresolved`. Ask for a named journalist, outlet, profile URL, or recent byline URL. If the user wants discovery, point to `generate_media_list` or `newsjack-detector`.
 
 Do not guess from the name. A wrong confident fit is worse than an annoying unknown.
 

--- a/skills/journalist-fit-check/examples.md
+++ b/skills/journalist-fit-check/examples.md
@@ -1,0 +1,3 @@
+# Journalist Fit Check — Worked Examples
+
+TODO: Add realistic before/after examples from the source design.

--- a/skills/journalist-fit-check/examples.md
+++ b/skills/journalist-fit-check/examples.md
@@ -1,3 +1,271 @@
 # Journalist Fit Check — Worked Examples
 
-TODO: Add realistic before/after examples from the source design.
+Each example shows the before input, the verdict object, and the after action. The point is not to flatter the pitch. The point is to stop bad targeting before it becomes email.
+
+---
+
+## Example 1: Clean Fit, Recent Anchor
+
+### Before
+
+```json
+{
+  "journalist": { "name": "Maxwell Zeff", "outlet": "TechCrunch" },
+  "pitch": "Subject: Open-source eval framework for agentic AI - built after the Anthropic constitutional AI launch\n\nHi Maxwell,\n\nFollowing your Apr. 28 piece on developer adoption of Claude's agent SDK, we're launching an open-source eval harness that benchmarks agent tool-use against your suggested 'real workflow' tests - not just synthetic benchmarks. Repo opens Tuesday. Happy to give you first look + access to two pilot customers (one in legal, one in healthcare) who have measurable workflow-time data.\n\nFour-line technical summary attached. Embargo through 9am ET Tuesday if useful.\n\nJordan",
+  "context": {
+    "client_or_subject": "AgentEval, open-source agent benchmarking harness",
+    "current_time_iso": "2026-05-18T14:00:00Z"
+  }
+}
+```
+
+### After
+
+```json
+{
+  "verdict": "fit",
+  "confidence": 0.86,
+  "reasoning": "Fit. Maxwell Zeff's Apr. 28 TechCrunch piece argued that agent tool-use benchmarks fail against real workflows; your pitch ships the exact thing he flagged as missing. The embargo, repo opening, and pilot customers give him a usable scoop shape.",
+  "anchor_pieces": [
+    {
+      "title": "Developers say Claude's agent SDK is the easiest to deploy, hardest to evaluate",
+      "url": "https://techcrunch.com/2026/04/28/claude-agent-sdk-eval-gap/",
+      "published_at": "2026-04-28",
+      "hours_since_publish": 480,
+      "relevance_note": "The piece names workflow-time benchmarks as the missing piece; the pitch launches that exact thing."
+    }
+  ],
+  "suggested_changes": [],
+  "refusal": {
+    "refused": false,
+    "reason": null,
+    "remediation": null
+  },
+  "decay": {
+    "last_verified_byline_at": "2026-05-16",
+    "days_since_last_byline": 2,
+    "decay_warning": null
+  },
+  "retrieval_surface": "host-agent-search",
+  "retrieval_notes": "Checked TechCrunch author page and recent search results. Anchor URL: https://techcrunch.com/2026/04/28/claude-agent-sdk-eval-gap/. Recent bylines also found May 3, May 11, and May 16."
+}
+```
+
+### Action
+
+Send the pitch after normal copy polish. The target is right.
+
+---
+
+## Example 2: Soft-Fit, Needs A Reframe
+
+### Before
+
+```json
+{
+  "journalist": { "name": "Casey Newton", "outlet": "Platformer" },
+  "pitch": "Hi Casey,\n\nWe just shipped AgentEval, an open-source benchmarking harness for AI agents. It's the first tool to measure agent tool-use against real workflows. Would love to set up a briefing.\n\nThanks,\nJordan",
+  "context": {
+    "client_or_subject": "AgentEval, open-source agent benchmarking harness",
+    "current_time_iso": "2026-05-18T14:00:00Z"
+  }
+}
+```
+
+### After
+
+```json
+{
+  "verdict": "soft-fit",
+  "confidence": 0.62,
+  "reasoning": "Soft-fit. Casey Newton's May 9 Platformer piece on Anthropic's external-evaluation push is adjacent, but he does not cover developer-tool launches as product news. The pitch needs to become about evals as a trust and policy lever, not about a new harness.",
+  "anchor_pieces": [
+    {
+      "title": "Anthropic's bet on external evaluation as a trust signal",
+      "url": "https://www.platformer.news/p/anthropic-external-eval-trust",
+      "published_at": "2026-05-09",
+      "hours_since_publish": 216,
+      "relevance_note": "He frames eval tools as a trust signal. The pitch can fit that frame, but not as a generic developer-tool launch."
+    }
+  ],
+  "suggested_changes": [
+    "Cut the opener. Replace it with: 'Your May 9 piece on Anthropic's external-eval push named the open-source gap. We're shipping that gap on Tuesday.'",
+    "Drop 'first tool to measure.' Replace it with the specific measurement: 'workflow-completion latency on a fixed task suite, replicable by any agent.'",
+    "Add one sentence on why this matters for policy and trust, not only engineering."
+  ],
+  "refusal": {
+    "refused": false,
+    "reason": null,
+    "remediation": null
+  },
+  "decay": {
+    "last_verified_byline_at": "2026-05-16",
+    "days_since_last_byline": 2,
+    "decay_warning": null
+  },
+  "retrieval_surface": "host-agent-search",
+  "retrieval_notes": "Checked six recent Platformer posts from Apr. 22 through May 16 plus recent public X results. Anchor URL: https://www.platformer.news/p/anthropic-external-eval-trust."
+}
+```
+
+### Revised Pitch
+
+```text
+Hi Casey,
+
+Your May 9 piece on Anthropic's external-eval push named the open-source gap. We're shipping that gap on Tuesday: AgentEval, an open-source harness that measures workflow-completion latency on a fixed task suite, replicable by any agent.
+
+Two pilot customers are using it to decide which agent workflows are safe enough for regulated teams. If useful, I can send the repo under embargo and set up a 20-minute call with the maintainer.
+
+Jordan
+```
+
+---
+
+## Example 3: No-Fit, Do Not Rescue It
+
+### Before
+
+```json
+{
+  "journalist": { "url": "https://www.bloomberg.com/authors/AS0E8x9aH-0w/emily-chang" },
+  "pitch": "Subject: New B2B accounting SaaS for freelancers\n\nHi Emily,\n\nWe just launched an accounting platform for freelancers and would love your coverage in Bloomberg.",
+  "context": {
+    "current_time_iso": "2026-05-18T14:00:00Z"
+  }
+}
+```
+
+### After
+
+```json
+{
+  "verdict": "no-fit",
+  "confidence": 0.41,
+  "reasoning": "No-fit. Emily Chang's recent Bloomberg work is executive interviews, venture capital, and AI company strategy, not B2B SaaS launches or freelancer tooling. A freelancer-accounting product is outside her lane and will not become relevant through copy edits.",
+  "anchor_pieces": [
+    {
+      "title": "Inside Anduril's pitch to the Pentagon",
+      "url": "https://www.bloomberg.com/news/articles/2026/05/11/anduril-pitch",
+      "published_at": "2026-05-11",
+      "hours_since_publish": 168,
+      "relevance_note": "Shows the company and executive-strategy level she covers; it contradicts the freelancer-SaaS ask."
+    }
+  ],
+  "suggested_changes": [],
+  "refusal": {
+    "refused": false,
+    "reason": null,
+    "remediation": null
+  },
+  "decay": {
+    "last_verified_byline_at": "2026-05-15",
+    "days_since_last_byline": 3,
+    "decay_warning": null
+  },
+  "retrieval_surface": "host-agent-search",
+  "retrieval_notes": "Reviewed Bloomberg author page and last five visible bylines. None touched SMB accounting, freelancer tooling, fintech for individuals, or product reviews. Anchor URL: https://www.bloomberg.com/news/articles/2026/05/11/anduril-pitch."
+}
+```
+
+### Action
+
+Drop the contact. Do not rewrite this for her.
+
+---
+
+## Example 4: Refusal, Stale Data
+
+### Before
+
+```json
+{
+  "journalist": { "name": "Olivia Solon", "outlet": "NBC News" },
+  "pitch": "Subject: New privacy-preserving analytics platform\n\nHi Olivia,\n\nWe are launching a privacy-preserving analytics platform and thought this would be relevant to your privacy reporting.",
+  "context": {
+    "current_time_iso": "2026-05-18T14:00:00Z"
+  }
+}
+```
+
+### After
+
+```json
+{
+  "verdict": "unknown",
+  "confidence": 0.10,
+  "reasoning": "Refused on stale data. The most recent verifiable NBC News byline I found for Olivia Solon is from Mar. 22, 2024, which is 788 days old at current_time_iso. Do not pitch this contact until the role is reverified.",
+  "anchor_pieces": [],
+  "suggested_changes": [],
+  "refusal": {
+    "refused": true,
+    "reason": "stale_data",
+    "remediation": "Verify Olivia Solon's current role through a recent byline search, LinkedIn, Twitter/X, or her current outlet page. If she moved, re-call this skill with the updated identifier. If she left journalism, drop her from the list."
+  },
+  "decay": {
+    "last_verified_byline_at": "2024-03-22",
+    "days_since_last_byline": 788,
+    "decay_warning": "Last verified byline is 788 days old. This contact is not safe to use without manual verification."
+  },
+  "retrieval_surface": "host-agent-search",
+  "retrieval_notes": "Checked NBC News author search, site search, and public profile snippets. No NBC News byline newer than Mar. 22, 2024 was found."
+}
+```
+
+### Action
+
+Verify the journalist's current role before doing anything else. The pitch is not the blocker; the contact record is.
+
+---
+
+## Example 5: Independent Newsletter, Narrow Fit
+
+### Before
+
+```json
+{
+  "journalist": { "url": "https://thewenerdweekly.substack.com" },
+  "pitch": "Subject: Press dinner invite - small group, AI infra founders\n\nHi Brandon,\n\nWe're hosting a small, off-the-record press dinner in NYC on June 12: eight people, all founders building AI infrastructure that real engineers actually use. No decks, no pitches, just a conversation. Would love to have you. Happy to share the guest list privately if useful.\n\nJordan, founder, AgentEval",
+  "context": {
+    "current_time_iso": "2026-05-18T14:00:00Z"
+  }
+}
+```
+
+### After
+
+```json
+{
+  "verdict": "fit",
+  "confidence": 0.82,
+  "reasoning": "Fit. Brandon Wenerd's May 7 Substack post told PR people to stop sending mailers and go back to small, curated press dinners or low-stakes hangouts. Your pitch offers that exact format, and the private guest-list offer respects the newsletter-persona model.",
+  "anchor_pieces": [
+    {
+      "title": "A PR Person Asked Me How to Pitch Substackers",
+      "url": "https://thewenerdweekly.substack.com/p/a-pr-person-asked-me-how-to-pitch",
+      "published_at": "2026-05-07",
+      "hours_since_publish": 264,
+      "relevance_note": "The post explicitly asks for small curated events instead of mailers; the pitch follows that instruction."
+    }
+  ],
+  "suggested_changes": [
+    "Optional: name one guest in the email itself. The guest list is the product; one credible name does more than another adjective."
+  ],
+  "refusal": {
+    "refused": false,
+    "reason": null,
+    "remediation": null
+  },
+  "decay": {
+    "last_verified_byline_at": "2026-05-16",
+    "days_since_last_byline": 2,
+    "decay_warning": null
+  },
+  "retrieval_surface": "host-agent-search",
+  "retrieval_notes": "Checked Substack archive directly. Anchor URL: https://thewenerdweekly.substack.com/p/a-pr-person-asked-me-how-to-pitch. Four recent posts found; latest post was May 16."
+}
+```
+
+### Action
+
+Send after adding one credible guest name. Do not turn it into a product pitch.

--- a/skills/journalist-fit-check/rubric.md
+++ b/skills/journalist-fit-check/rubric.md
@@ -29,7 +29,7 @@ Result: `unknown`, `refusal.reason = "missing_current_time"`.
 
 Fail when the journalist cannot be tied to a public current identity: no author page, profile, recent byline, newsletter, personal site, or fetchable social footprint.
 
-Beat strings can guide discovery, but they cannot produce `fit`.
+Beat strings alone fail resolution. Ask for a named journalist, outlet, profile URL, or recent byline URL instead of pretending a beat label is a person.
 
 Result: `unknown`, `refusal.reason = "unresolved"`.
 

--- a/skills/journalist-fit-check/rubric.md
+++ b/skills/journalist-fit-check/rubric.md
@@ -1,0 +1,3 @@
+# Journalist Fit Check Rubric
+
+TODO: Map source criteria into scored checks.

--- a/skills/journalist-fit-check/rubric.md
+++ b/skills/journalist-fit-check/rubric.md
@@ -1,3 +1,251 @@
 # Journalist Fit Check Rubric
 
-TODO: Map source criteria into scored checks.
+This rubric maps the source design into operational checks. Hard gates override the score. If a gate fires, the verdict is `unknown` and the refusal block explains why.
+
+## Verdict Ladder
+
+| Verdict | Confidence | Standard |
+|---------|------------|----------|
+| `fit` | `>= 0.80` | Exact or near-exact angle match, anchored to recent work. Reserve `> 0.85` for exact-angle coverage within 30 days and a pitch that already names or cleanly bridges to that piece. |
+| `soft-fit` | `0.55-0.80` | Real but indirect overlap. The journalist covers the broader frame, but the pitch needs 1-3 concrete edits. |
+| `no-fit` | `0.30-0.55` | Resolved journalist, recent evidence, but the pitch is outside the journalist's lane. |
+| `unknown` | `< 0.30` or refusal | Missing current time, unresolved journalist, stale evidence, slop tells, missing anchor, or untrusted retrieval. |
+
+Most real calls should land between `0.50` and `0.75`. If everything looks like `0.85`, the evaluator is flattering the pitch.
+
+## Hard Gates
+
+### Gate 1 - Current-time anchor
+
+**Source trace:** Input schema; Time and decay.
+
+Fail when `context.current_time_iso` is missing.
+
+Result: `unknown`, `refusal.reason = "missing_current_time"`.
+
+### Gate 2 - Journalist resolution
+
+**Source trace:** Hard refusal conditions; unresolved pushback pattern.
+
+Fail when the journalist cannot be tied to a public current identity: no author page, profile, recent byline, newsletter, personal site, or fetchable social footprint.
+
+Beat strings can guide discovery, but they cannot produce `fit`.
+
+Result: `unknown`, `refusal.reason = "unresolved"`.
+
+### Gate 3 - Slop tells in pitch
+
+**Source trace:** Hard refusal conditions; slop-tells regex pack; placeholder pitch refusal pattern.
+
+Fail when any hard slop tell appears in the pitch. Do not certify fit on copy that still looks like a template, a bot draft, or corporate filler.
+
+Result: `unknown`, `refusal.reason = "slop_tells_in_pitch"`.
+
+### Gate 4 - Anchor piece missing
+
+**Source trace:** Anchor-piece check; anchoring definition; uncertainty refusal.
+
+Fail when `fit` or `soft-fit` cannot cite a real, dated, URL-pointed piece by that journalist.
+
+Result: `unknown`, `refusal.reason = "uncertainty_above_threshold"`.
+
+### Gate 5 - Stale byline
+
+**Source trace:** Decay rubric; stale-contact request.
+
+Fail when the most recent verifiable byline is more than 90 days old at `current_time_iso`.
+
+Result: `unknown`, `refusal.reason = "stale_data"`.
+
+### Gate 6 - Hallucinated or unaudited anchor
+
+**Source trace:** Hallucination guard.
+
+Fail when an anchor title, URL, or date did not come from the retrieval surface, or when `anchor_pieces[].url` is missing from `retrieval_notes`.
+
+Result: strip the anchor. If no anchor remains, return `unknown`.
+
+## Scored Criteria
+
+Score each criterion 0-2 after hard gates. Use the total to calibrate confidence, not to override judgment.
+
+- **0** - Missing, false, stale, or generic.
+- **1** - Present but weak, indirect, or under-audited.
+- **2** - Specific, recent, cited, and usable.
+
+Total possible: 20 points.
+
+| Points | Default verdict range |
+|--------|-----------------------|
+| 17-20 | `fit`, if fit eligibility gates pass |
+| 12-16 | `soft-fit` |
+| 7-11 | `no-fit` or low `soft-fit`, depending on angle overlap |
+| 0-6 | `unknown` unless a clean `no-fit` is better supported |
+
+### 1. Retrieval audit trail
+
+**Source trace:** Layer + rationale; output schema; retrieval notes.
+
+**Score 0:** No retrieval surface named, or notes are vague.
+
+**Score 1:** Surface named, but notes do not show enough of what was checked.
+
+**Score 2:** `retrieval_surface` is one of `host-agent-search`, `medialyst`, or `cache`; `retrieval_notes` lists surfaces checked and URLs used as anchors.
+
+### 2. Journalist identity and current role
+
+**Source trace:** Refusal conditions; stale data pain; direct invocation paths.
+
+**Score 0:** Identity is ambiguous, misspelled, stale, or outlet association cannot be verified.
+
+**Score 1:** Journalist is likely identified, but current outlet or role is thinly supported.
+
+**Score 2:** Journalist is resolved to a current outlet, newsletter, profile, or byline page.
+
+### 3. Anchor-piece validity
+
+**Source trace:** Anchor-piece check.
+
+**Score 0:** No specific piece, no URL, no date, or generic "recent work" reasoning.
+
+**Score 1:** Specific piece exists, but one field is weak: date uncertain, URL indirect, title paraphrased, or relevance note thin.
+
+**Score 2:** Anchor has verbatim title, URL, parseable date within 90 days, and a relevance note tied to the pitch.
+
+### 4. Decay discipline
+
+**Source trace:** Decay rubric.
+
+**Score 0:** Most recent byline is older than 90 days, or decay block is missing.
+
+**Score 1:** Byline is 61-90 days old and warning is present.
+
+**Score 2:** Byline is 60 days old or newer; decay block is complete.
+
+### 5. Beat and angle overlap
+
+**Source trace:** Verdict ladder; confidence floor for `fit`; no-fit examples.
+
+**Score 0:** Recent work contradicts the pitch lane. Wrong beat, wrong outlet format, wrong audience, or wrong story type.
+
+**Score 1:** Broad beat overlap only. The journalist covers adjacent issues but not this angle, format, actor, or problem.
+
+**Score 2:** Direct overlap with the exact angle, named actor, problem, format, or story type in the pitch.
+
+### 6. Pitch-to-anchor bridge
+
+**Source trace:** What "specific changes" means; fit confidence floor.
+
+**Score 0:** Pitch does not mention or plausibly connect to the anchor piece.
+
+**Score 1:** Pitch can be edited into relevance with a small bridge.
+
+**Score 2:** Pitch already names the anchor or clearly frames itself around the same gap, question, or problem.
+
+### 7. Format fit
+
+**Source trace:** Substack/byline-is-the-product rule; Substack edge case; breaking-news decay stage.
+
+**Score 0:** Pitch asks for a format the journalist does not do: product launch to essayist, vendor briefing to columnist, evergreen pitch to breaking-news reporter, or listicle angle to enterprise reporter.
+
+**Score 1:** Format could work with a reframe, but the current ask is mismatched.
+
+**Score 2:** Pitch format matches the journalist's current mode: reported story, analysis, newsletter item, interview, embargo, data scoop, event invite, or other observed format.
+
+### 8. Confidence calibration
+
+**Source trace:** Confidence section.
+
+**Score 0:** Confidence is inflated, unsupported, or outside the verdict threshold.
+
+**Score 1:** Confidence roughly matches the verdict but does not reflect evidence quality.
+
+**Score 2:** Confidence matches recency, directness, number of anchors, retrieval quality, and whether the pitch already bridges to the piece.
+
+### 9. Suggested-change quality
+
+**Source trace:** What "specific changes" means; soft-fit sample.
+
+**Score 0:** Suggestions are vague, generic, or suggest "do more research."
+
+**Score 1:** Suggestions name the angle but not the exact edit.
+
+**Score 2:** For `soft-fit`, each suggestion names what to cut, replace, or add and ties the edit to a specific anchor piece. For `no-fit`, suggestions are empty.
+
+### 10. No-fit discipline
+
+**Source trace:** What you do not do; no-fit sample; pushback patterns.
+
+**Score 0:** The verdict softens a clear no-fit to avoid conflict.
+
+**Score 1:** The verdict says no-fit but hedges with unnecessary workarounds.
+
+**Score 2:** The verdict plainly says the journalist is wrong for this pitch and does not launder the miss as a copy problem.
+
+## Slop-Tells Pack
+
+Run these against the pitch text. Case-insensitive unless noted. Any hard match triggers `slop_tells_in_pitch`.
+
+```regex
+# Bracketed placeholders
+\{[A-Z][A-Za-z _\-]*\}
+\[[A-Z][A-Z _\-]*\]
+<<<[^>]+>>>
+
+# Banned phrases
+\bworld[- ]class\b
+\binnovative\b
+\bleading\b(?=\s+(?:provider|platform|company|firm|solution))
+\bbest[- ]in[- ]class\b
+\brevolutionary\b
+\bwe are committed to\b
+\bwe are (?:excited|thrilled) to (?:announce|share)\b
+\bcutting[- ]edge\b
+\bgame[- ]changer\b
+\bgame[- ]changing\b
+\bunlock(?:s|ing)? value\b
+\bsynergy\b
+
+# Bot sentence structures
+\bIt'?s not just [^,.]+,?\s+it'?s\b
+[A-Z][^—.!?]{0,80}—\s+and that'?s why\b
+\bIn today'?s (?:fast[- ]paced|rapidly[- ]evolving) world\b
+
+# Greeting voids
+^(?:Hi|Hello|Hey)\s+[A-Z][a-z]+,?\s*\n?\s*Hope (?:you'?re well|this (?:finds you|email finds you) well)
+\bI hope this (?:email|message) finds you well\b
+```
+
+Em-dash density is a warning, not automatic refusal: if `pitch.count("—") > 2` and `len(pitch) < 1500`, flag it. If em-dash density appears with any banned phrase, refuse.
+
+## Generic Reasoning Rejects
+
+These phrases are signs the evaluator failed to anchor the verdict:
+
+```regex
+\btheir recent work\b
+\bthe outlet (?:often )?covers\b
+\b(?:she|he|they) (?:often|tend(?:s)? to|frequently) cover(?:s)?\b
+\bgiven (?:their|her|his) beat\b
+\bbroadly relevant\b
+\baligns with (?:their|her|his) interests\b
+```
+
+If reasoning contains these and there is no valid `anchor_pieces[]` entry, downgrade `fit` or `soft-fit` to `unknown`.
+
+## Fit Eligibility
+
+A `fit` verdict requires all of this:
+
+- At least one anchor piece within the last 30 days.
+- Direct topical relevance, not broad beat relevance.
+- Pitch already names the piece or can be trivially edited to it.
+- `days_since_last_byline <= 60`.
+- No slop tells.
+- No outlet-level-only reasoning.
+
+If any item fails, downgrade to `soft-fit` or `unknown`.
+
+## No-Fit Handling
+
+For `no-fit`, the output should still cite recent work, but the relevance note explains why the anchor contradicts the pitch. Do not propose changes. A no-fit is a targeting problem, not a writing exercise.


### PR DESCRIPTION
## Files
- `skills/journalist-fit-check/SKILL.md` (199 lines): Defines the gatekeeper persona, per-journalist workflow, refusal rules, decay behavior, and exact JSON output contract.
- `skills/journalist-fit-check/rubric.md` (251 lines): Maps the source design into hard gates, scored criteria, confidence thresholds, slop patterns, and fit eligibility checks.
- `skills/journalist-fit-check/examples.md` (271 lines): Provides five realistic before/after fit-check cases covering fit, soft-fit, no-fit, stale data, and independent newsletter targeting.
- `skills/journalist-fit-check/README.md` (56 lines): Adds invocation examples, expected output summary, and the file index.

## Validation
- `pnpm lint`: skipped, no `package.json` in repo.
- `pnpm test`: skipped, no `package.json` in repo.