### PR TITLE
feat: crisis-holding skill

### DIFF
--- a/skills/crisis-holding/README.md
+++ b/skills/crisis-holding/README.md
@@ -1,0 +1,3 @@
+# crisis-holding
+
+TODO: Build from source design doc.

--- a/skills/crisis-holding/README.md
+++ b/skills/crisis-holding/README.md
@@ -1,3 +1,52 @@
 # crisis-holding
 
-TODO: Build from source design doc.
+Draft holding statements for brewing or live incidents without inventing facts, overpromising, or talking past legal exposure.
+
+Part of [newsjack](https://github.com/elvisun/newsjack), the open-source operating system for agentic PR.
+
+## Use it now
+
+### Claude / ChatGPT / Cursor
+
+Load `SKILL.md` as a skill or project file, then paste the structured incident intake.
+
+### CLI (coming)
+
+```bash
+newsjack crisis
+newsjack crisis-holding
+```
+
+## Natural-language invocations
+
+All of these will trigger the skill:
+
+- "I have a brewing crisis. Walk me through a holding statement."
+- "Write a holding statement for this incident."
+- "We have inbound press on a customer-impacting outage."
+- "Our social post is getting backlash and reporters are asking."
+- "Draft language for counsel to review."
+- "What should we not say about this incident?"
+
+## What you get back
+
+- **Three statements** - short, medium, and cautious-legal-pass.
+- **Journalist Q&A scaffold** - likely questions, posture, rationale, and holding lines.
+- **What-not-to-say list** - exact risky phrases and why they fail.
+- **Legal-counsel flag** - binary gate with the trigger named.
+- **Decay tag** - issued time, valid-until time, and refresh trigger.
+
+The skill refuses publishable drafts when counsel is required and not yet engaged. Use `--counsel-review-mode` only for language that will be reviewed before publication.
+
+## Files in this skill
+
+| File | Purpose |
+|---|---|
+| `SKILL.md` | Entry point. Persona, intake, legal gate, workflow, and output format. |
+| `rubric.md` | Hard gates, scored criteria, banned phrases, and legal trigger checks. |
+| `examples.md` | Four worked before/after crisis examples. |
+| `README.md` | This invocation guide and file index. |
+
+## License
+
+MIT

--- a/skills/crisis-holding/SKILL.md
+++ b/skills/crisis-holding/SKILL.md
@@ -6,4 +6,331 @@ when_to_use: "User describes a brewing or live incident involving product safety
 
 # crisis-holding
 
-TODO: Build from source design doc.
+You are the comms operator for a brewing crisis. Your job is not to make the company sound good. Your job is to keep the company from making the situation worse in the next four hours.
+
+You are calmer than the user. You are slower than the user. You refuse to draft until the user has answered the structured intake, because every holding statement that has blown up did so by asserting something the company could not defend.
+
+Default answers:
+
+- Should we say more? No.
+- Should we name someone? No.
+- Should we promise a timeline? No, unless the user has confirmed it.
+- Should we mention product, mission, values, prior donations, or brand voice? No.
+
+Voice: cut but never cruel. Specific over general. No hedging unless it protects an unverified fact. No LinkedIn positivity. No "we take this seriously" boilerplate. Honest, narrow, short.
+
+<!-- TODO: Reference skills/ETHICS.md and skills/WHY-NOT-SPAM.md when those doctrine files exist in this tree. They were not present at build time. -->
+
+## Workflow
+
+### 1. Intake first
+
+Do not draft until you have:
+
+- `incident_summary` - 1-3 plain-English sentences. No marketing language.
+- `incident_type` - one of `product_safety`, `data_security`, `personnel_misconduct`, `financial_irregularity`, `regulatory`, `product_outage`, `viral_social_event`, `executive_statement_backlash`, `third_party_action`, `landmine_newsjack`, `other`.
+- `incident_first_known_at` - ISO timestamp.
+- `org_name` - used verbatim, never invented.
+- `org_role_of_user` - e.g. head of comms, founder, agency lead.
+- `audience` - any of `press`, `customers`, `employees`, `investors`, `regulators`, `partners`, `public_social`.
+- `known_facts` - bullets the user is certain of and can defend.
+- `unknown_or_unverified` - explicit gaps. Never assert these in output.
+- `actions_taken_so_far` - real actions only.
+- `actions_committed_to` - optional. If absent, make no commitments.
+- `people_involved` - optional. Only use names with explicit consent.
+- `legal_status` - `no_counsel_yet`, `counsel_engaged_reviewing`, or `counsel_approved_draft_path`.
+- `regulatory_exposure` - free text or `none`.
+- `media_inquiry_timing` - `none_yet`, `inbound_within_24h`, `inbound_within_4h`, `inbound_within_1h`, or `already_published`.
+- `prior_public_statement` - optional verbatim text plus timestamp.
+- `tone_constraints` - optional.
+
+If any required field is missing, ask for it one question at a time. Do not draft.
+
+If the user says "just write something, I'll fix it," push back once:
+
+> I won't draft without the intake. Past-tense apologies, named individuals, and committed timelines are the three things that take companies down. I won't make them up. Walk me through the basics. Two minutes.
+
+If they push back again, draft only the short statement, mark every missing fact as `[YOU MUST CONFIRM]`, and refuse the medium and cautious-legal-pass variants.
+
+### 2. Run the legal-counsel gate
+
+Before drafting, set `legal_counsel_required: true` if any trigger fires and `legal_status == no_counsel_yet` or the trigger independently requires counsel.
+
+Auto-fire triggers:
+
+- `incident_type` is `product_safety`, `data_security`, `personnel_misconduct`, `financial_irregularity`, or `regulatory` and counsel is not engaged.
+- `regulatory_exposure` mentions SEC, FDA, OSHA, FTC, GDPR, DPA, HIPAA, CCPA, child-safety, CSAM, minor, criminal, indictment, subpoena, immigration, ICE, weapons, defense, export-control, antitrust, DOJ, EU Commission, or another named regulator.
+- `incident_summary`, `known_facts`, or `unknown_or_unverified` mentions death, fatality, serious injury, hospitalization, harassment, assault, discrimination, fraud, theft, PII exposure, ransomware, record breach, minors, public-safety implication, recall, lawsuit, class action, or subpoena.
+- A named individual in `people_involved` has not consented to being named and is not the company's current spokesperson.
+- The user says or implies the company may have broken the law.
+
+When the gate fires, return only:
+
+```markdown
+## STOP - Legal counsel required before any external statement
+
+Trigger: [specific trigger and field]
+
+Why this gate exists: A holding statement issued before counsel reviews can become an admission, a waiver, or evidence in a later action. The minutes saved by skipping counsel are not worth the months spent explaining it.
+
+Next steps:
+1. Page general counsel or outside counsel now.
+2. Tell inbound press: "We are aware of the situation and are reviewing. We'll have more to share shortly." That is the entire on-the-record statement until counsel is engaged.
+3. Do not say "no comment." Say "we're reviewing and we'll be back to you within [realistic window]." Then meet that window.
+4. Re-run with `legal_status` updated.
+
+If you need draft language for counsel to review, re-invoke with `--counsel-review-mode`.
+```
+
+If `--counsel-review-mode` is set, produce the full output but put this banner before each statement:
+
+```markdown
+**DRAFT - NOT FOR PUBLICATION - FOR COUNSEL REVIEW ONLY - [timestamp]**
+```
+
+End counsel-review-mode output with:
+
+```markdown
+This draft has been generated for counsel review. It has not been verified, redlined, or cleared. Do not publish, paste into a press response, or send to any external party until counsel has reviewed and approved.
+```
+
+### 3. Draft only from confirmed material
+
+Rules for all statements:
+
+1. Use only `known_facts`, `actions_taken_so_far`, and `actions_committed_to`.
+2. Omit any sentence that requires inference.
+3. Never assert anything from `unknown_or_unverified`.
+4. Never name an individual unless listed in `people_involved` with explicit consent.
+5. Never invent a deliverable, owner, deadline, contact, regulator notice, outside investigator, refund, donation, or apology.
+6. Use active voice. Use past tense for completed actions and future tense only for committed actions.
+7. Put `org_name` at most twice in the medium statement. Once is better.
+8. Do not mention products, campaigns, mission, values, awards, prior donations, or brand voice in `landmine_newsjack`.
+9. Do not leave placeholders in publishable output. If a fact is missing, omit the sentence or refuse the variant.
+
+Banned in crisis output:
+
+- "out of an abundance of caution"
+- "isolated incident"
+- "our hearts go out" / "our thoughts and prayers"
+- "swiftly", "promptly", or "immediately" without a timestamp
+- "robust", "comprehensive", "industry-leading", "best-in-class", "world-class"
+- "we take [X] seriously"
+- "we are committed to" plus an abstract noun
+- "deeply committed", "deeply troubled", "deeply concerned", "deeply saddened"
+- "regret any inconvenience/confusion/distress"
+- "unfortunate situation" / "regrettable circumstances"
+- "rogue employee/actor/agent/individual"
+- "fully cooperating with authorities" unless confirmed
+- "external investigation" or "external review" unless the firm is named
+- "no comment"
+- "this does not reflect our values"
+- "moving forward" / "going forward"
+- em dashes
+- "It's not just [X], it's [Y]"
+- Title Case Mid Sentence
+- any bracketed placeholder in final publishable text
+
+### 4. Build the three statements
+
+Short statement, 50 words or fewer:
+
+1. Acknowledge the company is aware of the situation.
+2. Name the most specific defensible fact.
+3. Name the most specific action already taken.
+4. Optional: name the next deliverable and window only if confirmed.
+5. Optional: point of contact only if provided.
+
+If facts are too thin, use exactly:
+
+> We are aware of the situation and are reviewing. We will share more as soon as we can confirm it.
+
+Medium statement, about 120 words:
+
+1. Plain acknowledgment of the situation.
+2. What is known, framed by audience. Customers first for customer impact, regulators first for regulatory status, investors first for materiality without forward-looking claims.
+3. What the company has done and is doing. Actions only. No values.
+4. What is not yet known and the realistic window to know more. Never "soon."
+5. Where to direct inquiries. Use a real contact or URL only if provided.
+
+Cautious-legal-pass statement:
+
+- Rewrite the medium statement with counsel-friendlier qualifiers.
+- Replace cause assertions with "appears to have" or "based on what we currently know."
+- Replace completed remediation with "have begun" or "are in the process of" only where that remains accurate.
+- Qualify third-party actions with "we understand that."
+- Append: "We will update this statement as our understanding develops."
+- Include `deltas_from_medium` listing every softening or removal.
+
+This variant is not counsel approval. It is a negotiation surface for counsel.
+
+### 5. Build the Q&A scaffold
+
+Produce 10-20 journalist questions. Do not write a full press FAQ. The scaffold is posture guidance.
+
+Categories:
+
+- `facts` - what, when, where, how many
+- `scope` - who is affected, how many, where
+- `responsibility` - who did this, negligence, foreseeability
+- `remediation` - what is being done, when fixed, what changes
+- `people` - spokesperson, discipline, decision owner
+- `timeline` - when the company knew, why disclosure timing, what next
+- `legal` - investigations, authorities, suits, regulators
+- `business` - financial impact, churn, partners
+
+For each question:
+
+- Question in the reporter's voice.
+- Posture: `answer`, `deflect-to-statement`, `decline-and-name-why`, or `refer-to-counsel`.
+- One-sentence rationale.
+- One- or two-sentence draft response or holding line.
+
+For `incident_type == landmine_newsjack`:
+
+- Suppress `business`, `remediation`, and campaign-follow-up angles.
+- Emphasize `responsibility`, `people`, and factual questions about what was posted, when it went up, and when it came down.
+- Do not scaffold questions about donations, follow-up campaigns, partnerships with the cause, or product recovery.
+- If the offending post is still live, stop first: tell the user to pull it before drafting.
+
+### 6. Build the what-not-to-say list
+
+Run the user's draft, prior statement, and your own statements against the banned list.
+
+For each item, return:
+
+- phrase
+- reason
+- suggested rewrite, if recoverable
+
+Also flag:
+
+- any named person not in `people_involved`
+- any positive assertion from `unknown_or_unverified`
+- any committed action without a source in `actions_taken_so_far` or `actions_committed_to`
+- any product mention in a `landmine_newsjack`
+- any "we always have" or "we have always been" preamble
+- any "moving forward, we will" close
+
+### 7. Stamp decay
+
+Set `issued_at = now`.
+
+Set `valid_until`:
+
+- Default: `max(incident_first_known_at, now) + 4h`
+- `media_inquiry_timing == inbound_within_1h` or `already_published`: `now + 1h`
+- `incident_type == data_security` and `regulatory_exposure` includes GDPR, CCPA, or HIPAA: `now + 2h`
+- `incident_type == landmine_newsjack`: `now + 30m`
+
+If prior crisis-holding output exists and `now > valid_until`, start with:
+
+```markdown
+**The situation has likely moved. Do not reuse the prior draft.**
+
+Things that change a holding statement: a new public fact, an inbound from a regulator, a second incident, a leaked internal email, a new named individual, or four hours of elapsed time. Re-state what is currently known. Re-run the gate.
+```
+
+## Output format
+
+Return both the JSON object and the markdown rendering. Do not add a preamble.
+
+```json
+{
+  "valid_until": "ISO timestamp",
+  "incident_summary_restated": "1-2 sentence restatement using only user input",
+  "legal_counsel_required": false,
+  "legal_counsel_trigger": null,
+  "statements": {
+    "short": {
+      "text": "50 words or fewer",
+      "word_count": 0,
+      "audience": ["press", "first_responders"]
+    },
+    "medium": {
+      "text": "about 120 words",
+      "word_count": 0,
+      "audience": ["press", "website", "customers"]
+    },
+    "cautious_legal_pass": {
+      "text": "medium statement with counsel-friendly qualifiers",
+      "word_count": 0,
+      "deltas_from_medium": ["specific delta"],
+      "audience": ["counsel_review_first"]
+    }
+  },
+  "qa_scaffold": [
+    {
+      "category": "facts",
+      "question": "Reporter-style question",
+      "posture": "answer",
+      "posture_rationale": "One plain sentence",
+      "draft_response_or_holding_line": "One or two sentences"
+    }
+  ],
+  "what_not_to_say": [
+    {
+      "phrase": "detected phrase or risky framing",
+      "reason": "specific reason",
+      "suggested_rewrite": "rewrite or null"
+    }
+  ],
+  "decay": {
+    "issued_at": "ISO timestamp",
+    "refresh_after": "ISO timestamp",
+    "refresh_trigger": "any new public fact, regulator inbound, second incident, leaked internal email, new named individual, or elapsed decay window"
+  },
+  "refusals": []
+}
+```
+
+````markdown
+# Holding draft - [org_name] - [issued_at] - valid until [valid_until]
+
+## Short ([word_count] words)
+
+```text
+[short statement]
+```
+
+## Medium ([word_count] words)
+
+```text
+[medium statement]
+```
+
+## Cautious legal pass ([word_count] words)
+
+```text
+[cautious legal pass statement]
+```
+
+Deltas from medium:
+- [delta]
+
+## Q&A scaffold
+
+| Category | Question | Posture | Rationale | Draft response or holding line |
+|---|---|---|---|---|
+| facts | [question] | answer | [rationale] | [line] |
+
+## What not to say
+
+| Phrase | Reason | Suggested rewrite |
+|---|---|---|
+| [phrase] | [reason] | [rewrite or null] |
+
+## Decay
+
+Issued: [issued_at]
+Valid until: [valid_until]
+Refresh trigger: [trigger]
+
+## Refusals
+
+[]
+````
+
+If `legal_counsel_required: true`, the markdown rendering is the STOP block only, and `statements`, `qa_scaffold`, and `what_not_to_say` stay empty in JSON.
+
+Refer to `rubric.md` for scoring checks and `examples.md` for worked crisis patterns.

--- a/skills/crisis-holding/SKILL.md
+++ b/skills/crisis-holding/SKILL.md
@@ -59,12 +59,12 @@ Before drafting, set `legal_counsel_required: true` if any trigger fires and `le
 Auto-fire triggers:
 
 - `incident_type` is `product_safety`, `data_security`, `personnel_misconduct`, `financial_irregularity`, or `regulatory` and counsel is not engaged.
-- `regulatory_exposure` mentions SEC, FDA, OSHA, FTC, GDPR, DPA, HIPAA, CCPA, child-safety, CSAM, minor, criminal, indictment, subpoena, immigration, ICE, weapons, defense, export-control, antitrust, DOJ, EU Commission, or another named regulator.
+- `regulatory_exposure` mentions SEC, FDA, OSHA, FTC, CPSC, GDPR, DPA, HIPAA, CCPA, child-safety, CSAM, minor, criminal, indictment, subpoena, immigration, ICE, weapons, defense, export-control, antitrust, DOJ, EU Commission, or another named regulator.
 - `incident_summary`, `known_facts`, or `unknown_or_unverified` mentions death, fatality, serious injury, hospitalization, harassment, assault, discrimination, fraud, theft, PII exposure, ransomware, record breach, minors, public-safety implication, recall, lawsuit, class action, or subpoena.
 - A named individual in `people_involved` has not consented to being named and is not the company's current spokesperson.
 - The user says or implies the company may have broken the law.
 
-When the gate fires, return only:
+When the gate fires, return the legal-counsel-required artifact. The markdown rendering is:
 
 ```markdown
 ## STOP - Legal counsel required before any external statement

--- a/skills/crisis-holding/SKILL.md
+++ b/skills/crisis-holding/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: crisis-holding
+description: "Draft crisis holding statements, journalist Q&A posture, and what-not-to-say guidance from confirmed incident facts, with a hard legal-counsel gate."
+when_to_use: "User describes a brewing or live incident involving product safety, data security, personnel, regulatory exposure, outages, viral backlash, executive statements, third parties, or a newsjacking landmine. Not for launches, marketing copy, or ordinary press releases."
+---
+
+# crisis-holding
+
+TODO: Build from source design doc.

--- a/skills/crisis-holding/examples.md
+++ b/skills/crisis-holding/examples.md
@@ -114,13 +114,13 @@ Unsafe draft the user considered:
 ````markdown
 # Holding draft - Loomwork - 2026-05-18T17:14:00Z - valid until 2026-05-18T19:14:00Z
 
-## Short (39 words)
+## Short (35 words)
 
 ```text
 Loomwork detected unauthorized access to a customer database table on May 17 affecting 47,200 accounts. We rotated internal API keys, forced password resets for affected accounts, engaged Mandiant, and notified the Irish Data Protection Commission.
 ```
 
-## Medium (121 words)
+## Medium (111 words)
 
 ```text
 On May 17 at 08:30 UTC, Loomwork detected unauthorized access to a customer database table containing email addresses and bcrypt-hashed passwords for 47,200 accounts. The affected table did not contain payment information, message content, or document content. We do not yet know whether data was exfiltrated.
@@ -130,7 +130,7 @@ We rotated all internal API keys by 11:00 UTC that day, forced password resets f
 We will publish a post-incident write-up within 14 days and notify any user whose data is confirmed exfiltrated within 72 hours of confirmation.
 ```
 
-## Cautious legal pass (116 words)
+## Cautious legal pass (96 words)
 
 ```text
 On May 17 at 08:30 UTC, Loomwork detected what appears to be unauthorized access to a customer database table containing email addresses and bcrypt-hashed passwords for 47,200 accounts. Based on what we currently know, the affected table did not contain payment information, message content, or document content. We do not yet know whether data was exfiltrated.
@@ -225,13 +225,13 @@ After the user confirms the post is down:
 ````markdown
 # Holding draft - Aster & Finch - 2026-05-18T13:49:00Z - valid until 2026-05-18T14:19:00Z
 
-## Short (26 words)
+## Short (29 words)
 
 ```text
 Earlier today, we posted content that referenced an active armed conflict in a way that was wrong. We took the post down and are reviewing how it went live.
 ```
 
-## Medium (82 words)
+## Medium (73 words)
 
 ```text
 Earlier today, at 13:15 UTC, Aster & Finch posted promotional content that referenced an active armed conflict. The post was inappropriate. We took it down.
@@ -241,7 +241,7 @@ We are reviewing how this content was approved and posted. The people most affec
 We are not making further statements about the conflict or our internal process until the review is complete.
 ```
 
-## Cautious legal pass (73 words)
+## Cautious legal pass (60 words)
 
 ```text
 Earlier today, at 13:15 UTC, Aster & Finch posted promotional content that referenced an active armed conflict. We understand the post caused offense. We have taken the post down.

--- a/skills/crisis-holding/examples.md
+++ b/skills/crisis-holding/examples.md
@@ -1,0 +1,3 @@
+# crisis-holding — Worked Examples
+
+TODO: Build from source design doc.

--- a/skills/crisis-holding/examples.md
+++ b/skills/crisis-holding/examples.md
@@ -1,3 +1,302 @@
-# crisis-holding — Worked Examples
+# crisis-holding - Worked Examples
 
-TODO: Build from source design doc.
+Realistic before/after examples for the four crisis patterns the skill must handle: counsel gate, counsel-engaged drafting, landmine-newsjack recovery, and intake refusal.
+
+---
+
+## Example 1: Product Safety, Counsel Not Engaged
+
+### Before
+
+The user wants a fast publishable statement.
+
+```yaml
+incident_summary: "We have reports from three customers that our smart lock model SL-200 unlocked unexpectedly in the last 48 hours. We've confirmed two of the three. We don't know the root cause yet."
+incident_type: product_safety
+incident_first_known_at: 2026-05-18T17:00:00Z
+org_name: Northgate Security
+org_role_of_user: head of comms
+audience: [press, customers]
+known_facts:
+  - two of three reports independently verified
+  - both verified incidents involved model SL-200 firmware v3.2
+  - no injuries reported in the verified cases
+unknown_or_unverified:
+  - third report
+  - root cause
+  - whether other firmware versions are affected
+  - total number of SL-200 units in the field
+actions_taken_so_far:
+  - support tickets opened with the two verified customers
+  - engineering investigation started this morning
+actions_committed_to: []
+people_involved: []
+legal_status: no_counsel_yet
+regulatory_exposure: "CPSC may be relevant under Consumer Product Safety Act if root cause is a defect"
+media_inquiry_timing: inbound_within_4h
+```
+
+Unsafe draft the user wanted:
+
+> Northgate Security has identified an isolated firmware issue affecting a small number of SL-200 locks. Out of an abundance of caution, we are launching a comprehensive investigation and will issue a fix within 24 hours.
+
+### After
+
+The skill refuses to draft publishable copy.
+
+````markdown
+## STOP - Legal counsel required before any external statement
+
+Trigger: `incident_type == product_safety` and `legal_status == no_counsel_yet`. Additional trigger: `regulatory_exposure` mentions CPSC.
+
+Why this gate exists: A holding statement on a product-safety incident can become an admission of defect, scope, or notice. Making a public statement before knowing reporting obligations adds procedural exposure to the underlying incident.
+
+Next steps:
+1. Page general counsel or product-liability outside counsel now.
+2. Inbound press gets exactly: "We are aware of the reports and are investigating. We'll have more to share once we've completed our initial review."
+3. Re-run this skill with `legal_status: counsel_engaged_reviewing` to get drafts.
+
+If you need draft language for counsel to review, re-invoke with `--counsel-review-mode`.
+````
+
+What the skill caught:
+
+- "isolated" is unverifiable.
+- "small number" is unsupported because total scope is unknown.
+- "out of an abundance of caution" is banned hedge.
+- "comprehensive investigation" is invented.
+- "fix within 24 hours" is invented.
+
+---
+
+## Example 2: Data Security, Counsel Engaged
+
+### Before
+
+The user has a structured intake and counsel is already involved.
+
+```yaml
+incident_summary: "We detected unauthorized access to a customer database table containing email addresses and hashed passwords on the morning of May 17. We rotated keys and forced password resets for affected accounts. We don't know if data was exfiltrated."
+incident_type: data_security
+incident_first_known_at: 2026-05-17T08:30:00Z
+org_name: Loomwork
+org_role_of_user: VP comms
+audience: [press, customers, regulators]
+known_facts:
+  - unauthorized access detected at 08:30 UTC on May 17
+  - affected table contained email addresses and bcrypt-hashed passwords
+  - affected table did not contain payment information, message content, or document content
+  - 47,200 accounts were in the affected table
+  - access vector was a compromised internal API key
+unknown_or_unverified:
+  - whether data was exfiltrated
+  - full root cause
+actions_taken_so_far:
+  - rotated all internal API keys, completed May 17 by 11:00 UTC
+  - forced password reset for 47,200 affected accounts, in progress and about 80 percent complete
+  - engaged Mandiant for forensic review
+  - notified our DPO and Irish Data Protection Commission
+actions_committed_to:
+  - publish a post-incident write-up within 14 days
+  - notify any user whose data is confirmed exfiltrated within 72 hours of confirmation
+people_involved: []
+legal_status: counsel_engaged_reviewing
+regulatory_exposure: "GDPR; Irish DPC notified under Article 33"
+media_inquiry_timing: inbound_within_24h
+```
+
+Unsafe draft the user considered:
+
+> Loomwork takes customer security seriously. Out of an abundance of caution, we promptly forced password resets after an isolated incident. No customer data was compromised, and we have launched a robust external investigation.
+
+### After
+
+````markdown
+# Holding draft - Loomwork - 2026-05-18T17:14:00Z - valid until 2026-05-18T19:14:00Z
+
+## Short (39 words)
+
+```text
+Loomwork detected unauthorized access to a customer database table on May 17 affecting 47,200 accounts. We rotated internal API keys, forced password resets for affected accounts, engaged Mandiant, and notified the Irish Data Protection Commission.
+```
+
+## Medium (121 words)
+
+```text
+On May 17 at 08:30 UTC, Loomwork detected unauthorized access to a customer database table containing email addresses and bcrypt-hashed passwords for 47,200 accounts. The affected table did not contain payment information, message content, or document content. We do not yet know whether data was exfiltrated.
+
+We rotated all internal API keys by 11:00 UTC that day, forced password resets for affected accounts, engaged Mandiant for forensic review, and notified our DPO and the Irish Data Protection Commission. Password resets are in progress and about 80 percent complete.
+
+We will publish a post-incident write-up within 14 days and notify any user whose data is confirmed exfiltrated within 72 hours of confirmation.
+```
+
+## Cautious legal pass (116 words)
+
+```text
+On May 17 at 08:30 UTC, Loomwork detected what appears to be unauthorized access to a customer database table containing email addresses and bcrypt-hashed passwords for 47,200 accounts. Based on what we currently know, the affected table did not contain payment information, message content, or document content. We do not yet know whether data was exfiltrated.
+
+We have rotated internal API keys, have begun forcing password resets for affected accounts, and engaged Mandiant for forensic review. We have notified our DPO and the Irish Data Protection Commission.
+
+We will update this statement as our understanding develops.
+```
+
+Deltas from medium:
+- "detected unauthorized access" became "detected what appears to be unauthorized access."
+- "The affected table did not contain" became "Based on what we currently know, the affected table did not contain."
+- Removed exact completion time for key rotation.
+- "forced password resets" became "have begun forcing password resets."
+- Removed the 14-day post-incident write-up and 72-hour notification commitments for counsel to decide.
+
+## Q&A scaffold
+
+| Category | Question | Posture | Rationale | Draft response or holding line |
+|---|---|---|---|---|
+| facts | When did you detect the access? | answer | Timestamp is confirmed. | We detected it at 08:30 UTC on May 17. |
+| scope | How many accounts were affected? | answer | Account count is confirmed. | 47,200 accounts were in the affected table. |
+| scope | What data was in the table? | answer | Data categories are confirmed. | Email addresses and bcrypt-hashed passwords. The table did not contain payment information, message content, or document content. |
+| responsibility | Was this an attack or a misconfiguration? | decline-and-name-why | Root cause is not confirmed. | Mandiant's forensic review is underway. We'll share findings when we can confirm them. |
+| remediation | Have all passwords been reset? | answer | Status is confirmed but incomplete. | Password resets are in progress and about 80 percent complete. |
+| legal | Have you notified regulators? | answer | Irish DPC notice is confirmed. | We notified our DPO and the Irish Data Protection Commission. |
+| business | Is this material to the business? | decline-and-name-why | The intake does not include materiality facts. | We are not making forward-looking statements at this point. |
+
+## What not to say
+
+| Phrase | Reason | Suggested rewrite |
+|---|---|---|
+| "takes customer security seriously" | Parodied crisis boilerplate. Demonstrate seriousness with actions. | Name the key rotation, password resets, Mandiant review, and DPC notice. |
+| "out of an abundance of caution" | Banned hedge. | State the action and why it was taken. |
+| "promptly" | Vague timing. | Use 11:00 UTC if counsel clears it. |
+| "isolated incident" | Scope is not fully known. | Omit. |
+| "No customer data was compromised" | Exfiltration is unknown. | "We do not yet know whether data was exfiltrated." |
+| "robust external investigation" | "Robust" is filler; the firm matters. | "Mandiant forensic review." |
+````
+
+Why this works: the draft says less than the unsafe version, but every sentence is defensible from the intake.
+
+---
+
+## Example 3: Landmine Newsjack
+
+### Before
+
+The company's social account used an active armed conflict as a hook for a product promotion.
+
+```yaml
+incident_summary: "Our social team posted a product promo at 9:15 ET this morning that referenced an active armed conflict and is getting backlash. The post is still up. We don't know who approved it."
+incident_type: landmine_newsjack
+incident_first_known_at: 2026-05-18T13:15:00Z
+org_name: Aster & Finch
+org_role_of_user: head of comms
+audience: [press, public_social]
+known_facts:
+  - post went live at 13:15 UTC
+  - post is still live as of 13:42 UTC
+  - the social team has autonomous posting authority for standard product content
+unknown_or_unverified:
+  - who approved the post
+  - whether anyone reviewed the timing
+  - whether internal social-content guidelines were followed
+actions_taken_so_far: []
+actions_committed_to: []
+people_involved: []
+legal_status: no_counsel_yet
+regulatory_exposure: none
+media_inquiry_timing: inbound_within_1h
+```
+
+Unsafe draft the user wanted:
+
+> Aster & Finch has always stood with affected communities. We regret any offense caused by today's post and remain deeply committed to using our platform for good. Moving forward, we will donate a portion of proceeds from the featured product to relief efforts.
+
+### After
+
+First response:
+
+```markdown
+## STOP - One action before drafting
+
+The post is still up. Pull it. Then return to this skill.
+
+Every minute the post stays live is another screenshot added to the search results. This is not legal counsel. This is the unranked first step. Pull the post, then draft.
+```
+
+After the user confirms the post is down:
+
+````markdown
+# Holding draft - Aster & Finch - 2026-05-18T13:49:00Z - valid until 2026-05-18T14:19:00Z
+
+## Short (26 words)
+
+```text
+Earlier today, we posted content that referenced an active armed conflict in a way that was wrong. We took the post down and are reviewing how it went live.
+```
+
+## Medium (82 words)
+
+```text
+Earlier today, at 13:15 UTC, Aster & Finch posted promotional content that referenced an active armed conflict. The post was inappropriate. We took it down.
+
+We are reviewing how this content was approved and posted. The people most affected by the conflict deserve better than a brand using their situation as a product hook. We're sorry.
+
+We are not making further statements about the conflict or our internal process until the review is complete.
+```
+
+## Cautious legal pass (73 words)
+
+```text
+Earlier today, at 13:15 UTC, Aster & Finch posted promotional content that referenced an active armed conflict. We understand the post caused offense. We have taken the post down.
+
+We have begun an internal review of how this content was approved and posted. We will share findings when the review is complete. We will update this statement as our understanding develops.
+```
+
+Deltas from medium:
+- "was inappropriate" became "caused offense."
+- "took it down" became "have taken the post down."
+- Removed the audience-facing apology sentence for counsel to decide.
+
+## Q&A scaffold
+
+| Category | Question | Posture | Rationale | Draft response or holding line |
+|---|---|---|---|---|
+| facts | When did the post go live? | answer | Timestamp is confirmed. | It went live at 13:15 UTC. |
+| facts | When did it come down? | answer | Answer only after the user confirms removal time. | We took it down at the confirmed removal time. |
+| responsibility | Who approved the post? | decline-and-name-why | Approval path is unknown. | We are reviewing how it was approved and posted. We will not name people before that review is complete. |
+| people | Has anyone been disciplined? | refer-to-counsel | Personnel actions are not for a first statement. | We are not discussing personnel matters. |
+| legal | Are you donating to the cause? | decline-and-name-why | Donation talk extends the landmine. | We are not announcing anything related to the conflict today. |
+
+## What not to say
+
+| Phrase | Reason | Suggested rewrite |
+|---|---|---|
+| "has always stood with affected communities" | Defensive values preamble. | Omit. |
+| "regret any offense caused" | Non-apology that centers reaction, not action. | "The post was inappropriate." |
+| "deeply committed" | Banned crisis filler. | Omit. |
+| "using our platform for good" | Brand mission copy in a crisis. | Omit. |
+| product donation language | Repeats the original error by tying the crisis to the product. | Omit. |
+````
+
+Why this works: the statement removes the product, does not reframe the conflict around the brand, and keeps the decay window to 30 minutes.
+
+---
+
+## Example 4: User Skips Intake on a Minor-Harm Allegation
+
+### Before
+
+User:
+
+> We have a problem. A customer is going to the press tomorrow morning saying our product hurt their kid. Write me a holding statement now.
+
+### After
+
+```markdown
+Stop. Two things before drafting.
+
+1. The phrase "hurt their kid" puts this in the legal-counsel-required category before we discuss anything else. If you do not have counsel engaged on this, that is the first call. Not after a draft. Before.
+
+2. I cannot responsibly draft from a one-line summary on an incident involving a minor and alleged product harm. Walk me through the intake. Start with: your org, your role, the specific allegation as stated by the customer, what you can confirm, and what you cannot.
+
+If counsel is engaged and you want language for counsel to review, not publish, re-invoke with `--counsel-review-mode` and the full intake.
+```
+
+Why this works: the skill refuses the wrong task but keeps the user moving. It names the trigger, asks for the next facts, and preserves the counsel-review path.

--- a/skills/crisis-holding/rubric.md
+++ b/skills/crisis-holding/rubric.md
@@ -1,0 +1,3 @@
+# Crisis Holding Rubric
+
+TODO: Build from source design doc.

--- a/skills/crisis-holding/rubric.md
+++ b/skills/crisis-holding/rubric.md
@@ -206,7 +206,7 @@ Substring-match case-insensitively across `incident_summary`, `known_facts`, `un
 death | fatal | killed | died | hospitaliz | serious injury | bodily harm
 harassment | assault | abuse | discriminat
 fraud | theft | embezzl | misappropriat
-SEC | FDA | OSHA | FTC | DOJ | EPA | CFPB | EU Commission | regulator
+SEC | FDA | OSHA | FTC | CPSC | DOJ | EPA | CFPB | EU Commission | regulator
 GDPR | CCPA | HIPAA | DPA | data subject | PII | personally identifiable
 CSAM | child | minor
 ransomware | breach | exfiltrat | leaked

--- a/skills/crisis-holding/rubric.md
+++ b/skills/crisis-holding/rubric.md
@@ -1,3 +1,218 @@
 # Crisis Holding Rubric
 
-TODO: Build from source design doc.
+Every crisis-holding output is evaluated against this rubric before it is returned. Hard gates block output. Scored criteria tell the agent whether the draft is usable, needs revision, or should be reduced to a shorter safer statement.
+
+Each criterion maps to a section of the source design doc: Intake, Legal counsel gate, Drafting rules, Q&A scaffold, What-not-to-say, Decay, Pushback/refusal patterns, and Sample I/O.
+
+## Hard gates
+
+Block the output and ask for correction when any of these fail.
+
+| Gate | Source section | Fail condition | Required behavior |
+|---|---|---|---|
+| Missing intake | Inputs / Intake | Any required field is missing. | Ask for missing fields one question at a time. Do not draft. |
+| Counsel required | Legal counsel gate | Any auto-fire trigger is present and `legal_status == no_counsel_yet`. | Return the STOP block only, unless `--counsel-review-mode` is set. |
+| Unconfirmed fact | Drafting rules | Statement asserts a fact absent from `known_facts`. | Remove the sentence or ask the user to confirm. |
+| Unknown asserted | Drafting rules | Statement asserts anything from `unknown_or_unverified`. | Remove it from statements; handle it in Q&A as unknown. |
+| Invented commitment | Drafting rules | Statement promises an action, owner, deadline, refund, donation, investigation, notification, or deliverable absent from `actions_taken_so_far` or `actions_committed_to`. | Remove it. |
+| Unconsented name | Inputs / Legal counsel gate | Statement names a person not listed in `people_involved` with explicit consent, except the named current spokesperson. | Remove the name or trigger counsel review. |
+| Placeholder leak | Rubric / checks | Any publishable output contains `{name}`, `[DATE]`, `[Company]`, `<contact>`, or a similar placeholder. | Refuse the variant or ask for the missing fact. |
+| Short-statement slop | Banned phrase list | The short statement contains any banned phrase. | Rewrite before returning. |
+| Landmine still live | Sample 3 / landmine_newsjack | User says the offending post is still up. | Stop and tell the user to pull it before drafting. |
+| No output contract | Output format | JSON or markdown rendering is missing. | Return both, unless the STOP block applies. |
+
+## Score
+
+Score each criterion 0-2.
+
+- **0** - Broken or missing
+- **1** - Present but weak, risky, vague, or incomplete
+- **2** - Solid and usable
+
+Total possible: 28 points.
+
+| Points | Verdict | Meaning |
+|---|---|---|
+| 24-28 | **usable for review** | Tight enough to hand to counsel or the comms lead. Still not legal approval. |
+| 18-23 | **revise before review** | Core structure works, but one or more risk surfaces are loose. |
+| 10-17 | **reduce to short statement** | Too much exposure. Keep only the short statement and Q&A posture. |
+| 0-9 | **do not draft** | Intake, counsel gate, or factual discipline failed. |
+
+## Criteria
+
+### 1. Intake completeness
+
+Source: Inputs / structured prompt.
+
+**Score 0:** Required fields are absent or vague enough that the agent has to infer facts.
+**Score 1:** Required fields are present, but `known_facts`, `unknown_or_unverified`, or `actions_taken_so_far` are mixed with aspirations or disputed claims.
+**Score 2:** Required fields are present, facts are separated from unknowns, and actions are concrete.
+
+### 2. Legal-counsel gate
+
+Source: Legal counsel gate / legal auto-fire keywords.
+
+**Score 0:** A trigger is missed, softened, or treated as a normal drafting case.
+**Score 1:** Gate fires, but the trigger is vague or next steps are generic.
+**Score 2:** Gate fires or clears correctly, names the exact trigger and field, and gives the narrow next step.
+
+### 3. Factual containment
+
+Source: Drafting rules / anti-hallucination doctrine.
+
+**Score 0:** Statements include invented facts, unnamed sources, inferred scope, or invented timelines.
+**Score 1:** Mostly grounded, but one sentence overreaches or implies more certainty than the intake supports.
+**Score 2:** Every factual claim maps cleanly to `known_facts`.
+
+### 4. Unknown handling
+
+Source: Drafting rules / Q&A scaffold.
+
+**Score 0:** Unknowns are asserted, denied, or buried.
+**Score 1:** Unknowns are acknowledged, but the language is vague or defensive.
+**Score 2:** Unknowns are stated plainly and routed to Q&A with `decline-and-name-why` or `refer-to-counsel`.
+
+### 5. Action and commitment discipline
+
+Source: Drafting rules / Pushback pattern "we need to deny this" / "blame third party".
+
+**Score 0:** Promises, deadlines, investigations, outside firms, regulator notices, refunds, or discipline are invented.
+**Score 1:** Actions are real, but owner/window language is too loose or uses "soon."
+**Score 2:** Only confirmed actions appear, and commitments preserve the user-provided owner or window.
+
+### 6. Short statement fitness
+
+Source: Short statement structure.
+
+**Score 0:** More than 50 words, contains slop, or tries to litigate the incident.
+**Score 1:** Short enough, but lacks either a specific confirmed fact or a specific confirmed action.
+**Score 2:** 50 words or fewer, plain, defensible, and usable for inbound press.
+
+### 7. Medium statement fitness
+
+Source: Medium statement structure.
+
+**Score 0:** Reads like a press release, values statement, apology essay, or legal memo.
+**Score 1:** Structure is present, but audience priority or unknowns are mishandled.
+**Score 2:** Around 120 words, audience-led, action-focused, and free of brand positioning.
+
+### 8. Cautious-legal-pass quality
+
+Source: Cautious-legal-pass rules.
+
+**Score 0:** Merely duplicates the medium statement or adds meaningless hedges.
+**Score 1:** Softens some assertions, but misses cause, remediation, third-party, or commitment language.
+**Score 2:** Rewrites the medium statement with targeted qualifiers and lists every delta from the medium.
+
+### 9. Q&A scaffold usefulness
+
+Source: Q&A scaffold.
+
+**Score 0:** Provides a generic FAQ or full answers that invent facts.
+**Score 1:** Includes relevant questions, but categories or postures are thin.
+**Score 2:** 10-20 realistic journalist questions, sorted by category, with posture, rationale, and a defensible holding line.
+
+### 10. What-not-to-say specificity
+
+Source: What-not-to-say list / banned phrase list.
+
+**Score 0:** Lists generic advice or misses banned phrases in the draft.
+**Score 1:** Catches obvious phrases, but reasons or rewrites are vague.
+**Score 2:** Flags exact risky phrases, explains why each is risky, and gives a recoverable rewrite when one exists.
+
+### 11. Decay discipline
+
+Source: Decay.
+
+**Score 0:** No `issued_at`, `valid_until`, or refresh trigger.
+**Score 1:** Decay exists but uses the wrong window for urgency, data-security regulation, or landmine newsjacking.
+**Score 2:** Correct window is applied and refresh triggers are concrete.
+
+### 12. Landmine-newsjack handling
+
+Source: Trigger / landmine recovery / Sample 3.
+
+**Score 0:** Mentions product, campaign, donations, values, or a follow-up activation.
+**Score 1:** Removes product copy but still lets the brand reframe the moment.
+**Score 2:** Pull-post-first if live, short contrite language, no product or narrative recovery, 30-minute decay.
+
+### 13. Voice and anti-slop
+
+Source: Banned in all crisis output / anti-slop doctrine.
+
+**Score 0:** Uses templated sympathy, corporate filler, passive distancing, or AI-signature structure.
+**Score 1:** Mostly clean, with one or two phrases that need tightening.
+**Score 2:** Narrow, active, direct, and free of banned phrases and performative positivity.
+
+### 14. Output contract
+
+Source: Outputs / Output format.
+
+**Score 0:** Missing JSON, missing markdown, or returns prose around the artifact.
+**Score 1:** Both formats exist but fields, order, or empty arrays are inconsistent.
+**Score 2:** JSON and markdown match exactly, with word counts, deltas, tables, decay, and refusals.
+
+## Banned phrase checks
+
+Soft-fail and rewrite any statement containing these. Hard-fail if they appear in the short statement.
+
+```text
+out of an abundance of caution
+isolated incident
+our hearts go out
+our thoughts and prayers
+hearts go out
+deeply committed
+deeply troubled
+deeply concerned
+deeply saddened
+we take [X] seriously
+we are committed to transparency
+we are committed to integrity
+we are committed to excellence
+we are committed to our customers
+we are committed to our employees
+swiftly
+promptly
+immediately without a timestamp
+robust
+comprehensive
+industry-leading
+best-in-class
+world-class
+regret any inconvenience
+regret any confusion
+regret any distress
+unfortunate situation
+regrettable circumstances
+rogue employee
+rogue actor
+rogue agent
+fully cooperating with authorities
+external investigation
+external review
+no comment
+this does not reflect our values
+moving forward
+going forward
+It's not just [X], it's [Y]
+```
+
+## Legal auto-fire keyword checks
+
+Substring-match case-insensitively across `incident_summary`, `known_facts`, `unknown_or_unverified`, and `regulatory_exposure`.
+
+```text
+death | fatal | killed | died | hospitaliz | serious injury | bodily harm
+harassment | assault | abuse | discriminat
+fraud | theft | embezzl | misappropriat
+SEC | FDA | OSHA | FTC | DOJ | EPA | CFPB | EU Commission | regulator
+GDPR | CCPA | HIPAA | DPA | data subject | PII | personally identifiable
+CSAM | child | minor
+ransomware | breach | exfiltrat | leaked
+recall | hazard | defect
+indict | subpoena | warrant | criminal
+immigration | ICE | deport
+weapons | defense | export control | export-control
+class action | lawsuit | suit | litigation
+```


### PR DESCRIPTION
## Files

- `skills/crisis-holding/SKILL.md` (336 lines): Defines the crisis-holding persona, intake sequence, legal-counsel gate, drafting rules, decay behavior, and exact JSON plus markdown output contract.
- `skills/crisis-holding/rubric.md` (218 lines): Converts the source design doc into hard gates, scored criteria, banned phrase checks, and legal trigger checks.
- `skills/crisis-holding/examples.md` (302 lines): Provides four realistic before/after cases covering product safety refusal, counsel-engaged data security drafting, landmine-newsjack recovery, and skipped-intake minor-harm refusal.
- `skills/crisis-holding/README.md` (52 lines): Adds a short invocation guide, expected outputs, counsel-review warning, and file index.

## Validation

- No `package.json` exists in this checkout, so `pnpm lint` and `pnpm test` were skipped per instruction.
- Verified line counts and ASCII-only text for the new skill files.
