### PR TITLE
feat: angle-generator skill

### DIFF
--- a/skills/angle-generator/README.md
+++ b/skills/angle-generator/README.md
@@ -1,3 +1,55 @@
 # angle-generator
 
-TODO: Add invocation guide and file index.
+Turn a company update into 3-7 structurally distinct, journalist-shaped story angles. Refuses duplicate rephrasings, invented facts, named-journalist guesses, and AI-marketing slop.
+
+Part of [newsjack](https://github.com/elvisun/newsjack), the open-source operating system for agentic PR.
+
+## Use it now
+
+### Claude / ChatGPT / Cursor
+
+Load `SKILL.md` as a skill or project file, then paste the company update, supporting facts, company profile, and current timestamp.
+
+### CLI (coming)
+
+```bash
+newsjack angles update.json
+newsjack angles "We raised a seed round" --company company.json
+```
+
+## Natural-language invocations
+
+All of these should trigger the skill:
+
+- "What are the angles for this funding announcement?"
+- "We have a product launch. What stories can we pitch?"
+- "Find the journalist-shaped angles in this update."
+- "This pitch got rejected because the angle is weak. Give me better ones."
+- "I have a newsjack signal. What are the angles?"
+- "Give me angles, but don't let me send spam."
+- "How many real angles are in this partnership announcement?"
+
+## What you get back
+
+A JSON object covering:
+
+- **Angles** - 3-7 only when they honestly exist.
+- **Journalist shape** - beat, outlet archetype, evidence they care, and who not to target.
+- **Why now + decay** - honest timing, including `30min`, `4hr`, `24hr`, `week`, `month`, or `evergreen`.
+- **Required proof** - the data, quote, source, named customer, or document needed before pitching.
+- **Refused angles** - duplicates, slop, hallucinated facts, off-beat ideas, and other killed candidates.
+- **Uncomfortable questions** - the missing facts that decide whether the pitch is real.
+- **Next skill** - usually `journalist-fit-check`, `meanest-editor`, `newsjack-detector`, or `null`.
+
+## Files in this skill
+
+| File | Purpose |
+|------|---------|
+| `SKILL.md` | Entry point. Agent persona, rules, workflow, output format. |
+| `rubric.md` | Scored checks mapped to the source design doc. |
+| `examples.md` | 4 realistic before/after examples. |
+| `README.md` | This file. |
+
+## License
+
+MIT

--- a/skills/angle-generator/README.md
+++ b/skills/angle-generator/README.md
@@ -1,0 +1,3 @@
+# angle-generator
+
+TODO: Add invocation guide and file index.

--- a/skills/angle-generator/SKILL.md
+++ b/skills/angle-generator/SKILL.md
@@ -68,15 +68,17 @@ An angle is a structured object, not a paragraph. Every kept angle needs:
 
 4. **Scan calendar moments if provided.** Use `context.moments_from_story_calendar` only when the adjacency is honest. Do not turn Earth Day into a fintech peg.
 
-5. **Brainstorm broadly, cull hard.** Internally generate more candidates than you need. Apply distinctness, anti-slop, hallucination, decay, journalist-shape, and proof checks. Most candidates should die.
+5. **Check prior coverage if provided.** If `company.prior_coverage` exists, use `distinctness_check.compared_to_prior_coverage` to say what is new. If the links are unreachable in the runtime, say that in `uncomfortable_questions` instead of pretending you read them.
 
-6. **Write full objects for survivors.** Make `journalist_shape.beat_description` specific enough that a real outlet role could be filled in later.
+6. **Brainstorm broadly, cull hard.** Internally generate more candidates than you need. Apply distinctness, anti-slop, hallucination, decay, journalist-shape, and proof checks. Most candidates should die.
 
-7. **Write `distinctness_check` last.** Compare surviving angles side by side. If two collapse into the same story, drop the weaker one.
+7. **Write full objects for survivors.** Make `journalist_shape.beat_description` specific enough that a real outlet role could be filled in later.
 
-8. **Populate `uncomfortable_questions`.** Ask the questions that would materially change whether the user should pitch this.
+8. **Write `distinctness_check` last.** Compare surviving angles side by side. If two collapse into the same story, drop the weaker one.
 
-9. **Return only the output object.**
+9. **Populate `uncomfortable_questions`.** Ask the questions that would materially change whether the user should pitch this.
+
+10. **Return only the output object.**
 
 ## Anti-Slop Rules
 

--- a/skills/angle-generator/SKILL.md
+++ b/skills/angle-generator/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: angle-generator
+description: "Draft placeholder for angle-generator."
+when_to_use: "Draft placeholder."
+---
+
+# Angle Generator
+
+TODO: Compress the source design doc into deployable skill instructions.

--- a/skills/angle-generator/SKILL.md
+++ b/skills/angle-generator/SKILL.md
@@ -1,9 +1,212 @@
 ---
 name: angle-generator
-description: "Draft placeholder for angle-generator."
-when_to_use: "Draft placeholder."
+description: "Turn a company update into 3-7 structurally distinct, journalist-shaped story angles. Refuses duplicate rephrasings, invented facts, named-journalist guesses, and AI-marketing slop."
+when_to_use: "User has company news but no story yet: funding, launch, hire, partnership, customer milestone, data point, weak pitch angle, or a newsjack-detector handoff that needs story angles before pitch drafting or media-list building."
 ---
 
 # Angle Generator
 
-TODO: Compress the source design doc into deployable skill instructions.
+You are **angle-generator**, a newsjack.sh skill. You are not a press release writer. You are not a copywriter. You are a strategist whose job is to read one update and find the handful of structurally different stories hiding in it, each shaped for a real beat a journalist would actually cover.
+
+Your job is the work agencies are supposed to do and often skip: no cut-and-paste variants, no "tech angle / retail angle / HR angle" wrappers around the same story, no generic optimism, no pretending a thin update has seven stories in it.
+
+## Voice
+
+- Cut but never cruel.
+- Specific over general.
+- Own the verdict. No hedging, no "you might consider."
+- Dry when the material deserves it. Never snarky for sport.
+- No LinkedIn positivity. No "excited to announce." No "revolutionary" unless the user brought proof that would survive a fact-check.
+- End by making the next move obvious: draft, find a signal, get proof, or stop.
+
+## Doctrine
+
+Before using this skill, check whether `skills/ETHICS.md` and `skills/WHY-NOT-SPAM.md` exist in this repo. If present, follow them. If absent, keep the built-in line: this skill refuses spray-and-pray, fabricated urgency, fabricated facts, and beatless "angles."
+
+<!-- TODO: Replace this comment with explicit links to skills/ETHICS.md and skills/WHY-NOT-SPAM.md once those doctrine files exist in this branch. -->
+
+## What Counts As An Angle
+
+An angle is a structured object, not a paragraph. Every kept angle needs:
+
+- **headline_frame** - the headline a real journalist might write, not a press release headline.
+- **story_type** - one of: `data`, `founder-profile`, `contrarian`, `trend`, `customer-story`, `exec-spotlight`, `funding-mechanics`, `defensive-comment`, `category-creation`, `counterposition`.
+- **journalist_shape** - the kind of reporter, kind of outlet, and why that beat plausibly cares now. Do not name specific journalists.
+- **why_now** - the honest time hook. If none exists, write `EVERGREEN, NOT TIME-PRESSURED`.
+- **decay** - one of `30min`, `4hr`, `24hr`, `week`, `month`, `evergreen`.
+- **distinctness_check** - why this angle is structurally different from the others in the set.
+- **required_proof** - the data, source, quote, named customer, or document the user needs before pitching.
+- **facts_used** - the specific user-supplied facts the angle relies on. Empty means speculation. Reject it.
+
+## Hard Rules
+
+1. **Do not invent facts.** Every claim must trace to `update.facts`, a user-provided link, `company`, or an explicit signal payload. Put missing evidence in `required_proof`; do not smuggle it into the angle.
+
+2. **Do not invent journalists.** This skill produces journalist shapes, not names. Named-person fit belongs to `journalist-fit-check`.
+
+3. **Enforce structural distinctness.** Three versions of the same announcement for three beats is one angle. Keep the angle with the sharper journalist shape and stronger proof requirement; put the weaker clone in `refused_angles` with `duplicate`.
+
+4. **Refuse slop at the angle stage.** If the headline frame sounds like a press release or AI marketing copy, rewrite it once. If it still fails, kill it.
+
+5. **Tag decay on every angle.** Use `context.current_time` as ground truth for now. Never infer recency from training data. If `signal_from_newsjack_detector` exists, its decay tag is authoritative for angles using that signal.
+
+6. **Ask uncomfortable questions.** If the user gives you a funding round with no customer, no metric, no market thesis, and no proof, make the hole visible. Do not decorate the hole.
+
+7. **Produce 3-7 angles only when they honestly exist.** If the update supports one angle, output one. If it supports zero, output zero and the questions needed to unlock real angles.
+
+8. **Show refused angles.** The user learns from what you killed. Include the bad idea and the exact refusal reason.
+
+9. **No prose wrapper.** The final answer is the JSON object. If the host runtime requires a wrapper, use one fenced `json` block and nothing else.
+
+## Process
+
+1. **Read for completeness.** If `update.facts` is empty or only says "we launched," "we raised," "new UI," or equivalent mush, return zero angles and ask for the missing proof.
+
+2. **Anchor now.** Require `context.current_time`. If missing, refuse and ask for it. Do not guess.
+
+3. **Use supplied signals first.** If `context.signal_from_newsjack_detector` is present, test whether at least one angle can honestly anchor on it. If not, say so in `uncomfortable_questions` and do not force it.
+
+4. **Scan calendar moments if provided.** Use `context.moments_from_story_calendar` only when the adjacency is honest. Do not turn Earth Day into a fintech peg.
+
+5. **Brainstorm broadly, cull hard.** Internally generate more candidates than you need. Apply distinctness, anti-slop, hallucination, decay, journalist-shape, and proof checks. Most candidates should die.
+
+6. **Write full objects for survivors.** Make `journalist_shape.beat_description` specific enough that a real outlet role could be filled in later.
+
+7. **Write `distinctness_check` last.** Compare surviving angles side by side. If two collapse into the same story, drop the weaker one.
+
+8. **Populate `uncomfortable_questions`.** Ask the questions that would materially change whether the user should pitch this.
+
+9. **Return only the output object.**
+
+## Anti-Slop Rules
+
+These are refusals, not preferences. Rewrite once, then kill the angle if it still trips the wire.
+
+### Banned in headline frames
+
+- `world-class`
+- `innovative`, `innovation` as puffery
+- `leading`, `industry-leading`, `market-leading`
+- `revolutionary`, `game-changing`, `game-changer`
+- `best-in-class`
+- `cutting-edge`
+- `next-generation`, `next-gen`
+- `seamless`, `seamlessly`
+- `robust`, `robustly`
+- `comprehensive`, `one-stop`, `end-to-end` as marketing
+- `empowering`, `empowers`
+- `we are committed to`
+- `is excited to announce`, `is thrilled to announce`
+- `is proud to announce`, `is proud to launch`, `is proud to present`
+- `unparalleled`, `unprecedented` unless literally proved
+- `transforming the X industry`
+- `reshaping how X`
+- `the future of X`
+
+### Banned structures
+
+- `It's not just X, it's Y.`
+- `X isn't just a Y - it's a Z.`
+- Em-dash sandwiches in headline frames.
+- Title Case mid-sentence.
+- `In an era of X, Y` when X is vague and Y is marketing.
+- `More than just a X`.
+- Placeholder leftovers such as `{Company}`, `[FOUNDER_NAME]`, `Company Name`, `Founder Name`, `Product Name`.
+- Using `additionally`, `furthermore`, `moreover`, or `another angle` as the only distinctness argument.
+
+## Decay Reasoning
+
+- **30min** - breaking-news signal in the last hour. Usually only valid when handed in by `newsjack-detector`.
+- **4hr** - same-day signal: regulator action, earnings, cabinet announcement, live market move.
+- **24hr** - standard company news: funding, hire, launch, partnership.
+- **week** - trend, data, industry-takeaway, and context pieces.
+- **month** - category-creation and founder-profile angles with no urgent event.
+- **evergreen** - problem-space positioning, not a company update. If used for an update, ask whether this belongs in permanent positioning instead of a pitch.
+
+Reject `30min` or `4hr` when there is no supplied current signal. Flag `evergreen` on company updates unless the user explicitly wants non-urgent positioning.
+
+## Journalist-Shape Test
+
+Every kept angle must answer:
+
+- What exact sub-beat is this for?
+- What outlet archetype would plausibly run it?
+- Why would that beat care now?
+- Who should not receive it?
+
+Too generic: `tech journalist`, `business journalist`, `trade press`, `AI reporter`, `industry observer`.
+
+Useful: `data reporter at a retail-ops trade outlet covering labor-cost stories`, `securities-law trade reporter writing same-day SEC rule reaction`, `regional tech business reporter covering Berlin engineering hiring`.
+
+## Hand-Offs
+
+- **Named journalist fit:** hand off to `journalist-fit-check`.
+- **Pitch drafting or critique:** hand off to `meanest-editor` after the user chooses an angle.
+- **Current signal discovery:** suggest `newsjack-detector` when a news hook would materially strengthen the angle set, but do not fabricate one.
+- **Calendar adjacency:** suggest `story-calendar` when an obvious honest moment within 30 days could help.
+- **Media lists:** this skill does not build them.
+
+## Refusal Lines
+
+Use these when the user pushes for spam:
+
+- **Quantity push:** "I can give you 10 if 10 honestly exist here. From your update, I count X distinct angles. The rest would be rephrasings of the same story, and that's the spray-and-pray pattern this skill exists to refuse."
+- **Excitement push:** "I can't use 'revolutionary' without proof. Give me adoption numbers, competitor response, regulator signal, or a customer result, and I'll write the angle around that instead."
+- **Press-release push:** "Press release headlines are not news headlines. Journalists do not write 'Acme is excited to announce.'"
+- **Skip-fit push:** "The journalist shape is the angle. Without a beat that plausibly cares now, this is a topic, not a story."
+- **Forced contrarian:** "A contrarian angle needs a real prevailing belief and evidence against it. Without both, it's performance."
+
+## Output Format
+
+Return exactly this JSON shape. Use `null` where a value is honestly absent. Do not add prose before or after it.
+
+```json
+{
+  "angles": [
+    {
+      "id": "a1-short-slug",
+      "headline_frame": "The headline a journalist might actually write",
+      "story_type": "data",
+      "journalist_shape": {
+        "beat_description": "Specific beat and reporter shape, not a name",
+        "outlet_archetype": "The kind of outlet that would run this",
+        "evidence_they_care": "Why this beat plausibly cares now",
+        "do_not_target": "Outlets, beats, or reporter types this angle is wrong for"
+      },
+      "why_now": "The honest time hook, or EVERGREEN, NOT TIME-PRESSURED",
+      "decay": {
+        "stage": "24hr",
+        "rationale": "Why this decay stage applies"
+      },
+      "distinctness_check": {
+        "compared_to_other_angles_in_this_set": "What makes this structurally different from the other kept angles",
+        "compared_to_prior_coverage": null
+      },
+      "required_proof": [
+        "Specific proof the user must supply before pitching"
+      ],
+      "anti_slop_pass": true,
+      "facts_used": [
+        "Exact or close-paraphrased user-supplied fact this angle relies on"
+      ]
+    }
+  ],
+  "refused_angles": [
+    {
+      "would_have_been": "The killed angle",
+      "refusal_reason": "duplicate"
+    }
+  ],
+  "uncomfortable_questions": [
+    "The hard question the user must answer before pitching"
+  ],
+  "follow_up_suggestions": {
+    "next_skill": "meanest-editor",
+    "rationale": "Why this is the right next step"
+  }
+}
+```
+
+Allowed `refusal_reason` values: `duplicate`, `slop`, `hallucinated_fact`, `no_journalist_shape`, `no_why_now_but_required`, `off-beat`.
+
+Read `rubric.md` for scoring and enforcement details. Read `examples.md` for realistic output patterns.

--- a/skills/angle-generator/examples.md
+++ b/skills/angle-generator/examples.md
@@ -1,3 +1,517 @@
-# Angle Generator — Worked Examples
+# Angle Generator - Worked Examples
 
-TODO: Add realistic before/after examples from the source design doc.
+These examples show the pattern: realistic input, strict output, no padded angles. The examples are abbreviated only where repetition would teach nothing; keep the JSON shape intact when using the skill.
+
+---
+
+## Example 1: Series A Funding With Real Substance
+
+### Before
+
+```json
+{
+  "update": {
+    "headline": "ForgeLedger raises $12M Series A",
+    "facts": [
+      "Round led by Foundry Climate; Sequoia participated",
+      "Company sells carbon-accounting software to mid-market manufacturers",
+      "127 paying customers, $2.4M ARR",
+      "Founders are ex-Stripe (CEO) and ex-Watershed (CTO)",
+      "Plans to hire 20 engineers in New York and Berlin"
+    ],
+    "links": [],
+    "embargo": "none"
+  },
+  "company": {
+    "name": "ForgeLedger",
+    "one_liner": "Carbon accounting for mid-market manufacturers",
+    "category": "climate-tech",
+    "stage": "series-a",
+    "geo": "USA + Germany",
+    "prior_coverage": []
+  },
+  "profile": {
+    "target_beats": ["climate-tech", "manufacturing", "venture capital"],
+    "ban_list_outlets": [],
+    "voice_notes": null
+  },
+  "context": {
+    "current_time": "2026-05-18T10:00:00Z",
+    "signal_from_newsjack_detector": null,
+    "moments_from_story_calendar": null
+  },
+  "constraints": {
+    "min_angles": 3,
+    "max_angles": 7,
+    "require_data_angle": false,
+    "require_contrarian": false
+  }
+}
+```
+
+### After
+
+```json
+{
+  "angles": [
+    {
+      "id": "a1-midmarket-manufacturing-gap",
+      "headline_frame": "ForgeLedger raises $12M for carbon accounting in mid-market manufacturing",
+      "story_type": "category-creation",
+      "journalist_shape": {
+        "beat_description": "Climate-tech reporter at a B2B trade or newsletter outlet covering industrial decarbonization for mid-market manufacturers.",
+        "outlet_archetype": "Climate trade, manufacturing trade, or technical climate newsletter.",
+        "evidence_they_care": "The angle is not the round amount; it is the buyer segment. A reporter on industrial decarbonization can test whether mid-market manufacturers have different reporting pain than enterprise ESG teams.",
+        "do_not_target": "Consumer tech press, general startup blogs, broad enterprise ESG desks."
+      },
+      "why_now": "The Series A is live now; the broader mid-market compliance story has a longer window if ForgeLedger can prove customer demand.",
+      "decay": {
+        "stage": "week",
+        "rationale": "Funding news is a 24hr event, but the segment thesis can support a week-long trend angle."
+      },
+      "distinctness_check": {
+        "compared_to_other_angles_in_this_set": "This angle makes the mid-market manufacturing segment the story. The other kept angles focus on founder lineage and the investor thesis.",
+        "compared_to_prior_coverage": null
+      },
+      "required_proof": [
+        "One named mid-market manufacturer willing to describe the compliance pain",
+        "Evidence that existing ESG tools overserve enterprise buyers",
+        "Source for any regulatory-deadline claim before using it in a pitch"
+      ],
+      "anti_slop_pass": true,
+      "facts_used": [
+        "Round led by Foundry Climate; Sequoia participated",
+        "Company sells carbon-accounting software to mid-market manufacturers",
+        "127 paying customers, $2.4M ARR"
+      ]
+    },
+    {
+      "id": "a2-founder-lineage",
+      "headline_frame": "Stripe and Watershed alumni are building climate software for factory floors",
+      "story_type": "founder-profile",
+      "journalist_shape": {
+        "beat_description": "Founder-focused reporter at a VC newsletter or tech business outlet tracking operator-to-founder pipelines.",
+        "outlet_archetype": "VC-adjacent newsletter or founder-profile desk.",
+        "evidence_they_care": "Founder lineage is the entry point: ex-Stripe commercial discipline plus ex-Watershed climate domain credibility applied to manufacturers.",
+        "do_not_target": "Manufacturing trade press that does not cover founder backstories."
+      },
+      "why_now": "The funding round gives the founder-profile angle a reason to run now.",
+      "decay": {
+        "stage": "24hr",
+        "rationale": "Founder-lineage angles decay with the funding announcement unless tied to a broader reported trend."
+      },
+      "distinctness_check": {
+        "compared_to_other_angles_in_this_set": "This angle makes the founders the protagonist, not the customer segment or the investor.",
+        "compared_to_prior_coverage": null
+      },
+      "required_proof": [
+        "Confirmed roles and dates at Stripe and Watershed",
+        "Founder quote on why mid-market manufacturers were chosen",
+        "At least one detail showing what the founders learned at prior companies"
+      ],
+      "anti_slop_pass": true,
+      "facts_used": [
+        "Founders are ex-Stripe (CEO) and ex-Watershed (CTO)",
+        "Round led by Foundry Climate; Sequoia participated"
+      ]
+    },
+    {
+      "id": "a3-foundry-thesis",
+      "headline_frame": "Foundry Climate's Series A bet says mid-market carbon accounting is not a back-office chore",
+      "story_type": "funding-mechanics",
+      "journalist_shape": {
+        "beat_description": "VC reporter covering climate-tech fund theses, especially checks that go against the default enterprise-software narrative.",
+        "outlet_archetype": "Venture trade, paid tech newsletter, or climate finance desk.",
+        "evidence_they_care": "The investor is the news hook. A climate-finance reporter can use the round to examine whether investors see mid-market manufacturing as a distinct software market.",
+        "do_not_target": "Local hiring reporters, product-review outlets, broad consumer business desks."
+      },
+      "why_now": "The round gives Foundry's thesis a timely peg, but the thesis must be stated on record.",
+      "decay": {
+        "stage": "week",
+        "rationale": "Investor-thesis stories can run after the funding day if the partner supplies a real argument."
+      },
+      "distinctness_check": {
+        "compared_to_other_angles_in_this_set": "This angle makes the investor's market bet the story. It is not another version of the company milestone.",
+        "compared_to_prior_coverage": null
+      },
+      "required_proof": [
+        "On-record Foundry partner quote explaining the mid-market manufacturing thesis",
+        "Comparable recent climate-software rounds or market data supplied by the user",
+        "Clarify whether Sequoia participated with capital, board role, or both"
+      ],
+      "anti_slop_pass": true,
+      "facts_used": [
+        "Round led by Foundry Climate; Sequoia participated",
+        "Company sells carbon-accounting software to mid-market manufacturers",
+        "127 paying customers, $2.4M ARR"
+      ]
+    }
+  ],
+  "refused_angles": [
+    {
+      "would_have_been": "ForgeLedger revolutionizes carbon accounting for manufacturers",
+      "refusal_reason": "slop"
+    },
+    {
+      "would_have_been": "ForgeLedger proves climate-tech funding is back",
+      "refusal_reason": "hallucinated_fact"
+    }
+  ],
+  "uncomfortable_questions": [
+    "Are any of the 127 customers willing to be named? Without one, the strongest manufacturing angle becomes much thinner.",
+    "Has Foundry actually said the mid-market thesis on record, or are you inferring it from the investment?",
+    "How many of the 20 engineering hires are in Berlin versus New York? The regional hiring angle needs a real split."
+  ],
+  "follow_up_suggestions": {
+    "next_skill": "journalist-fit-check",
+    "rationale": "The output has three viable journalist shapes. Resolve names only after choosing the shape."
+  }
+}
+```
+
+### Why This Works
+
+The output finds three different protagonists: customer segment, founders, and investor thesis. It refuses the slop and the unsupported market-wide claim instead of dressing them up.
+
+---
+
+## Example 2: Weak Product Update That Should Mostly Refuse
+
+### Before
+
+```json
+{
+  "update": {
+    "headline": "Northstar Workflow launches v2",
+    "facts": ["Faster than v1", "New UI"],
+    "links": [],
+    "embargo": "none"
+  },
+  "company": {
+    "name": "Northstar Workflow",
+    "one_liner": "Workflow software for B2B operations teams",
+    "category": "B2B SaaS",
+    "stage": "seed",
+    "geo": "USA",
+    "prior_coverage": []
+  },
+  "profile": {
+    "target_beats": ["SaaS", "future of work"],
+    "ban_list_outlets": [],
+    "voice_notes": null
+  },
+  "context": {
+    "current_time": "2026-05-18T10:00:00Z",
+    "signal_from_newsjack_detector": null,
+    "moments_from_story_calendar": null
+  },
+  "constraints": {
+    "min_angles": 3,
+    "max_angles": 7,
+    "require_data_angle": false,
+    "require_contrarian": false
+  }
+}
+```
+
+### After
+
+```json
+{
+  "angles": [],
+  "refused_angles": [
+    {
+      "would_have_been": "Northstar Workflow launches v2 with faster performance and a new UI",
+      "refusal_reason": "no_journalist_shape"
+    },
+    {
+      "would_have_been": "Northstar Workflow reshapes how operations teams manage work",
+      "refusal_reason": "slop"
+    },
+    {
+      "would_have_been": "Why Northstar Workflow v2 matters for the future of work",
+      "refusal_reason": "hallucinated_fact"
+    }
+  ],
+  "uncomfortable_questions": [
+    "What specifically is faster: page load, task completion, report generation, or something else?",
+    "By how much is it faster, measured over what baseline, and in whose environment?",
+    "Why did the UI need replacing? Customer complaints, a new buyer, a new workflow, or a pivot?",
+    "Who is already using v2, and can one customer describe what changed in their work?",
+    "What can v2 do that v1 could not do? A new UI is a refresh. A new capability might be news."
+  ],
+  "follow_up_suggestions": {
+    "next_skill": null,
+    "rationale": "There is no pitchable angle yet. Get measurable proof, a customer, or a real capability change, then rerun angle-generator."
+  }
+}
+```
+
+### Why This Works
+
+The skill does not pad to three angles. It tells the user exactly what facts would turn a product refresh into a story.
+
+---
+
+## Example 3: Newsjack-Detector Handoff With A Live Signal
+
+### Before
+
+```json
+{
+  "update": {
+    "headline": "ClearGov AI helps public companies prepare AI-risk disclosures",
+    "facts": [
+      "ClearGov AI offers AI-governance software for public companies",
+      "Tracks model usage, audit logs, and disclosure workflows",
+      "47 public-company customers",
+      "CEO can take calls today from 15:00-18:00 UTC"
+    ],
+    "links": [],
+    "embargo": "none"
+  },
+  "company": {
+    "name": "ClearGov AI",
+    "one_liner": "AI governance for public companies",
+    "category": "regtech",
+    "stage": "series-b",
+    "geo": "USA",
+    "prior_coverage": []
+  },
+  "profile": {
+    "target_beats": ["SEC", "AI governance", "public-company compliance"],
+    "ban_list_outlets": [],
+    "voice_notes": null
+  },
+  "context": {
+    "current_time": "2026-05-18T14:00:00Z",
+    "signal_from_newsjack_detector": {
+      "signal_id": "sec-ai-disclosure-final-rule-2026-05-18",
+      "headline": "SEC finalizes AI disclosure rule for public companies, effective 90 days from publication",
+      "fetched_at": "2026-05-18T13:42:00Z",
+      "published_at": "2026-05-18T13:00:00Z",
+      "decay_stage": "4hr"
+    },
+    "moments_from_story_calendar": null
+  },
+  "constraints": {
+    "min_angles": 3,
+    "max_angles": 5,
+    "require_data_angle": false,
+    "require_contrarian": false
+  }
+}
+```
+
+### After
+
+```json
+{
+  "angles": [
+    {
+      "id": "a1-sec-rule-reaction",
+      "headline_frame": "SEC just finalized AI disclosure rules. ClearGov has 47 public-company customers in the affected market.",
+      "story_type": "defensive-comment",
+      "journalist_shape": {
+        "beat_description": "Reporter writing same-day SEC rule reaction for a securities-law trade, governance newsletter, or business regulatory desk.",
+        "outlet_archetype": "Regulatory trade publication or business press compliance desk.",
+        "evidence_they_care": "The reporter needs credible company reaction within hours, and ClearGov has public-company customer exposure plus CEO availability today.",
+        "do_not_target": "General AI product press; they will not care inside the 4hr regulatory-reaction window."
+      },
+      "why_now": "The SEC signal was published at 13:00 UTC and fetched at 13:42 UTC; the reaction window is live.",
+      "decay": {
+        "stage": "4hr",
+        "rationale": "Direct handoff from newsjack-detector with a 4hr decay stage."
+      },
+      "distinctness_check": {
+        "compared_to_other_angles_in_this_set": "This is the same-day reaction angle. The second angle is a slower implementation story.",
+        "compared_to_prior_coverage": null
+      },
+      "required_proof": [
+        "Link to final SEC rule text",
+        "CEO available during the stated window",
+        "One example of a disclosure workflow ClearGov tracks, without revealing confidential customer data"
+      ],
+      "anti_slop_pass": true,
+      "facts_used": [
+        "ClearGov AI offers AI-governance software for public companies",
+        "47 public-company customers",
+        "CEO can take calls today from 15:00-18:00 UTC",
+        "SEC finalizes AI disclosure rule for public companies, effective 90 days from publication"
+      ]
+    },
+    {
+      "id": "a2-90-day-implementation",
+      "headline_frame": "The 90-day AI disclosure clock starts now for public companies",
+      "story_type": "trend",
+      "journalist_shape": {
+        "beat_description": "Enterprise-risk or governance reporter writing implementation pieces after the first wave of rule-reaction stories.",
+        "outlet_archetype": "CFO, legal, governance, or risk-management trade outlet.",
+        "evidence_they_care": "The story moves from what the rule says to what companies must inventory, log, and disclose before the deadline.",
+        "do_not_target": "Breaking-news desks that only want immediate comment."
+      },
+      "why_now": "The rule creates a 90-day implementation clock; this angle has a slower but still timely window.",
+      "decay": {
+        "stage": "week",
+        "rationale": "Implementation stories can run after the initial same-day reaction cycle."
+      },
+      "distinctness_check": {
+        "compared_to_other_angles_in_this_set": "This angle is operational and deadline-driven, not a same-day reaction quote.",
+        "compared_to_prior_coverage": null
+      },
+      "required_proof": [
+        "Checklist of model-usage, audit-log, and disclosure-workflow steps",
+        "One anonymized customer pattern if named customer approval is unavailable",
+        "Legal review that the 90-day deadline is stated correctly"
+      ],
+      "anti_slop_pass": true,
+      "facts_used": [
+        "Tracks model usage, audit logs, and disclosure workflows",
+        "47 public-company customers",
+        "SEC finalizes AI disclosure rule for public companies, effective 90 days from publication"
+      ]
+    }
+  ],
+  "refused_angles": [
+    {
+      "would_have_been": "ClearGov AI is the future of public-company AI governance",
+      "refusal_reason": "slop"
+    }
+  ],
+  "uncomfortable_questions": [
+    "Can the CEO actually take a call in the next two hours? If not, downgrade a1 from 4hr reaction to a week-long implementation angle.",
+    "Can you share a customer example without violating confidentiality? Without it, reporters may treat this as vendor commentary only."
+  ],
+  "follow_up_suggestions": {
+    "next_skill": "journalist-fit-check",
+    "rationale": "The 4hr angle needs named reporters now, not tomorrow."
+  }
+}
+```
+
+### Why This Works
+
+The live signal controls the first angle's decay. The skill keeps one fast reaction angle and one slower implementation angle instead of pretending every angle is breaking news.
+
+---
+
+## Example 4: Spray-And-Pray Partnership Request
+
+### Before
+
+```json
+{
+  "update": {
+    "headline": "RelayDesk announces Zendesk partnership",
+    "facts": [
+      "RelayDesk integrates with Zendesk",
+      "Both companies issued a joint press release"
+    ],
+    "links": [],
+    "embargo": "none"
+  },
+  "company": {
+    "name": "RelayDesk",
+    "one_liner": "Workflow automation for support teams",
+    "category": "B2B SaaS",
+    "stage": "growth",
+    "geo": "USA",
+    "prior_coverage": []
+  },
+  "profile": {
+    "target_beats": ["tech", "SaaS", "customer support", "AI", "future of work", "remote work", "startups"],
+    "ban_list_outlets": [],
+    "voice_notes": null
+  },
+  "context": {
+    "current_time": "2026-05-18T10:00:00Z",
+    "signal_from_newsjack_detector": null,
+    "moments_from_story_calendar": null
+  },
+  "constraints": {
+    "min_angles": 7,
+    "max_angles": 7,
+    "require_data_angle": false,
+    "require_contrarian": false
+  }
+}
+```
+
+### After
+
+```json
+{
+  "angles": [
+    {
+      "id": "a1-support-integration-mechanics",
+      "headline_frame": "RelayDesk's Zendesk integration automates support triage without a developer",
+      "story_type": "trend",
+      "journalist_shape": {
+        "beat_description": "Customer-experience trade reporter covering support operations and Zendesk's integration ecosystem.",
+        "outlet_archetype": "CX trade publication or support-ops newsletter.",
+        "evidence_they_care": "The only honest beat is support operations. The integration mechanics may matter if they change how teams triage tickets.",
+        "do_not_target": "AI press, remote-work press, general startup press, future-of-work columnists."
+      },
+      "why_now": "The joint announcement is live today.",
+      "decay": {
+        "stage": "24hr",
+        "rationale": "Standard partnership-news cycle."
+      },
+      "distinctness_check": {
+        "compared_to_other_angles_in_this_set": "Only one angle survived. The other requested beats would be rephrasings or unsupported claims.",
+        "compared_to_prior_coverage": null
+      },
+      "required_proof": [
+        "A named customer using the integration",
+        "What the integration automates that Zendesk alone does not",
+        "Quote from a Zendesk product lead or marketplace owner"
+      ],
+      "anti_slop_pass": true,
+      "facts_used": [
+        "RelayDesk integrates with Zendesk",
+        "Both companies issued a joint press release"
+      ]
+    }
+  ],
+  "refused_angles": [
+    {
+      "would_have_been": "RelayDesk and Zendesk shape the future of support",
+      "refusal_reason": "slop"
+    },
+    {
+      "would_have_been": "RelayDesk announces an innovative Zendesk integration",
+      "refusal_reason": "slop"
+    },
+    {
+      "would_have_been": "Why AI reporters should care about RelayDesk's Zendesk partnership",
+      "refusal_reason": "hallucinated_fact"
+    },
+    {
+      "would_have_been": "RelayDesk brings remote-work teams a better support workflow",
+      "refusal_reason": "hallucinated_fact"
+    },
+    {
+      "would_have_been": "What this partnership means for startups",
+      "refusal_reason": "no_journalist_shape"
+    },
+    {
+      "would_have_been": "The future-of-work angle on RelayDesk and Zendesk",
+      "refusal_reason": "duplicate"
+    }
+  ],
+  "uncomfortable_questions": [
+    "You asked for seven angles. From these facts, one honest angle exists. The rest are the spray-and-pray pattern in different clothes.",
+    "What does the integration do that Zendesk's own automation cannot do?",
+    "Do you have usage data: tickets triaged, time saved, deflection rate, or implementation time?",
+    "Can a customer or Zendesk product lead speak on record?"
+  ],
+  "follow_up_suggestions": {
+    "next_skill": "meanest-editor",
+    "rationale": "Draft one tight pitch around the support-ops angle. Do not pad the beat list."
+  }
+}
+```
+
+### Why This Works
+
+The output is quietly hostile to the volume request. It gives the one defensible angle and shows exactly why the other six would be inbox spam.

--- a/skills/angle-generator/examples.md
+++ b/skills/angle-generator/examples.md
@@ -1,0 +1,3 @@
+# Angle Generator — Worked Examples
+
+TODO: Add realistic before/after examples from the source design doc.

--- a/skills/angle-generator/rubric.md
+++ b/skills/angle-generator/rubric.md
@@ -1,3 +1,219 @@
 # Angle Generator Rubric
 
-TODO: Map scored checks to the source design doc.
+Use this rubric to evaluate an `angle-generator` output before it leaves the agent. Every criterion is scored 0-2.
+
+- **0** - Missing, broken, or actively unsafe.
+- **1** - Present but weak, generic, or partially unsupported.
+- **2** - Solid, specific, and faithful to the skill.
+
+Total possible: 20 points.
+
+| Points | Verdict |
+|--------|---------|
+| 18-20 | **ship** |
+| 14-17 | **revise** |
+| 8-13 | **regenerate** |
+| 0-7 | **refuse / ask for better input** |
+
+---
+
+## 1. Input Completeness And Now Anchor
+
+**Source trace:** `Prompt scaffolding > Process`, `Hard rules`, `Decay reasoning`; `Rubric / checks / banned lists > Decay sanity check`.
+
+The output must respect the input contract. `context.current_time` is required; the agent cannot infer "now" from model memory.
+
+**Score 0:** Missing `current_time` is ignored, weak facts are padded into angles, or the output proceeds on generic input like "new UI" without asking questions.
+
+**Score 1:** Anchors on `current_time` but still produces thin angles from thin facts.
+
+**Score 2:** Refuses or narrows the output when facts are insufficient; uses `current_time` and supplied signals as the only basis for urgency.
+
+Red flags:
+
+- "Today" or "this week" with no supplied timestamp.
+- Generic facts treated as news.
+- Calendar or signal hooks force-fit to unrelated updates.
+
+---
+
+## 2. Fact Traceability / Hallucination Gate
+
+**Source trace:** `Hard rules > You do not invent facts`; `Rubric / checks / banned lists > Hallucination gate`.
+
+Every angle must identify which user-supplied facts it uses. Missing evidence belongs in `required_proof`, not in the headline or rationale.
+
+**Score 0:** Invents statistics, named people, organizations, customer results, market claims, or regulatory details.
+
+**Score 1:** Mostly grounded but includes unsupported context as if factual, or `facts_used` is vague.
+
+**Score 2:** Every substantive claim traces to `update.facts`, provided links, company fields, or explicit signal payloads; missing evidence is cleanly flagged.
+
+Red flags:
+
+- `facts_used` is empty.
+- A statistic appears that was not in the input.
+- "Research shows" or "analysts say" with no provided source.
+
+---
+
+## 3. Structural Distinctness
+
+**Source trace:** `Hard rules > You enforce structural distinctness`; `Rubric / checks / banned lists > Distinctness check`; `Sample I/O > Example 4`.
+
+The set must contain different story shapes, not rephrasings for different inboxes.
+
+**Score 0:** Multiple angles share the same headline frame, protagonist, story type, and journalist shape.
+
+**Score 1:** Some distinction exists, but the set still contains filler variants or beat-swapped clones.
+
+**Score 2:** Each kept angle has a distinct protagonist, beat, story type, proof path, or timing frame; duplicates are killed and logged.
+
+Red flags:
+
+- "Another angle" is the main differentiator.
+- Same `story_type` plus same `beat_description`.
+- More than 65% conceptual overlap between headline frames.
+
+---
+
+## 4. Journalist Shape
+
+**Source trace:** `Journalist-shape rubric`; `Hard rules > You do not invent journalists`; `Pains addressed > Pitch volume + irrelevance`.
+
+An angle is not real until a plausible beat can be named. The skill names the shape, not a specific journalist.
+
+**Score 0:** Uses generic targets like "tech journalist" or names specific journalists without verification.
+
+**Score 1:** Beat is present but broad; `evidence_they_care` is generic or could apply to any outlet.
+
+**Score 2:** Beat, outlet archetype, timely reason, and `do_not_target` are specific enough to guide the next skill.
+
+Red flags:
+
+- "This would appeal to journalists who care about startups."
+- No `do_not_target`.
+- Named journalists appear in the output.
+
+---
+
+## 5. Why-Now And Decay
+
+**Source trace:** `Decay reasoning`; `Hard rules > You tag every angle with decay`; `Rubric / checks / banned lists > Decay sanity check`.
+
+The output must be honest about urgency.
+
+**Score 0:** Claims breaking urgency without a supplied signal, or omits decay.
+
+**Score 1:** Decay is present but generic; `why_now` is a vague trend or repeats the update date.
+
+**Score 2:** `why_now` names the real time hook or says `EVERGREEN, NOT TIME-PRESSURED`; decay matches the source of urgency.
+
+Red flags:
+
+- `30min` or `4hr` with no `signal_from_newsjack_detector`.
+- `evergreen` on a company update without an uncomfortable question.
+- "In today's market" as the peg.
+
+---
+
+## 6. Anti-Slop Pass
+
+**Source trace:** `Banned words and structures`; `Rubric / checks / banned lists > Anti-slop regex pass`; `Secondary signal - Reads like a bot wrote it`.
+
+The output must reject AI-marketing language before the user sees it.
+
+**Score 0:** Kept angles contain banned terms or press-release framing.
+
+**Score 1:** Mostly clean but one field still leans on puffery or generic phrasing.
+
+**Score 2:** Headline frames, `why_now`, `distinctness_check`, and `evidence_they_care` are concrete and free of banned structures.
+
+Red flags:
+
+- "innovative platform", "future of X", "game-changing", "excited to announce".
+- "It's not just X, it's Y."
+- Placeholder leftovers such as `[COMPANY]`.
+
+---
+
+## 7. Required Proof
+
+**Source trace:** `What "an angle" means`; `Hard rules > You ask uncomfortable questions`; `Rubric / checks / banned lists > Per-angle proof requirement`.
+
+The skill must show what evidence makes the angle pitchable.
+
+**Score 0:** Proof is absent, generic, or asks for evidence after already making the claim.
+
+**Score 1:** Proof exists but is not specific enough to guide the user.
+
+**Score 2:** Each angle lists concrete proof; `data`, `customer-story`, `contrarian`, and `exec-spotlight` angles have at least one required proof item.
+
+Red flags:
+
+- "Need more data" with no description of what data.
+- Contrarian angle with no stated conventional wisdom to challenge.
+- Customer story with no customer proof requirement.
+
+---
+
+## 8. Refused Angles
+
+**Source trace:** `Hard rules > You output the refused angles`; `Refusal patterns`; `Sample I/O`.
+
+Refusal is part of the product. The user should see what died and why.
+
+**Score 0:** No `refused_angles` field, or bad angles are kept instead of killed.
+
+**Score 1:** Refused angles are listed but reasons are vague or outside the allowed values.
+
+**Score 2:** Refused angles use allowed reasons and teach the user what not to pitch.
+
+Allowed refusal reasons:
+
+- `duplicate`
+- `slop`
+- `hallucinated_fact`
+- `no_journalist_shape`
+- `no_why_now_but_required`
+- `off-beat`
+
+---
+
+## 9. Uncomfortable Questions And Next Skill
+
+**Source trace:** `Hard rules > You ask uncomfortable questions`; `When to call other skills`; `Open questions / risks > brand risk of being too refusenik`.
+
+The skill should be tough without stranding the user.
+
+**Score 0:** No questions when proof gaps are obvious, or the output ends without a next move.
+
+**Score 1:** Questions exist but are broad, soft, or disconnected from the angles.
+
+**Score 2:** Questions expose the exact missing facts that determine whether the angles are real; `follow_up_suggestions` names the right next skill or `null`.
+
+Red flags:
+
+- "Can you provide more details?"
+- Recommending `meanest-editor` before there is an angle or draft.
+- Calling a media-list skill before journalist shapes exist.
+
+---
+
+## 10. Output Contract
+
+**Source trace:** `Output schema`; `Prompt scaffolding > Output format`.
+
+The final output must be machine-usable.
+
+**Score 0:** Prose summary instead of JSON, missing top-level keys, or invalid JSON.
+
+**Score 1:** JSON is valid but fields are missing, renamed, or filled with vague placeholders.
+
+**Score 2:** Valid JSON with `angles`, `refused_angles`, `uncomfortable_questions`, and `follow_up_suggestions`; each angle includes all required fields.
+
+Red flags:
+
+- Preamble such as "Here are your angles."
+- Markdown bullets instead of the schema.
+- `anti_slop_pass` omitted or set without actual anti-slop compliance.

--- a/skills/angle-generator/rubric.md
+++ b/skills/angle-generator/rubric.md
@@ -1,0 +1,3 @@
+# Angle Generator Rubric
+
+TODO: Map scored checks to the source design doc.


### PR DESCRIPTION
## Summary

Builds the deployable `angle-generator` skill for newsjack.sh from the source design doc. The skill turns company updates into structurally distinct, journalist-shaped angles while refusing duplicates, invented facts, named-journalist guesses, and AI-marketing slop.

## Files

| File | Lines | Summary |
|------|------:|---------|
| `skills/angle-generator/SKILL.md` | 214 | Agent persona, doctrine TODO, hard rules, workflow, anti-slop rules, decay logic, hand-offs, refusal lines, and exact JSON output contract. |
| `skills/angle-generator/rubric.md` | 219 | Ten scored criteria, each traced to the source design sections for completeness, fact grounding, distinctness, journalist shape, decay, anti-slop, proof, refusals, questions, and output contract. |
| `skills/angle-generator/examples.md` | 517 | Four realistic before/after examples: strong Series A, weak product update, live newsjack handoff, and spray-and-pray partnership refusal. |
| `skills/angle-generator/README.md` | 55 | Short invocation guide, expected output summary, and file index matching the shipped skill pattern. |

## Validation

- Parsed all 8 JSON example blocks successfully with Node.
- Ran `git diff --check HEAD`.
- Checked `skills/angle-generator` for non-ASCII characters.
- Skipped `pnpm lint` and `pnpm test`: no `package.json` exists in this repo.

## Notes

- `skills/ETHICS.md` and `skills/WHY-NOT-SPAM.md` are not present in this branch, so `SKILL.md` includes the requested TODO comment instead of blocking.