### PR TITLE
[codex] add agent runtime harness

### DIFF
--- a/.github/workflows/agent-harness-ci.yml
+++ b/.github/workflows/agent-harness-ci.yml
@@ -1,0 +1,21 @@
+name: Agent Harness CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  no-token-installer:
+    name: No-token installer harness
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build harness image
+        run: docker build -f harness/Dockerfile -t newsjack-agent-harness:local .
+
+      - name: Test all runtime install targets
+        run: python3 harness/run.py --mode ci-installer --runtime all --local-source

--- a/.github/workflows/agent-harness-integration.yml
+++ b/.github/workflows/agent-harness-integration.yml
@@ -1,0 +1,68 @@
+name: Agent Harness Integration
+
+on:
+  workflow_dispatch:
+    inputs:
+      runtime:
+        description: Runtime to test
+        required: true
+        default: codex
+        type: choice
+        options:
+          - codex
+          - claude
+          - hermes
+          - openclaw
+          - all
+      mode:
+        description: Token-burning test mode
+        required: true
+        default: native-smoke
+        type: choice
+        options:
+          - native-smoke
+          - acp-smoke
+          - setup-flow
+      production_path:
+        description: Use public newsjack.sh installer path
+        required: true
+        default: false
+        type: boolean
+
+jobs:
+  integration:
+    name: Token-burning integration harness
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Write integration env file
+        shell: bash
+        run: |
+          umask 077
+          {
+            echo "OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}"
+            echo "ANTHROPIC_API_KEY=${{ secrets.ANTHROPIC_API_KEY }}"
+            echo "OPENROUTER_API_KEY=${{ secrets.OPENROUTER_API_KEY }}"
+            echo "MEDIALYST_API_KEY=${{ secrets.MEDIALYST_API_KEY }}"
+            echo "MEDIALYST_API_BASE=https://medialyst.ai/api"
+            echo "MEDIALYST_NEWS_PATH=/v1/news/search"
+            echo "NEWSJACK_HARNESS_ALLOW_MODEL_CALLS=1"
+          } > harness/.env.local
+
+      - name: Build harness image
+        run: docker build -f harness/Dockerfile -t newsjack-agent-harness:local .
+
+      - name: Run integration harness
+        shell: bash
+        run: |
+          source_flag="--local-source"
+          if [ "${{ inputs.production_path }}" = "true" ]; then
+            source_flag="--production-path"
+          fi
+          python3 harness/run.py \
+            --mode "${{ inputs.mode }}" \
+            --runtime "${{ inputs.runtime }}" \
+            --env-file harness/.env.local \
+            "$source_flag"

--- a/README.md
+++ b/README.md
@@ -8,6 +8,34 @@
 curl newsjack.sh | sh
 ```
 
+The install path tracks `main`. No release artifact is required: pushing to this repo updates the root `install.sh`, and `newsjack.sh/install.sh` serves the current script from GitHub raw with a short cache.
+
+The installer:
+- fetches `elvisun/newsjack@main`
+- installs a managed copy at `~/.newsjack/newsjack`
+- installs `newsjack` at `~/.newsjack/bin/newsjack`
+- copies every `skills/*/SKILL.md` skill folder, including bundled scripts and references, into detected runtimes
+- configures the optional `medialyst` MCP server when the runtime exposes a noninteractive setup path
+
+Runtime detection is additive. If a user has multiple supported runtimes, the installer configures all of them.
+
+Supported targets:
+- **Codex:** skills to `~/.agents/skills`, MCP via `codex mcp add`
+- **Claude Code:** skills to `~/.claude/skills`, MCP via `claude mcp add-json --scope user`
+- **OpenClaw:** skills to `~/.openclaw/skills`, MCP via `openclaw mcp set`
+- **Hermes:** skills to `~/.hermes/skills`, MCP by adding `mcp_servers.medialyst` to `~/.hermes/config.yaml`
+
+Override auto-detection when needed:
+
+```bash
+NEWSJACK_RUNTIMES=codex,claude curl newsjack.sh | sh
+NEWSJACK_RUNTIMES=all curl newsjack.sh | sh
+NEWSJACK_INSTALL_MCP=0 curl newsjack.sh | sh
+NEWSJACK_REF=my-branch curl newsjack.sh | sh
+```
+
+See [Distribution Roadmap](./docs/distribution-roadmap.md) for the curl-v1 and npm-later plan.
+
 ## What is this?
 
 newsjack is the open-source operating system for **agentic PR** — a skill layer that installs into Claude, ChatGPT, Cursor, or any agent runtime that supports skills. Install it once and your agent becomes a PR operator: briefing, newsjacking, pitch critique, angle generation, media list workflow.
@@ -40,7 +68,7 @@ media_lists:write
 Save the key once:
 
 ```bash
-python3 skills/media-list-manager/scripts/medialyst_auth.py login
+newsjack login
 ```
 
 The helper stores credentials in `~/.newsjack/credentials.json` with user-only file permissions. Repo `.env` and `MEDIALYST_API_KEY` still work for CI and advanced local setups.
@@ -50,7 +78,7 @@ The helper stores credentials in `~/.newsjack/credentials.json` with user-only f
 Claude Code supports project MCP config and `headersHelper`, so it can use the repo `.mcp.json` directly:
 
 ```bash
-python3 skills/media-list-manager/scripts/medialyst_auth.py login
+newsjack login
 claude --strict-mcp-config --mcp-config .mcp.json
 ```
 
@@ -67,8 +95,8 @@ Expected result: `medialyst` is connected.
 Codex supports MCP servers, but not Claude Code's `headersHelper`. Use the stdio bridge, which reads the same saved Newsjack credential and runs `mcp-remote` under the hood:
 
 ```bash
-python3 skills/media-list-manager/scripts/medialyst_auth.py login
-codex mcp add medialyst -- python3 "$PWD/skills/media-list-manager/scripts/medialyst_mcp_bridge.py"
+newsjack login
+codex mcp add medialyst -- ~/.newsjack/bin/newsjack mcp-bridge
 codex mcp list
 ```
 
@@ -85,8 +113,8 @@ That native path requires `MEDIALYST_API_KEY` to be present in the Codex process
 OpenClaw supports configured MCP stdio servers. Use the same stdio bridge:
 
 ```bash
-python3 skills/media-list-manager/scripts/medialyst_auth.py login
-openclaw mcp set medialyst "{\"command\":\"python3\",\"args\":[\"$PWD/skills/media-list-manager/scripts/medialyst_mcp_bridge.py\"]}"
+newsjack login
+openclaw mcp set medialyst "{\"command\":\"$HOME/.newsjack/bin/newsjack\",\"args\":[\"mcp-bridge\"]}"
 openclaw mcp list
 ```
 
@@ -97,15 +125,15 @@ The bridge requires Node.js because it launches `npx -y mcp-remote`.
 If your client supports Claude-style `headersHelper`, point it at:
 
 ```bash
-python3 skills/media-list-manager/scripts/medialyst_auth.py headers
+~/.newsjack/bin/newsjack auth headers
 ```
 
 If your client supports only stdio MCP servers, configure:
 
 ```json
 {
-  "command": "python3",
-  "args": ["/absolute/path/to/newsjack/skills/media-list-manager/scripts/medialyst_mcp_bridge.py"]
+  "command": "/Users/alice/.newsjack/bin/newsjack",
+  "args": ["mcp-bridge"]
 }
 ```
 
@@ -156,7 +184,7 @@ install.sh   # what `curl newsjack.sh` serves to curl/wget clients
 
 ## How `curl newsjack.sh | sh` works
 
-The marketing site at `newsjack.sh` and the install script are served from the same URL. An edge function inspects the `User-Agent` header: curl and wget receive the shell script, while browsers receive the marketing page. Both the routing logic and the install script live in this repository under `apps/site/`.
+The marketing site at `newsjack.sh` and the install script are served from the same URL. The Next.js `proxy.ts` in `apps/site/` inspects the `User-Agent` header: curl and wget are rewritten to `/install.sh`, while browsers receive the marketing page. The `/install.sh` route serves the canonical root `install.sh` from GitHub `main`, with a bundled-file fallback for local development.
 
 ## License
 

--- a/apps/site/app/install.sh/route.ts
+++ b/apps/site/app/install.sh/route.ts
@@ -1,0 +1,39 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+const installUrl =
+  process.env.NEWSJACK_INSTALL_URL ??
+  "https://raw.githubusercontent.com/elvisun/newsjack/main/install.sh";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+async function readBundledInstaller() {
+  return readFile(join(process.cwd(), "../../install.sh"), "utf8");
+}
+
+export async function GET() {
+  let body: string;
+
+  try {
+    const response = await fetch(installUrl, {
+      cache: "no-store",
+      headers: { accept: "text/x-shellscript,text/plain,*/*" },
+    });
+
+    if (!response.ok) {
+      throw new Error(`installer fetch failed: ${response.status}`);
+    }
+
+    body = await response.text();
+  } catch {
+    body = await readBundledInstaller();
+  }
+
+  return new Response(body, {
+    headers: {
+      "cache-control": "public, max-age=60, stale-while-revalidate=300",
+      "content-type": "text/x-shellscript; charset=utf-8",
+    },
+  });
+}

--- a/apps/site/app/page.tsx
+++ b/apps/site/app/page.tsx
@@ -42,7 +42,7 @@ export default function Home() {
                 <code>curl newsjack.sh | sh</code>
               </pre>
               <p className="mt-3 font-mono text-xs text-zinc-500">
-                Coming soon — May 2026
+                Installs latest from GitHub main
               </p>
             </div>
 
@@ -71,7 +71,8 @@ export default function Home() {
                 <span className="text-emerald-300">$</span> newsjack install
               </p>
               <p className="text-zinc-500">resolving agent runtime...</p>
-              <p className="text-zinc-500">loading pr operator skills...</p>
+              <p className="text-zinc-500">syncing pr operator skills...</p>
+              <p className="text-zinc-500">configuring optional mcp...</p>
               <p className="text-zinc-100">ready</p>
             </div>
           </div>

--- a/apps/site/proxy.ts
+++ b/apps/site/proxy.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const installerUserAgent =
+  /\b(curl|wget|httpie|python-requests|go-http-client|libwww-perl|powershell|aria2)\b/i;
+
+export function proxy(request: NextRequest) {
+  const userAgent = request.headers.get("user-agent") ?? "";
+
+  if (installerUserAgent.test(userAgent)) {
+    const url = request.nextUrl.clone();
+    url.pathname = "/install.sh";
+    return NextResponse.rewrite(url);
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: "/",
+};

--- a/bin/newsjack
+++ b/bin/newsjack
@@ -1,0 +1,116 @@
+#!/bin/sh
+set -eu
+
+NEWSJACK_HOME="${NEWSJACK_HOME:-$HOME/.newsjack}"
+NEWSJACK_ROOT="${NEWSJACK_ROOT:-$NEWSJACK_HOME/newsjack}"
+
+die() {
+  printf '%s\n' "newsjack: error: $*" >&2
+  exit 1
+}
+
+have() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+need_root() {
+  [ -d "$NEWSJACK_ROOT" ] || die "newsjack is not installed at $NEWSJACK_ROOT; run: curl newsjack.sh | sh"
+}
+
+auth_script() {
+  printf '%s\n' "$NEWSJACK_ROOT/skills/media-list-manager/scripts/medialyst_auth.py"
+}
+
+detector_script() {
+  printf '%s\n' "$NEWSJACK_ROOT/skills/newsjack-detector/scripts/newsjack_detector.py"
+}
+
+usage() {
+  cat <<'EOF'
+newsjack
+
+Usage:
+  newsjack help
+  newsjack path
+  newsjack skills
+  newsjack login [--key KEY]
+  newsjack auth status|headers|logout
+  newsjack detector [args...]
+  newsjack filter-apply [args...]
+  newsjack summarize-run [args...]
+  newsjack mcp-bridge
+  newsjack update
+
+Commands:
+  path        Print the installed newsjack repo path.
+  skills      List installed Newsjack skill names.
+  login       Save a Medialyst API key in ~/.newsjack/credentials.json.
+  auth        Run the Medialyst auth helper directly.
+  detector    Run the local newsjack-detector engine.
+  filter-apply
+              Apply newsjack-detector cheap-filter decisions.
+  summarize-run
+              Render a newsjack-detector run summary.
+  mcp-bridge  Start the Medialyst MCP stdio bridge.
+  update      Fetch and run the latest installer from newsjack.sh.
+EOF
+}
+
+cmd=${1:-help}
+case "$cmd" in
+  help|--help|-h)
+    usage
+    ;;
+  path)
+    need_root
+    printf '%s\n' "$NEWSJACK_ROOT"
+    ;;
+  skills)
+    need_root
+    find "$NEWSJACK_ROOT/skills" -mindepth 2 -maxdepth 2 -name SKILL.md -print |
+      sed 's#/SKILL\.md$##; s#.*/##' |
+      sort
+    ;;
+  login)
+    need_root
+    shift
+    exec python3 "$(auth_script)" login "$@"
+    ;;
+  auth)
+    need_root
+    shift
+    exec python3 "$(auth_script)" "$@"
+    ;;
+  detector)
+    need_root
+    shift
+    exec python3 "$(detector_script)" "$@"
+    ;;
+  filter-apply)
+    need_root
+    shift
+    exec python3 "$NEWSJACK_ROOT/skills/newsjack-detector/scripts/newsjack_filter_apply.py" "$@"
+    ;;
+  summarize-run)
+    need_root
+    shift
+    exec python3 "$NEWSJACK_ROOT/fixtures/newsjack-detector-agent/scripts/summarize-run.py" "$@"
+    ;;
+  mcp-bridge)
+    need_root
+    exec python3 "$NEWSJACK_ROOT/skills/media-list-manager/scripts/medialyst_mcp_bridge.py"
+    ;;
+  update|install)
+    if have curl; then
+      curl -fsSL https://newsjack.sh/install.sh | sh
+    elif have wget; then
+      wget -qO- https://newsjack.sh/install.sh | sh
+    else
+      die "curl or wget is required"
+    fi
+    ;;
+  *)
+    usage >&2
+    die "unknown command: $cmd"
+    ;;
+esac

--- a/docs/agent-runtime-harness-plan.md
+++ b/docs/agent-runtime-harness-plan.md
@@ -1,0 +1,481 @@
+# Agent Runtime Harness Plan
+
+## Goal
+
+Build a repeatable harness that tests the real Newsjack installer and setup flow against real agent runtimes:
+
+- Claude Code
+- Codex
+- Hermes
+- OpenClaw
+
+The harness must not install anything into the developer's host home directory. All runtime binaries, auth state, Newsjack state, transcripts, and generated artifacts must live inside disposable containers or explicit harness output directories.
+
+## Non-goals
+
+- Do not fake runtime binaries for the main test path.
+- Do not mutate host `~/.codex`, `~/.claude`, `~/.hermes`, `~/.openclaw`, or `~/.newsjack`.
+- Do not rely on terminal scraping as the primary control plane when ACP is available.
+- Do not require browser-based login during automated runs.
+
+## Design Summary
+
+Use a container-first harness:
+
+1. Build a Linux image with common runtime dependencies.
+2. Install the real agent CLIs inside the image.
+3. Run each test in a fresh container with an isolated `HOME`.
+4. Execute the real installer through the public curl path or a local source override.
+5. Drive agent turns through ACP when available.
+6. Fall back to each runtime's non-interactive CLI only for smoke coverage.
+7. Keep tmux as a last-resort fallback for interactive flows that cannot be exercised through ACP or non-interactive commands.
+
+## Repository Layout
+
+Proposed files:
+
+```text
+harness/
+  README.md
+  Dockerfile
+  .env.example
+  .env.local        # ignored; local token-burning integration credentials
+  run.py
+  acp_client.py
+  runtime_probe.py
+  assertions.py
+  config.example.yaml
+  adapters/
+    __init__.py
+    codex.py
+    claude.py
+    hermes.py
+    openclaw.py
+  prompts/
+    install-smoke.md
+    setup-flow.md
+    detector-mock.md
+  scripts/
+    install-runtimes.sh
+    run-in-container.sh
+```
+
+Output:
+
+```text
+harness/runs/
+  2026-05-25T120000Z/
+    codex/
+      env.json
+      installer.log
+      acp-events.jsonl
+      final-response.md
+      artifacts/
+    claude/
+    hermes/
+    openclaw/
+```
+
+`harness/runs/` should be gitignored.
+
+Local token-burning integration credentials should live at:
+
+```text
+harness/.env.local
+```
+
+That file must never be committed. Start from `harness/.env.example` and pass it to Docker with:
+
+```bash
+docker run --rm --env-file harness/.env.local ...
+```
+
+## Container Contract
+
+The host command should look like:
+
+```bash
+docker run --rm \
+  --name newsjack-harness-codex \
+  -v "$PWD:/repo:ro" \
+  -v "$PWD/harness/runs:/runs" \
+  -e OPENAI_API_KEY \
+  -e ANTHROPIC_API_KEY \
+  -e MEDIALYST_API_KEY \
+  newsjack-agent-harness \
+  python3 /harness/run.py --runtime codex --mode local-source
+```
+
+Runtime state stays inside the container:
+
+```bash
+export HOME=/tmp/newsjack-home
+export XDG_CONFIG_HOME=/tmp/newsjack-home/.config
+export XDG_CACHE_HOME=/tmp/newsjack-home/.cache
+export XDG_DATA_HOME=/tmp/newsjack-home/.local/share
+```
+
+The repo is mounted read-only. Test artifacts go to `/runs`.
+
+For local installer iteration:
+
+```bash
+NEWSJACK_SOURCE_DIR=/repo \
+NEWSJACK_RUNTIMES=codex \
+curl -fsSL https://newsjack.sh/install.sh | sh
+```
+
+For production-path validation:
+
+```bash
+NEWSJACK_RUNTIMES=codex \
+curl -fsSL https://newsjack.sh/install.sh | sh
+```
+
+Use local-source mode in PR tests and production-path mode in scheduled tests.
+
+## Runtime Installation
+
+The image should install common tools:
+
+- `bash`
+- `curl`
+- `git`
+- `python3`
+- `pipx`
+- `node`
+- `npm`
+- `jq`
+- `ripgrep`
+- `tmux`
+
+Install real runtimes inside the image:
+
+```bash
+npm install -g @openai/codex
+npm install -g @anthropic-ai/claude-code
+npm install -g openclaw@latest
+pipx install hermes-agent
+npm install -g acpx@latest
+npm install -g @zed-industries/codex-acp
+npm install -g @zed-industries/claude-agent-acp
+```
+
+Pin versions once the first green run establishes a baseline. Start unpinned only while discovering currently compatible versions.
+
+## ACP Launch Strategy
+
+Runtime ACP support changes quickly. The harness should probe supported launch commands instead of assuming one shape.
+
+Probe order:
+
+```json
+{
+  "codex": [
+    ["codex", "--acp", "--stdio"],
+    ["codex-acp"],
+    ["acpx", "codex"]
+  ],
+  "claude": [
+    ["claude", "--acp", "--stdio"],
+    ["claude-agent-acp"],
+    ["acpx", "claude"]
+  ],
+  "hermes": [
+    ["hermes", "--acp", "--stdio"],
+    ["hermes", "acp", "--accept-hooks"]
+  ],
+  "openclaw": [
+    ["openclaw", "--acp", "--stdio"],
+    ["openclaw", "acp"]
+  ]
+}
+```
+
+The chosen launch command must be recorded in `env.json`.
+
+ACP probing should verify more than process startup:
+
+1. Spawn the candidate command with clean stdio.
+2. Send ACP `initialize`.
+3. Create a new session with the test workspace cwd.
+4. Send a trivial prompt.
+5. Confirm at least one valid ACP response or update.
+
+If every ACP candidate fails, mark ACP unavailable and run only the runtime's native CLI smoke test for that runtime.
+
+## Native CLI Smoke Strategy
+
+Native smoke tests protect against adapter drift. They should be short and cheap.
+
+Commands:
+
+```bash
+codex exec --cd /workspace --sandbox danger-full-access --ask-for-approval never "Say READY."
+claude --bare -p "Say READY."
+hermes chat -Q -q "Say READY."
+openclaw agent --local --message "Say READY." --json
+```
+
+These do not replace ACP setup-flow tests. They only prove the installed runtime binary can run in the container with the supplied credentials.
+
+## Newsjack Installer Assertions
+
+After `curl newsjack.sh | sh`, assert:
+
+- `~/.newsjack/newsjack` exists.
+- `~/.newsjack/bin/newsjack` exists and is executable.
+- `~/.newsjack/bin/newsjack skills` lists the expected skills.
+- Runtime-specific skill directories exist:
+  - Codex: `~/.agents/skills`
+  - Claude Code: `~/.claude/skills`
+  - Hermes: `~/.hermes/skills`
+  - OpenClaw: `~/.openclaw/skills`
+- The selected runtime has `newsjack-setup`, `newsjack-detector`, and `media-list-manager`.
+- MCP config path was attempted or written:
+  - Codex: inspect `codex mcp list` when available.
+  - Claude: inspect `claude mcp list` when available.
+  - Hermes: inspect `~/.hermes/config.yaml`.
+  - OpenClaw: inspect `openclaw mcp list` when available.
+
+If `MEDIALYST_API_KEY` is present:
+
+```bash
+~/.newsjack/bin/newsjack login --key "$MEDIALYST_API_KEY"
+~/.newsjack/bin/newsjack auth status
+```
+
+If no key is present, skip Medialyst-backed tests but still run skills-only and detector mock tests.
+
+## Agent Setup-Flow Test
+
+Prompt file: `harness/prompts/setup-flow.md`
+
+Expected behavior:
+
+1. Agent discovers or uses the installed `newsjack-setup` skill.
+2. Agent creates a monitor profile for a fixture company.
+3. Agent saves it to `/runs/<run>/<runtime>/artifacts/profile.json`.
+4. Agent runs detector mock mode with that profile.
+5. Agent writes a short result summary to `/runs/<run>/<runtime>/artifacts/result.md`.
+
+Suggested prompt:
+
+```text
+You are testing the installed Newsjack skills.
+
+Create a Newsjack monitor profile for Fixture Coffee, a specialty coffee company.
+Save it exactly at ARTIFACT_DIR/profile.json.
+
+Then run the local newsjack detector in mock mode with that profile.
+Save a short Markdown result at ARTIFACT_DIR/result.md.
+
+Do not ask follow-up questions. Make reasonable assumptions.
+```
+
+The harness replaces `ARTIFACT_DIR` before sending.
+
+Assertions:
+
+- `profile.json` exists.
+- `profile.json` parses as JSON.
+- Required profile fields exist.
+- Detector mock command exits successfully.
+- `result.md` exists and mentions whether the run succeeded.
+
+## Detector Direct Test
+
+The harness should also directly exercise the installed CLI without an agent:
+
+```bash
+~/.newsjack/bin/newsjack detector run \
+  "specialty coffee" \
+  --profile /repo/fixtures/newsjack-detector-agent/profile.bluebottle.json \
+  --mock \
+  --emit json
+```
+
+This separates installer/CLI problems from agent orchestration problems.
+
+## Runtime-Specific Notes
+
+### Codex
+
+Primary path should be ACP if one of the candidate launchers works. Keep a native `codex exec` smoke test because Codex skill loading and MCP config are part of the Newsjack install surface.
+
+Auth:
+
+- Prefer `OPENAI_API_KEY`.
+
+### Claude Code
+
+Claude's ACP surface may be adapter-based depending on installed version. Keep a native `claude --bare -p` smoke test because the installer targets `~/.claude/skills`, and an ACP adapter may not exercise the same skill discovery path.
+
+Auth:
+
+- Prefer `ANTHROPIC_API_KEY`.
+- Run with `--bare` for deterministic automation when using native smoke.
+
+### Hermes
+
+Hermes exposes `hermes acp`. It uses the same Hermes configuration and credentials as normal CLI mode, so isolated `HOME` is important.
+
+Auth:
+
+- Prefer provider configuration via env vars for automation.
+- Use `--accept-hooks` in ACP mode to avoid headless hook prompts.
+
+### OpenClaw
+
+OpenClaw exposes `openclaw acp`, but it is Gateway-backed. The harness must either:
+
+- start a local OpenClaw Gateway inside the container before ACP tests, or
+- configure `openclaw acp` against a test Gateway URL.
+
+Start with local Gateway mode. If Gateway setup is too heavy for PR tests, keep OpenClaw in native smoke mode for PRs and run full ACP setup-flow in scheduled CI.
+
+## Test Modes
+
+### `installer`
+
+Runs only:
+
+- container setup
+- real runtime install
+- `curl newsjack.sh | sh`
+- installer assertions
+- direct detector mock
+
+No agent API spend unless runtime install/auth checks require it.
+
+### `native-smoke`
+
+Runs:
+
+- installer mode
+- one short native prompt per runtime
+
+### `acp-smoke`
+
+Runs:
+
+- installer mode
+- ACP launch probe
+- trivial ACP prompt
+
+### `setup-flow`
+
+Runs:
+
+- installer mode
+- ACP launch probe
+- full Newsjack setup-flow prompt
+- artifact assertions
+
+### `production-path`
+
+Same as selected mode, but does not use `NEWSJACK_SOURCE_DIR=/repo`. It validates the public `newsjack.sh` path.
+
+## CI Plan
+
+PR checks:
+
+```bash
+harness/run.py --runtime codex --mode installer --local-source
+harness/run.py --runtime claude --mode installer --local-source
+harness/run.py --runtime hermes --mode installer --local-source
+harness/run.py --runtime openclaw --mode installer --local-source
+```
+
+Nightly checks:
+
+```bash
+harness/run.py --runtime all --mode native-smoke --production-path
+harness/run.py --runtime all --mode acp-smoke --production-path
+```
+
+Manual/release checks:
+
+```bash
+harness/run.py --runtime all --mode setup-flow --production-path
+```
+
+## Failure Output
+
+Every failure should include:
+
+- runtime
+- mode
+- selected launch path
+- container image digest
+- runtime versions
+- installer log path
+- ACP event log path if applicable
+- artifact directory path
+- final assertion error
+
+Do not print secrets. Redact values for variables matching:
+
+- `*_API_KEY`
+- `*_TOKEN`
+- `*_SECRET`
+- `*_PASSWORD`
+
+## Implementation Phases
+
+### Phase 1: Container and Installer Assertions
+
+Build `harness/Dockerfile`, `harness/run.py`, and installer assertions for one runtime at a time. Start with Codex because its native non-interactive mode is straightforward.
+
+Done when:
+
+- host remains clean
+- container installs real Codex
+- installer succeeds with `NEWSJACK_SOURCE_DIR=/repo`
+- skill and CLI assertions pass
+
+### Phase 2: All Runtime Installer Coverage
+
+Add Claude, Hermes, and OpenClaw runtime installation and installer assertions.
+
+Done when:
+
+- all four runtimes pass installer mode in fresh containers
+- each runtime records version and skill installation paths
+
+### Phase 3: ACP Probe
+
+Implement minimal ACP JSON-RPC client and capability probes.
+
+Done when:
+
+- ACP probe records the first working candidate per runtime
+- failures are structured and readable
+- native smoke fallback works when ACP is unavailable
+
+### Phase 4: Agent Setup Flow
+
+Add `setup-flow.md`, artifact assertions, and direct detector separation.
+
+Done when:
+
+- at least one runtime completes the full setup flow through ACP
+- all generated artifacts are saved under `/runs`
+
+### Phase 5: CI and Hardening
+
+Add GitHub Actions workflow, version pins, log redaction, timeouts, and scheduled production-path checks.
+
+Done when:
+
+- PR checks do not require expensive agent calls
+- scheduled checks exercise real public installer path
+- manual workflow can run full setup flow with secrets
+
+## Open Questions
+
+- Which runtime versions should we pin for the first stable baseline?
+- Should full OpenClaw ACP run in PR checks or only scheduled checks because of Gateway setup cost?
+- Should `newsjack.sh` production-path checks run against `main` only, or also against a preview deployment for pull requests?
+- Do we need a small JSON schema for monitor profiles to make setup-flow validation stricter?
+- Should Medialyst MCP connection be tested with a real API call, or is `auth status` plus MCP config inspection enough for PR checks?

--- a/docs/distribution-roadmap.md
+++ b/docs/distribution-roadmap.md
@@ -1,0 +1,107 @@
+# Distribution Roadmap
+
+Newsjack v1 ships with the curl installer as the primary distribution path:
+
+```bash
+curl newsjack.sh | sh
+```
+
+The installer tracks GitHub `main`, installs the local skill layer, and configures supported agent runtimes. This keeps the beta loop fast: push to this repo, deploy the site, and new installs pick up the current installer and skills without a manual package release.
+
+## Current Channel
+
+### `curl newsjack.sh | sh`
+
+Status: v1 channel.
+
+Owns:
+
+- installing a managed checkout at `~/.newsjack/newsjack`
+- installing the `newsjack` shim at `~/.newsjack/bin/newsjack`
+- detecting Codex, Claude Code, OpenClaw, Hermes, or combinations of them
+- copying local skills, references, and scripts into runtime-specific skill directories
+- configuring optional Medialyst MCP where a noninteractive setup path exists
+- updating from GitHub `main`
+
+Use this channel for:
+
+- beta users
+- fast iteration
+- latest skill updates
+- dogfooding runtime detection and MCP setup
+
+Do not promise immutable installs on this channel. It follows `main` by design.
+
+## Later Channel
+
+### `npm install -g newsjack`
+
+Status: planned, not v1.
+
+Purpose:
+
+- stable versioned CLI installs
+- normal `npm update -g newsjack` and `npm uninstall -g newsjack` flows
+- npm package identity, registry metadata, and provenance
+- friendlier security review for teams that dislike `curl | sh`
+
+Open decision:
+
+- whether npm ships the full CLI and bundled skills, or acts as a bootstrapper for the GitHub-backed installer.
+
+Default recommendation:
+
+- keep `curl` as the latest-main channel
+- make npm the stable release channel
+- do not publish npm on every push to `main`
+- publish npm from tags or GitHub releases after v1 behavior settles
+
+## CLI Shape
+
+The `newsjack` command should become the stable product interface. Skill docs should call:
+
+```bash
+newsjack login
+newsjack skills
+newsjack detector run ...
+newsjack mcp-bridge
+```
+
+They should not rely on repo-relative paths like:
+
+```bash
+python3 skills/.../scripts/foo.py
+```
+
+Skill-local scripts can stay near the skills that need them, but they are implementation details. The CLI owns the public contract.
+
+## Runtime Targets
+
+Supported v1 targets:
+
+- Codex
+- Claude Code
+- OpenClaw
+- Hermes
+
+The installer should remain additive: if multiple runtimes are present, configure all detected runtimes unless `NEWSJACK_RUNTIMES` narrows the target list.
+
+## Release Gates
+
+Before calling the curl channel live:
+
+- DNS for `newsjack.sh` resolves
+- `newsjack.sh` browser requests serve the marketing site
+- curl/wget requests serve shell from `/install.sh`
+- installer smoke test passes from a clean temporary `$HOME`
+- runtime skill install paths are verified for Codex, Claude Code, OpenClaw, and Hermes
+- MCP setup failures are warnings, not install blockers
+- README install instructions match the actual hosted behavior
+
+Before npm:
+
+- move the CLI from a shell shim into a real `apps/cli` package or make the shim an intentional package entrypoint
+- decide package name: `newsjack` vs scoped package
+- add `npm pack --dry-run` to CI
+- add a tag/release-based publish workflow
+- prefer npm trusted publishing from GitHub Actions over long-lived npm tokens

--- a/harness/.env.example
+++ b/harness/.env.example
@@ -1,0 +1,31 @@
+# Newsjack agent runtime harness
+#
+# Copy this file to:
+#   harness/.env.local
+#
+# The real .env.local file is ignored by git. It is only needed for
+# token-burning integration modes. CI installer checks should run without
+# these model-provider keys.
+
+# Required for Codex integration-smoke/setup-flow modes.
+OPENAI_API_KEY=
+
+# Required for Claude Code integration-smoke/setup-flow modes.
+ANTHROPIC_API_KEY=
+
+# Optional. Hermes ACP advertises OpenRouter/Hermes setup auth; native Hermes
+# smoke uses ANTHROPIC_API_KEY, but hermes acp currently needs this path.
+OPENROUTER_API_KEY=
+
+# Required for Medialyst-backed login, MCP, and live news-search tests.
+MEDIALYST_API_KEY=
+MEDIALYST_API_BASE=https://medialyst.ai/api
+MEDIALYST_NEWS_PATH=/v1/news/search
+
+# Optional live X/trends coverage. Leave blank for the first E2E pass.
+X_BEARER_TOKEN=
+TWITTER_BEARER_TOKEN=
+
+# Safety switch. CI no-token mode must leave this as 0 or unset.
+# Token-burning integration modes should set it to 1 explicitly.
+NEWSJACK_HARNESS_ALLOW_MODEL_CALLS=0

--- a/harness/.gitignore
+++ b/harness/.gitignore
@@ -1,0 +1,3 @@
+runs/
+runs-local/
+.env.local

--- a/harness/Dockerfile
+++ b/harness/Dockerfile
@@ -1,0 +1,42 @@
+FROM node:22-bookworm
+
+ARG CODEX_VERSION=0.133.0
+ARG CLAUDE_CODE_VERSION=2.1.150
+ARG OPENCLAW_VERSION=2026.5.22
+ARG ACPX_VERSION=0.10.0
+ARG CODEX_ACP_VERSION=0.15.0
+ARG CLAUDE_AGENT_ACP_VERSION=0.23.1
+ARG HERMES_AGENT_VERSION=0.14.0
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV PIPX_HOME=/opt/pipx
+ENV PIPX_BIN_DIR=/usr/local/bin
+ENV PATH=/usr/local/bin:/usr/local/sbin:/usr/sbin:/usr/bin:/sbin:/bin
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    bash \
+    ca-certificates \
+    curl \
+    git \
+    jq \
+    pipx \
+    python3 \
+    python3-venv \
+    ripgrep \
+    tmux \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY harness/scripts/install-runtimes.sh /usr/local/bin/install-newsjack-harness-runtimes
+
+RUN CODEX_VERSION="$CODEX_VERSION" \
+    CLAUDE_CODE_VERSION="$CLAUDE_CODE_VERSION" \
+    OPENCLAW_VERSION="$OPENCLAW_VERSION" \
+    ACPX_VERSION="$ACPX_VERSION" \
+    CODEX_ACP_VERSION="$CODEX_ACP_VERSION" \
+    CLAUDE_AGENT_ACP_VERSION="$CLAUDE_AGENT_ACP_VERSION" \
+    HERMES_AGENT_VERSION="$HERMES_AGENT_VERSION" \
+    install-newsjack-harness-runtimes
+
+WORKDIR /workspace
+

--- a/harness/README.md
+++ b/harness/README.md
@@ -1,0 +1,61 @@
+# Newsjack Agent Runtime Harness
+
+Container-first harness for validating the Newsjack installer against real agent runtime binaries.
+
+## No-Token CI Lane
+
+This mode must not receive model-provider credentials and must not call agents:
+
+```bash
+python3 harness/run.py --build-image --mode ci-installer --runtime all --local-source
+```
+
+It runs one fresh container per runtime and validates:
+
+- real runtime binary is installed in the image
+- Newsjack installs into an isolated container `HOME`
+- expected runtime skill directories exist
+- `newsjack skills` works
+- direct detector mock run works
+
+## Token-Burning Integration Lane
+
+Create:
+
+```bash
+cp harness/.env.example harness/.env.local
+```
+
+Fill in:
+
+```bash
+OPENAI_API_KEY=...
+ANTHROPIC_API_KEY=...
+MEDIALYST_API_KEY=...
+NEWSJACK_HARNESS_ALLOW_MODEL_CALLS=1
+```
+
+Then run one runtime first:
+
+```bash
+python3 harness/run.py --build-image --mode native-smoke --runtime codex --env-file harness/.env.local --local-source
+```
+
+Full setup-flow mode should be run manually until spend and adapter behavior are stable.
+
+Current control-plane coverage:
+
+- Codex: native smoke and ACP setup-flow use `OPENAI_API_KEY`.
+- Claude Code: native smoke and ACP setup-flow use `ANTHROPIC_API_KEY`.
+- Hermes: native smoke/setup-flow use `ANTHROPIC_API_KEY`; `hermes acp` currently advertises OpenRouter/Hermes setup auth, so ACP smoke needs `OPENROUTER_API_KEY`.
+- OpenClaw: native smoke uses `OPENAI_API_KEY`; ACP smoke/setup-flow starts a local Gateway inside the container.
+
+OpenClaw injects a large default context even for trivial prompts. Prefer running it once per integration pass.
+
+## Production Installer Path
+
+Local-source mode tests the current checkout as installed source. Production-path mode validates the public installer and tarball:
+
+```bash
+python3 harness/run.py --mode ci-installer --runtime all --production-path
+```

--- a/harness/prompts/detector-mock.md
+++ b/harness/prompts/detector-mock.md
@@ -1,0 +1,3 @@
+Run the installed Newsjack detector in mock mode with the Blue Bottle fixture profile.
+Save a short Markdown success or failure note at ARTIFACT_DIR/result.md.
+

--- a/harness/prompts/install-smoke.md
+++ b/harness/prompts/install-smoke.md
@@ -1,0 +1,4 @@
+Reply exactly:
+
+READY
+

--- a/harness/prompts/setup-flow.md
+++ b/harness/prompts/setup-flow.md
@@ -1,0 +1,26 @@
+You are testing the installed Newsjack skills.
+
+Create a Newsjack monitor profile for Fixture Coffee, a specialty coffee company.
+Save it exactly at ARTIFACT_DIR/profile.json.
+
+Use this JSON shape:
+
+{
+  "company": "Fixture Coffee",
+  "website": "https://example.com",
+  "description": "...",
+  "topics": ["specialty coffee", "coffee roasting", "coffee shops"],
+  "competitors": ["Blue Bottle Coffee", "Stumptown Coffee Roasters", "Intelligentsia Coffee"],
+  "search_terms": ["specialty coffee", "coffee roasting", "coffee shops"],
+  "feed_urls": ["https://news.google.com/rss/headlines/section/topic/BUSINESS?hl=en-US&gl=US&ceid=US:en"],
+  "x_news": {"enabled": true},
+  "x_trends": {"mode": "none", "woeids": [], "locations": []},
+  "spokespeople": ["Founder", "Coffee sourcing lead"],
+  "proof_assets": ["company website", "product pages"],
+  "standing": ["specialty coffee", "coffee roasting"]
+}
+
+Then run the local newsjack detector in mock mode with that profile.
+Save a short Markdown result at ARTIFACT_DIR/result.md.
+
+Do not ask follow-up questions. Make reasonable assumptions.

--- a/harness/run.py
+++ b/harness/run.py
@@ -1,0 +1,848 @@
+#!/usr/bin/env python3
+"""Container-first Newsjack agent runtime harness."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Sequence
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_IMAGE = "newsjack-agent-harness:local"
+DEFAULT_INSTALLER_URL = "https://newsjack.sh/install.sh"
+RUNTIMES = ("codex", "claude", "hermes", "openclaw")
+EXPECTED_SKILLS = (
+    "newsjack-setup",
+    "newsjack-detector",
+    "media-list-manager",
+)
+MODEL_ENV_KEYS = (
+    "OPENAI_API_KEY",
+    "ANTHROPIC_API_KEY",
+)
+SECRET_MARKERS = (
+    "API_KEY",
+    "TOKEN",
+    "SECRET",
+    "PASSWORD",
+)
+
+
+@dataclass(frozen=True)
+class RuntimeSpec:
+    name: str
+    binary: str
+    version_cmd: tuple[str, ...]
+    skills_dir: str
+    native_smoke_cmd: tuple[str, ...]
+    acp_candidates: tuple[tuple[str, ...], ...]
+
+
+RUNTIME_SPECS = {
+    "codex": RuntimeSpec(
+        name="codex",
+        binary="codex",
+        version_cmd=("codex", "--version"),
+        skills_dir=".agents/skills",
+        native_smoke_cmd=(
+            "codex",
+            "exec",
+            "--skip-git-repo-check",
+            "--ephemeral",
+            "--ignore-rules",
+            "--sandbox",
+            "danger-full-access",
+            "--dangerously-bypass-approvals-and-sandbox",
+            "Reply exactly READY and stop.",
+        ),
+        acp_candidates=(
+            ("codex", "--acp", "--stdio"),
+            ("codex-acp",),
+            ("acpx", "codex"),
+        ),
+    ),
+    "claude": RuntimeSpec(
+        name="claude",
+        binary="claude",
+        version_cmd=("claude", "--version"),
+        skills_dir=".claude/skills",
+        native_smoke_cmd=(
+            "claude",
+            "--bare",
+            "--max-budget-usd",
+            "0.05",
+            "-p",
+            "Reply exactly READY and stop.",
+        ),
+        acp_candidates=(
+            ("claude", "--acp", "--stdio"),
+            ("claude-agent-acp",),
+            ("acpx", "claude"),
+        ),
+    ),
+    "hermes": RuntimeSpec(
+        name="hermes",
+        binary="hermes",
+        version_cmd=("hermes", "--version"),
+        skills_dir=".hermes/skills",
+        native_smoke_cmd=(
+            "hermes",
+            "chat",
+            "-Q",
+            "--ignore-rules",
+            "--provider",
+            "anthropic",
+            "--max-turns",
+            "1",
+            "-q",
+            "Reply exactly READY and stop.",
+        ),
+        acp_candidates=(
+            ("hermes", "--acp", "--stdio"),
+            ("hermes", "acp", "--accept-hooks"),
+        ),
+    ),
+    "openclaw": RuntimeSpec(
+        name="openclaw",
+        binary="openclaw",
+        version_cmd=("openclaw", "--version"),
+        skills_dir=".openclaw/skills",
+        native_smoke_cmd=(
+            "openclaw",
+            "agent",
+            "--local",
+            "--agent",
+            "main",
+            "--message",
+            "Reply exactly READY and stop.",
+            "--json",
+        ),
+        acp_candidates=(
+            ("openclaw", "--acp", "--stdio"),
+            ("openclaw", "acp"),
+        ),
+    ),
+}
+
+
+class HarnessError(RuntimeError):
+    pass
+
+
+def log(message: str) -> None:
+    print(f"harness: {message}", flush=True)
+
+
+def redact(value: str) -> str:
+    redacted = value
+    for key, secret in os.environ.items():
+        if not secret:
+            continue
+        if any(marker in key.upper() for marker in SECRET_MARKERS):
+            redacted = redacted.replace(secret, "<redacted>")
+    return redacted
+
+
+def command_text(cmd: Sequence[str]) -> str:
+    return " ".join(sh_quote(part) for part in cmd)
+
+
+def sh_quote(value: str) -> str:
+    if not value:
+        return "''"
+    safe = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_+-=.,/:@%"
+    if all(ch in safe for ch in value):
+        return value
+    return "'" + value.replace("'", "'\"'\"'") + "'"
+
+
+def run_cmd(
+    cmd: Sequence[str],
+    *,
+    cwd: Path | None = None,
+    env: dict[str, str] | None = None,
+    timeout: int = 120,
+    log_path: Path | None = None,
+    display: str | None = None,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    rendered = display or command_text(cmd)
+    rendered = redact(rendered)
+    if log_path:
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        with log_path.open("a", encoding="utf-8") as handle:
+            handle.write(f"\n$ {rendered}\n")
+    log(rendered)
+    result = subprocess.run(
+        list(cmd),
+        cwd=str(cwd) if cwd else None,
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=timeout,
+    )
+    output = ""
+    if result.stdout:
+        output += result.stdout
+    if result.stderr:
+        output += result.stderr
+    output = redact(output)
+    if log_path:
+        with log_path.open("a", encoding="utf-8") as handle:
+            if output:
+                handle.write(output)
+                if not output.endswith("\n"):
+                    handle.write("\n")
+            handle.write(f"[exit {result.returncode}]\n")
+    if check and result.returncode != 0:
+        raise HarnessError(f"command failed ({result.returncode}): {rendered}\n{output[-4000:]}")
+    return result
+
+
+def run_shell(
+    script: str,
+    *,
+    cwd: Path | None = None,
+    env: dict[str, str] | None = None,
+    timeout: int = 120,
+    log_path: Path | None = None,
+    display: str | None = None,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    return run_cmd(
+        ("bash", "-lc", script),
+        cwd=cwd,
+        env=env,
+        timeout=timeout,
+        log_path=log_path,
+        display=display or script,
+        check=check,
+    )
+
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--runtime", choices=(*RUNTIMES, "all"), default="all")
+    parser.add_argument(
+        "--mode",
+        choices=("ci-installer", "native-smoke", "acp-smoke", "setup-flow"),
+        default="ci-installer",
+    )
+    source = parser.add_mutually_exclusive_group()
+    source.add_argument("--local-source", dest="local_source", action="store_true", default=True)
+    source.add_argument("--production-path", dest="local_source", action="store_false")
+    parser.add_argument("--installer-url", default=DEFAULT_INSTALLER_URL)
+    parser.add_argument("--image", default=DEFAULT_IMAGE)
+    parser.add_argument("--env-file", default=None)
+    parser.add_argument("--build-image", action="store_true")
+    parser.add_argument("--container-runtime", choices=("auto", "docker", "podman"), default="auto")
+    parser.add_argument("--inside-container", action="store_true")
+    parser.add_argument("--repo", default=str(ROOT))
+    parser.add_argument("--runs", default=str(ROOT / "harness" / "runs"))
+    parser.add_argument("--run-id", default=None)
+    parser.add_argument("--timeout", type=int, default=600)
+    return parser.parse_args(argv)
+
+
+def selected_runtimes(runtime: str) -> list[str]:
+    return list(RUNTIMES) if runtime == "all" else [runtime]
+
+
+def find_container_tool(preference: str) -> str:
+    candidates = ("docker", "podman") if preference == "auto" else (preference,)
+    for candidate in candidates:
+        path = shutil.which(candidate)
+        if path:
+            return candidate
+        if candidate == "docker":
+            orbstack_docker = Path("/Applications/OrbStack.app/Contents/MacOS/xbin/docker")
+            if orbstack_docker.exists():
+                return str(orbstack_docker)
+    raise HarnessError("no container runtime found on PATH; install Docker or Podman to run fresh-container tests")
+
+
+def build_image(tool: str, image: str) -> None:
+    run_cmd((tool, "build", "-f", "harness/Dockerfile", "-t", image, "."), cwd=ROOT, timeout=1800)
+
+
+def host_main(args: argparse.Namespace) -> int:
+    tool = find_container_tool(args.container_runtime)
+    if args.build_image:
+        build_image(tool, args.image)
+
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    repo = Path(args.repo).resolve()
+    runs = Path(args.runs).resolve()
+    runs.mkdir(parents=True, exist_ok=True)
+
+    if args.mode == "ci-installer" and args.env_file:
+        raise HarnessError("ci-installer must not receive --env-file; it is the no-token lane")
+
+    failures: list[str] = []
+    for runtime in selected_runtimes(args.runtime):
+        name = f"newsjack-harness-{runtime}-{run_id.lower()}"
+        container_cmd = [
+            tool,
+            "run",
+            "--rm",
+            "--name",
+            name,
+            "-v",
+            f"{repo}:/repo:ro",
+            "-v",
+            f"{runs}:/runs",
+        ]
+        env_file_in_repo = None
+        if args.env_file:
+            env_file = Path(args.env_file).resolve()
+            try:
+                rel_env_file = env_file.relative_to(repo)
+            except ValueError:
+                container_cmd.extend(("--env-file", str(env_file)))
+            else:
+                env_file_in_repo = "/repo/" + str(rel_env_file)
+                container_cmd.extend(("-e", f"NEWSJACK_HARNESS_ENV_FILE={env_file_in_repo}"))
+        inner_cmd = [
+            "python3",
+            "/repo/harness/run.py",
+            "--inside-container",
+            "--runtime",
+            runtime,
+            "--mode",
+            args.mode,
+            "--repo",
+            "/repo",
+            "--runs",
+            "/runs",
+            "--timeout",
+            str(args.timeout),
+            "--installer-url",
+            args.installer_url,
+            "--local-source" if args.local_source else "--production-path",
+        ]
+        container_cmd.extend(("-e", f"NEWSJACK_HARNESS_RUN_ID={run_id}", args.image))
+        if env_file_in_repo:
+            container_cmd.extend(
+                (
+                    "sh",
+                    "-lc",
+                    f"set -a; . {sh_quote(env_file_in_repo)}; set +a; exec {command_text(inner_cmd)}",
+                )
+            )
+        else:
+            container_cmd.extend(inner_cmd)
+        try:
+            run_cmd(container_cmd, cwd=repo, timeout=args.timeout + 300)
+        except (HarnessError, subprocess.TimeoutExpired) as exc:
+            failures.append(f"{runtime}: {exc}")
+
+    if failures:
+        for failure in failures:
+            print(failure, file=sys.stderr)
+        return 1
+    log(f"all requested runtimes passed; run id: {run_id}")
+    return 0
+
+
+def base_container_env(runtime: str, run_dir: Path, repo: Path) -> dict[str, str]:
+    env = os.environ.copy()
+    run_id = run_dir.parent.name.replace("/", "_")
+    home = Path("/home/newsjack-harness") / f"{run_id}-{runtime}"
+    env.update(
+        {
+            "HOME": str(home),
+            "XDG_CONFIG_HOME": str(home / ".config"),
+            "XDG_CACHE_HOME": str(home / ".cache"),
+            "XDG_DATA_HOME": str(home / ".local" / "share"),
+            "PATH": f"{home}/.newsjack/bin:{env.get('PATH', '')}",
+            "NEWSJACK_RUNTIMES": runtime,
+            "NEWSJACK_STORE": str(run_dir / "newsjack.db"),
+            "NEWSJACK_INSTALL_MCP": "1",
+        }
+    )
+    if repo.exists():
+        env.setdefault("NEWSJACK_SOURCE_DIR", str(repo))
+    return env
+
+
+def assert_no_model_keys(mode: str) -> None:
+    present = [key for key in MODEL_ENV_KEYS if os.environ.get(key)]
+    if mode == "ci-installer" and present:
+        raise HarnessError(
+            "ci-installer is the no-token lane and refuses model-provider env vars: "
+            + ", ".join(present)
+        )
+
+
+def assert_model_allowed(mode: str) -> None:
+    if mode == "ci-installer":
+        return
+    if os.environ.get("NEWSJACK_HARNESS_ALLOW_MODEL_CALLS") != "1":
+        raise HarnessError(
+            f"{mode} can call paid model APIs; set NEWSJACK_HARNESS_ALLOW_MODEL_CALLS=1 to run it"
+        )
+
+
+def write_env_json(runtime: str, mode: str, run_dir: Path, env: dict[str, str]) -> None:
+    keys = [
+        "HOME",
+        "NEWSJACK_RUNTIMES",
+        "NEWSJACK_SOURCE_DIR",
+        "NEWSJACK_INSTALL_MCP",
+        "NEWSJACK_STORE",
+        "MEDIALYST_API_BASE",
+        "MEDIALYST_NEWS_PATH",
+        "NEWSJACK_HARNESS_ALLOW_MODEL_CALLS",
+    ]
+    payload = {
+        "runtime": runtime,
+        "mode": mode,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "env": {key: env.get(key) for key in keys if env.get(key) is not None},
+        "secrets_present": {
+            key: bool(env.get(key))
+            for key in ("OPENAI_API_KEY", "ANTHROPIC_API_KEY", "MEDIALYST_API_KEY", "X_BEARER_TOKEN", "TWITTER_BEARER_TOKEN")
+        },
+    }
+    (run_dir / "env.json").write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def install_newsjack(args: argparse.Namespace, runtime: str, repo: Path, env: dict[str, str], log_path: Path) -> None:
+    env = env.copy()
+    if args.local_source:
+        env["NEWSJACK_SOURCE_DIR"] = str(repo)
+        run_cmd(("sh", str(repo / "install.sh")), env=env, timeout=300, log_path=log_path, display="sh /repo/install.sh")
+    else:
+        env.pop("NEWSJACK_SOURCE_DIR", None)
+        run_shell(
+            f"curl -fsSL {sh_quote(args.installer_url)} | sh",
+            env=env,
+            timeout=300,
+            log_path=log_path,
+        )
+
+
+def assert_path(path: Path, description: str) -> None:
+    if not path.exists():
+        raise HarnessError(f"missing {description}: {path}")
+
+
+def assert_executable(path: Path, description: str) -> None:
+    assert_path(path, description)
+    if not os.access(path, os.X_OK):
+        raise HarnessError(f"{description} is not executable: {path}")
+
+
+def assert_installed(runtime: str, run_dir: Path, env: dict[str, str]) -> None:
+    home = Path(env["HOME"])
+    spec = RUNTIME_SPECS[runtime]
+    assert_path(home / ".newsjack" / "newsjack", "installed Newsjack repo")
+    assert_executable(home / ".newsjack" / "bin" / "newsjack", "Newsjack CLI")
+    skills_root = home / spec.skills_dir
+    assert_path(skills_root, f"{runtime} skills directory")
+    for skill in EXPECTED_SKILLS:
+        assert_path(skills_root / skill / "SKILL.md", f"{runtime} skill {skill}")
+
+    result = run_cmd(
+        (str(home / ".newsjack" / "bin" / "newsjack"), "skills"),
+        env=env,
+        timeout=60,
+        log_path=run_dir / "assertions.log",
+    )
+    listed = set(result.stdout.split())
+    missing = [skill for skill in EXPECTED_SKILLS if skill not in listed]
+    if missing:
+        raise HarnessError(f"newsjack skills missing expected entries: {', '.join(missing)}")
+
+    if runtime == "hermes":
+        hermes_config = home / ".hermes" / "config.yaml"
+        assert_path(hermes_config, "Hermes config")
+        text = hermes_config.read_text(encoding="utf-8")
+        if "mcp_servers:" not in text or "medialyst:" not in text:
+            raise HarnessError("Hermes MCP config does not contain mcp_servers.medialyst")
+
+
+def collect_versions(runtime: str, run_dir: Path, env: dict[str, str]) -> None:
+    spec = RUNTIME_SPECS[runtime]
+    payload: dict[str, dict[str, object]] = {}
+    version_commands = [
+        spec.version_cmd,
+        ("node", "--version"),
+        ("npm", "--version"),
+        ("python3", "--version"),
+    ]
+    for cmd in version_commands:
+        result = run_cmd(cmd, env=env, timeout=45, log_path=run_dir / "versions.log", check=False)
+        payload[" ".join(cmd)] = {
+            "returncode": result.returncode,
+            "stdout": redact(result.stdout).strip(),
+            "stderr": redact(result.stderr).strip(),
+        }
+    (run_dir / "versions.json").write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def run_direct_detector(repo: Path, run_dir: Path, env: dict[str, str]) -> None:
+    home = Path(env["HOME"])
+    output = run_dir / "artifacts" / "detector-mock.json"
+    output.parent.mkdir(parents=True, exist_ok=True)
+    result = run_cmd(
+        (
+            str(home / ".newsjack" / "bin" / "newsjack"),
+            "detector",
+            "run",
+            "specialty coffee",
+            "--profile",
+            str(repo / "fixtures" / "newsjack-detector-agent" / "profile.bluebottle.json"),
+            "--mock",
+            "--emit",
+            "json",
+        ),
+        cwd=repo,
+        env=env,
+        timeout=180,
+        log_path=run_dir / "detector.log",
+    )
+    output.write_text(result.stdout, encoding="utf-8")
+    try:
+        parsed = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise HarnessError(f"detector mock did not emit valid JSON: {exc}") from exc
+    if not isinstance(parsed, dict):
+        raise HarnessError("detector mock JSON was not an object")
+
+
+def maybe_medialyst_login(run_dir: Path, env: dict[str, str]) -> None:
+    api_key = env.get("MEDIALYST_API_KEY")
+    if not api_key:
+        return
+    home = Path(env["HOME"])
+    run_cmd(
+        (str(home / ".newsjack" / "bin" / "newsjack"), "login", "--key", api_key),
+        env=env,
+        timeout=60,
+        log_path=run_dir / "medialyst-auth.log",
+        display="~/.newsjack/bin/newsjack login --key <redacted>",
+    )
+    run_cmd(
+        (str(home / ".newsjack" / "bin" / "newsjack"), "auth", "status"),
+        env=env,
+        timeout=60,
+        log_path=run_dir / "medialyst-auth.log",
+    )
+
+
+def maybe_runtime_login(runtime: str, run_dir: Path, env: dict[str, str]) -> None:
+    if runtime != "codex":
+        return
+    api_key = env.get("OPENAI_API_KEY")
+    if not api_key:
+        raise HarnessError("codex integration modes require OPENAI_API_KEY")
+    run_shell(
+        "printf %s \"$OPENAI_API_KEY\" | codex login --with-api-key",
+        env=env,
+        timeout=60,
+        log_path=run_dir / "runtime-auth.log",
+        display="printf <redacted> | codex login --with-api-key",
+    )
+    run_cmd(
+        ("codex", "login", "status"),
+        env=env,
+        timeout=60,
+        log_path=run_dir / "runtime-auth.log",
+        check=False,
+    )
+
+
+def run_native_smoke(runtime: str, run_dir: Path, env: dict[str, str]) -> None:
+    spec = RUNTIME_SPECS[runtime]
+    result = run_cmd(
+        spec.native_smoke_cmd,
+        env=env,
+        cwd=run_dir / "artifacts",
+        timeout=240,
+        log_path=run_dir / "native-smoke.log",
+        check=True,
+    )
+    (run_dir / "final-response.md").write_text(result.stdout or result.stderr, encoding="utf-8")
+
+
+def run_acp_probe(runtime: str, run_dir: Path, env: dict[str, str]) -> tuple[str, int]:
+    prompt = "Reply exactly READY and stop."
+    result = run_acp_prompt(
+        runtime,
+        prompt,
+        run_dir,
+        env,
+        timeout=240,
+        max_turns=1,
+        log_name="acp-smoke.log",
+    )
+    (run_dir / "final-response.md").write_text(result.stdout or result.stderr, encoding="utf-8")
+    return "acpx", result.returncode
+
+
+def acpx_command(runtime: str, prompt: str, cwd: Path, timeout: int, max_turns: int) -> tuple[str, ...]:
+    base = (
+        "acpx",
+        "--cwd",
+        str(cwd),
+        "--auth-policy",
+        "fail",
+        "--approve-all",
+        "--non-interactive-permissions",
+        "fail",
+        "--timeout",
+        str(timeout),
+        "--max-turns",
+        str(max_turns),
+        "--format",
+        "text",
+    )
+    if runtime == "codex":
+        return (*base, "--agent", "codex-acp", "exec", prompt)
+    if runtime in ("claude", "openclaw"):
+        return (*base, runtime, "exec", prompt)
+    if runtime == "hermes":
+        return (*base, "--agent", "hermes acp --accept-hooks", "exec", prompt)
+    raise HarnessError(f"unsupported ACP runtime: {runtime}")
+
+
+def run_acp_prompt(
+    runtime: str,
+    prompt: str,
+    run_dir: Path,
+    env: dict[str, str],
+    *,
+    timeout: int,
+    max_turns: int,
+    log_name: str,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    if not shutil.which("acpx", path=env.get("PATH")):
+        raise HarnessError("acpx is not installed in the harness container")
+    env = env.copy()
+    if runtime == "codex" and env.get("OPENAI_API_KEY"):
+        env["ACPX_AUTH_OPENAI_API_KEY"] = env["OPENAI_API_KEY"]
+    elif runtime == "claude" and env.get("ANTHROPIC_API_KEY"):
+        env["ACPX_AUTH_API_KEY"] = env["ANTHROPIC_API_KEY"]
+        env["ACPX_AUTH_ANTHROPIC_API_KEY"] = env["ANTHROPIC_API_KEY"]
+    elif runtime == "hermes":
+        openrouter_key = env.get("OPENROUTER_API_KEY") or env.get("ACPX_AUTH_OPENROUTER")
+        if not openrouter_key:
+            raise HarnessError(
+                "Hermes ACP requires OPENROUTER_API_KEY or ACPX_AUTH_OPENROUTER; "
+                "use native-smoke with ANTHROPIC_API_KEY for the current Hermes path"
+            )
+        env["ACPX_AUTH_OPENROUTER"] = openrouter_key
+    artifact_dir = run_dir / "artifacts"
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    cmd = acpx_command(runtime, prompt, artifact_dir, timeout, max_turns)
+    (run_dir / "selected-acp.json").write_text(
+        json.dumps({"controller": "acpx", "command": command_text(cmd[: min(len(cmd), 4)])}, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    gateway = None
+    if runtime == "openclaw":
+        gateway = start_openclaw_gateway(run_dir, env)
+    try:
+        return run_cmd(
+            cmd,
+            env=env,
+            cwd=artifact_dir,
+            timeout=timeout + 30,
+            log_path=run_dir / log_name,
+            check=check,
+        )
+    finally:
+        if gateway:
+            gateway.terminate()
+            try:
+                gateway.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                gateway.kill()
+                gateway.wait(timeout=10)
+
+
+def start_openclaw_gateway(run_dir: Path, env: dict[str, str]) -> subprocess.Popen[str]:
+    log_path = run_dir / "openclaw-gateway.log"
+    handle = log_path.open("a", encoding="utf-8")
+    cmd = (
+        "openclaw",
+        "gateway",
+        "run",
+        "--dev",
+        "--auth",
+        "none",
+        "--bind",
+        "loopback",
+        "--port",
+        "18789",
+        "--allow-unconfigured",
+        "--compact",
+    )
+    handle.write(f"\n$ {command_text(cmd)}\n")
+    handle.flush()
+    process = subprocess.Popen(
+        cmd,
+        env=env,
+        text=True,
+        stdout=handle,
+        stderr=subprocess.STDOUT,
+    )
+    handle.close()
+    for _ in range(45):
+        if process.poll() is not None:
+            raise HarnessError(f"OpenClaw gateway exited before becoming ready; see {log_path}")
+        try:
+            gateway_log = log_path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            gateway_log = ""
+        if "[gateway] ready" in gateway_log:
+            return process
+        time_sleep(1)
+    process.terminate()
+    try:
+        process.wait(timeout=10)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.wait(timeout=10)
+    handle.close()
+    raise HarnessError(f"OpenClaw gateway did not become ready; see {log_path}")
+
+
+def time_sleep(seconds: float) -> None:
+    import time
+
+    time.sleep(seconds)
+
+
+def run_setup_flow(runtime: str, repo: Path, run_dir: Path, env: dict[str, str]) -> None:
+    prompt = (repo / "harness" / "prompts" / "setup-flow.md").read_text(encoding="utf-8")
+    artifact_dir = run_dir / "artifacts"
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    prompt = prompt.replace("ARTIFACT_DIR", str(artifact_dir))
+
+    if runtime == "hermes" and not (env.get("OPENROUTER_API_KEY") or env.get("ACPX_AUTH_OPENROUTER")):
+        result = run_cmd(
+            (
+                "hermes",
+                "chat",
+                "-Q",
+                "--ignore-rules",
+                "--provider",
+                "anthropic",
+                "--max-turns",
+                "12",
+                "--yolo",
+                "-q",
+                prompt,
+            ),
+            env=env,
+            cwd=artifact_dir,
+            timeout=900,
+            log_path=run_dir / "setup-flow.log",
+            check=False,
+        )
+    else:
+        result = run_acp_prompt(
+            runtime,
+            prompt,
+            run_dir,
+            env,
+            timeout=900,
+            max_turns=15,
+            log_name="setup-flow.log",
+            check=False,
+        )
+    (run_dir / "final-response.md").write_text(result.stdout or result.stderr, encoding="utf-8")
+
+    profile = artifact_dir / "profile.json"
+    result_md = artifact_dir / "result.md"
+    assert_path(profile, "setup-flow profile.json")
+    assert_path(result_md, "setup-flow result.md")
+    try:
+        profile_data = json.loads(profile.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise HarnessError(f"profile.json is invalid JSON: {exc}") from exc
+    if not (profile_data.get("company") or profile_data.get("name")):
+        raise HarnessError("profile.json missing required field: company")
+    if not profile_data.get("description"):
+        raise HarnessError("profile.json missing required field: description")
+    if result.returncode != 0:
+        (run_dir / "setup-flow.warning.txt").write_text(
+            "ACP controller exited nonzero after artifacts were produced and validated. "
+            f"Exit code: {result.returncode}\n",
+            encoding="utf-8",
+        )
+
+
+def inside_container_main(args: argparse.Namespace) -> int:
+    if args.runtime == "all":
+        raise HarnessError("--inside-container requires one concrete --runtime")
+    runtime = args.runtime
+    spec = RUNTIME_SPECS[runtime]
+    assert_no_model_keys(args.mode)
+    assert_model_allowed(args.mode)
+
+    repo = Path(args.repo)
+    run_id = args.run_id or os.environ.get("NEWSJACK_HARNESS_RUN_ID") or datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    run_dir = Path(args.runs) / run_id / runtime
+    run_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / "artifacts").mkdir(parents=True, exist_ok=True)
+
+    env = base_container_env(runtime, run_dir, repo)
+    home = Path(env["HOME"])
+    if str(home).startswith("/home/newsjack-harness/") and home.exists():
+        shutil.rmtree(home)
+    if not args.local_source:
+        env.pop("NEWSJACK_SOURCE_DIR", None)
+    write_env_json(runtime, args.mode, run_dir, env)
+
+    if not shutil.which(spec.binary, path=env.get("PATH")):
+        raise HarnessError(f"runtime binary not found in container: {spec.binary}")
+
+    collect_versions(runtime, run_dir, env)
+    install_newsjack(args, runtime, repo, env, run_dir / "installer.log")
+    assert_installed(runtime, run_dir, env)
+    run_direct_detector(repo, run_dir, env)
+
+    if args.mode in ("native-smoke", "acp-smoke", "setup-flow"):
+        maybe_medialyst_login(run_dir, env)
+        maybe_runtime_login(runtime, run_dir, env)
+
+    if args.mode == "native-smoke":
+        run_native_smoke(runtime, run_dir, env)
+    elif args.mode == "acp-smoke":
+        run_acp_probe(runtime, run_dir, env)
+    elif args.mode == "setup-flow":
+        run_setup_flow(runtime, repo, run_dir, env)
+
+    (run_dir / "PASS").write_text("ok\n", encoding="utf-8")
+    log(f"{runtime} {args.mode} passed; artifacts: {run_dir}")
+    return 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    try:
+        if args.inside_container:
+            return inside_container_main(args)
+        return host_main(args)
+    except subprocess.TimeoutExpired as exc:
+        print(f"harness: timeout: {exc}", file=sys.stderr)
+        return 124
+    except HarnessError as exc:
+        print(f"harness: error: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/harness/scripts/install-runtimes.sh
+++ b/harness/scripts/install-runtimes.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+log() {
+  printf '%s\n' "harness-runtimes: $*" >&2
+}
+
+log "installing Node runtime CLIs"
+npm install -g \
+  "@openai/codex@${CODEX_VERSION}" \
+  "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
+  "openclaw@${OPENCLAW_VERSION}" \
+  "acpx@${ACPX_VERSION}" \
+  "@zed-industries/codex-acp@${CODEX_ACP_VERSION}" \
+  "@zed-industries/claude-agent-acp@${CLAUDE_AGENT_ACP_VERSION}"
+
+log "installing Hermes Agent"
+pipx install "hermes-agent[acp]==${HERMES_AGENT_VERSION}"
+
+log "installed versions"
+codex --version || true
+claude --version || true
+openclaw --version || true
+hermes --version || true
+acpx --version || true
+codex-acp --version || true
+claude-agent-acp --version || true
+

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,387 @@
+#!/bin/sh
+set -eu
+
+NEWSJACK_REPO="${NEWSJACK_REPO:-elvisun/newsjack}"
+NEWSJACK_REF="${NEWSJACK_REF:-main}"
+NEWSJACK_HOME="${NEWSJACK_HOME:-$HOME/.newsjack}"
+NEWSJACK_INSTALL_DIR="${NEWSJACK_INSTALL_DIR:-$NEWSJACK_HOME/newsjack}"
+NEWSJACK_RUNTIMES="${NEWSJACK_RUNTIMES:-auto}"
+NEWSJACK_INSTALL_MCP="${NEWSJACK_INSTALL_MCP:-1}"
+NEWSJACK_FORCE="${NEWSJACK_FORCE:-0}"
+
+log() {
+  printf '%s\n' "newsjack: $*" >&2
+}
+
+warn() {
+  printf '%s\n' "newsjack: warning: $*" >&2
+}
+
+die() {
+  printf '%s\n' "newsjack: error: $*" >&2
+  exit 1
+}
+
+have() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+download() {
+  url=$1
+  if have curl; then
+    curl -fsSL "$url"
+  elif have wget; then
+    wget -qO- "$url"
+  else
+    die "curl or wget is required"
+  fi
+}
+
+json_escape() {
+  # JSON string escaping for paths used in MCP command payloads.
+  printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'
+}
+
+yaml_dq_escape() {
+  # YAML double-quoted scalar escaping for simple generated config blocks.
+  printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'
+}
+
+copy_tree() {
+  ct_src=$1
+  ct_dest=$2
+  rm -rf "$ct_dest"
+  mkdir -p "$ct_dest"
+  (cd "$ct_src" && tar -cf - .) | (cd "$ct_dest" && tar -xf -)
+}
+
+fetch_source() {
+  tmp=$1
+
+  if [ "${NEWSJACK_SOURCE_DIR:-}" ]; then
+    src=$NEWSJACK_SOURCE_DIR
+    [ -d "$src/skills" ] || die "NEWSJACK_SOURCE_DIR does not look like the newsjack repo: $src"
+    copy_tree "$src" "$tmp/source"
+    printf '%s\n' "$tmp/source"
+    return
+  fi
+
+  archive="$tmp/newsjack.tar.gz"
+  url="${NEWSJACK_TARBALL_URL:-https://codeload.github.com/$NEWSJACK_REPO/tar.gz/$NEWSJACK_REF}"
+  log "fetching $NEWSJACK_REPO@$NEWSJACK_REF"
+  download "$url" >"$archive"
+  tar -xzf "$archive" -C "$tmp"
+  src=$(find "$tmp" -mindepth 1 -maxdepth 1 -type d ! -name source | head -n 1)
+  [ -n "$src" ] || die "could not unpack newsjack archive"
+  [ -d "$src/skills" ] || die "archive does not contain a skills directory"
+  printf '%s\n' "$src"
+}
+
+install_source() {
+  src=$1
+  mkdir -p "$NEWSJACK_HOME"
+
+  new_dir="$NEWSJACK_INSTALL_DIR.new"
+  old_dir="$NEWSJACK_INSTALL_DIR.previous"
+
+  rm -rf "$new_dir"
+  copy_tree "$src" "$new_dir"
+
+  rm -rf "$old_dir"
+  if [ -d "$NEWSJACK_INSTALL_DIR" ]; then
+    mv "$NEWSJACK_INSTALL_DIR" "$old_dir"
+  fi
+  mv "$new_dir" "$NEWSJACK_INSTALL_DIR"
+  log "installed source to $NEWSJACK_INSTALL_DIR"
+}
+
+install_cli() {
+  src="$NEWSJACK_INSTALL_DIR/bin/newsjack"
+  [ -f "$src" ] || return 0
+
+  mkdir -p "$NEWSJACK_HOME/bin"
+  cp "$src" "$NEWSJACK_HOME/bin/newsjack"
+  chmod 755 "$NEWSJACK_HOME/bin/newsjack"
+  log "installed newsjack shim to $NEWSJACK_HOME/bin/newsjack"
+}
+
+runtime_list() {
+  printf '%s' "$NEWSJACK_RUNTIMES" |
+    tr '[:upper:]' '[:lower:]' |
+    tr '[:space:]' ',' |
+    sed 's/claude-code/claude/g; s/claude_code/claude/g; s/cladue/claude/g; s/,,*/,/g; s/^,//; s/,$//'
+}
+
+detect_runtime() {
+  runtime=$1
+  case "$runtime" in
+    codex)
+      have codex || [ -d "$HOME/.codex" ] || [ -d "$HOME/.agents" ]
+      ;;
+    claude)
+      have claude || [ -d "$HOME/.claude" ]
+      ;;
+    openclaw)
+      have openclaw || [ -d "$HOME/.openclaw" ]
+      ;;
+    hermes)
+      have hermes || [ -d "$HOME/.hermes" ]
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+want_runtime() {
+  runtime=$1
+  selected=$(runtime_list)
+  case ",$selected," in
+    *,none,*)
+      return 1
+      ;;
+    *,all,*)
+      return 0
+      ;;
+    *,auto,*)
+      detect_runtime "$runtime"
+      return $?
+      ;;
+    *,"$runtime",*)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+copy_one_skill() {
+  src=$1
+  target_root=$2
+  name=$(basename "$src")
+  dest="$target_root/$name"
+  marker="$dest/.newsjack-installed"
+
+  if [ -e "$dest" ] && [ ! -f "$marker" ] && [ "$NEWSJACK_FORCE" != "1" ]; then
+    warn "skipping existing non-newsjack skill: $dest (set NEWSJACK_FORCE=1 to overwrite)"
+    return 0
+  fi
+
+  mkdir -p "$target_root"
+  tmp_dest="$dest.tmp"
+  rm -rf "$tmp_dest"
+  copy_tree "$src" "$tmp_dest"
+  {
+    printf 'repo=%s\n' "$NEWSJACK_REPO"
+    printf 'ref=%s\n' "$NEWSJACK_REF"
+    printf 'source=%s\n' "$NEWSJACK_INSTALL_DIR"
+  } >"$tmp_dest/.newsjack-installed"
+  rm -rf "$dest"
+  mv "$tmp_dest" "$dest"
+}
+
+install_doctrine_files() {
+  target_root=$1
+  mkdir -p "$target_root"
+  for file in ETHICS.md WHY-NOT-SPAM.md; do
+    if [ -f "$NEWSJACK_INSTALL_DIR/skills/$file" ]; then
+      file_marker="$target_root/.$file.newsjack-installed"
+      if [ -e "$target_root/$file" ] && [ ! -f "$file_marker" ] && [ "$NEWSJACK_FORCE" != "1" ]; then
+        warn "skipping existing non-newsjack doctrine file: $target_root/$file (set NEWSJACK_FORCE=1 to overwrite)"
+        continue
+      fi
+      cp "$NEWSJACK_INSTALL_DIR/skills/$file" "$target_root/$file"
+      : >"$file_marker"
+    fi
+  done
+}
+
+install_skills_to() {
+  label=$1
+  target_root=$2
+
+  [ -d "$NEWSJACK_INSTALL_DIR/skills" ] || die "missing skills directory in $NEWSJACK_INSTALL_DIR"
+  mkdir -p "$target_root"
+
+  for skill_dir in "$NEWSJACK_INSTALL_DIR"/skills/*; do
+    [ -d "$skill_dir" ] || continue
+    [ -f "$skill_dir/SKILL.md" ] || continue
+    copy_one_skill "$skill_dir" "$target_root"
+  done
+  install_doctrine_files "$target_root"
+  log "installed skills for $label into $target_root"
+}
+
+configure_codex_mcp() {
+  bridge=$1
+  have codex || return 0
+  [ "$NEWSJACK_INSTALL_MCP" = "1" ] || return 0
+
+  if codex mcp add medialyst -- python3 "$bridge" >/dev/null 2>&1 </dev/null; then
+    log "configured Codex MCP server: medialyst"
+  else
+    warn "Codex MCP server 'medialyst' may already exist; leaving existing config in place"
+  fi
+}
+
+configure_claude_mcp() {
+  bridge=$1
+  have claude || return 0
+  [ "$NEWSJACK_INSTALL_MCP" = "1" ] || return 0
+
+  escaped_bridge=$(json_escape "$bridge")
+  json="{\"type\":\"stdio\",\"command\":\"python3\",\"args\":[\"$escaped_bridge\"]}"
+  if claude mcp add-json --scope user medialyst "$json" >/dev/null 2>&1 </dev/null; then
+    log "configured Claude Code MCP server: medialyst"
+  else
+    warn "Claude Code MCP server 'medialyst' may already exist; leaving existing config in place"
+  fi
+}
+
+configure_openclaw_mcp() {
+  bridge=$1
+  have openclaw || return 0
+  [ "$NEWSJACK_INSTALL_MCP" = "1" ] || return 0
+
+  escaped_bridge=$(json_escape "$bridge")
+  json="{\"command\":\"python3\",\"args\":[\"$escaped_bridge\"]}"
+  if openclaw mcp set medialyst "$json" >/dev/null 2>&1 </dev/null; then
+    log "configured OpenClaw MCP server: medialyst"
+  else
+    warn "could not configure OpenClaw MCP automatically"
+  fi
+}
+
+hermes_has_medialyst() {
+  config=$1
+  [ -f "$config" ] || return 1
+  awk '
+    /^[^[:space:]#][^:]*:/ {
+      top=$0
+      sub(/:.*/, "", top)
+    }
+    top == "mcp_servers" && /^[[:space:]]+medialyst:[[:space:]]*$/ {
+      found=1
+    }
+    END { exit found ? 0 : 1 }
+  ' "$config"
+}
+
+configure_hermes_mcp() {
+  bridge=$1
+  [ "$NEWSJACK_INSTALL_MCP" = "1" ] || return 0
+
+  config="${HERMES_CONFIG:-$HOME/.hermes/config.yaml}"
+  if hermes_has_medialyst "$config"; then
+    log "Hermes MCP server already configured: medialyst"
+    return 0
+  fi
+
+  mkdir -p "$(dirname "$config")"
+  [ -f "$config" ] || : >"$config"
+
+  escaped_bridge=$(yaml_dq_escape "$bridge")
+
+  if grep -q '^mcp_servers:' "$config" && ! grep -q '^mcp_servers:[[:space:]]*\(#.*\)\?$' "$config"; then
+    warn "Hermes config has an inline mcp_servers key; add medialyst manually in $config"
+    return 0
+  fi
+
+  tmp_config="$config.newsjack-tmp"
+  awk -v bridge="$escaped_bridge" '
+    function print_block() {
+      print "  medialyst:"
+      print "    command: \"python3\""
+      print "    args:"
+      print "      - \"" bridge "\""
+    }
+    !inserted && /^mcp_servers:[[:space:]]*(#.*)?$/ {
+      print
+      print_block()
+      inserted=1
+      next
+    }
+    { print }
+    END {
+      if (!inserted) {
+        print ""
+        print "mcp_servers:"
+        print_block()
+      }
+    }
+  ' "$config" >"$tmp_config"
+  mv "$tmp_config" "$config"
+  log "configured Hermes MCP server: medialyst"
+}
+
+configure_mcp() {
+  bridge="$NEWSJACK_INSTALL_DIR/skills/media-list-manager/scripts/medialyst_mcp_bridge.py"
+  [ -f "$bridge" ] || return 0
+
+  want_runtime codex && configure_codex_mcp "$bridge"
+  want_runtime claude && configure_claude_mcp "$bridge"
+  want_runtime openclaw && configure_openclaw_mcp "$bridge"
+  want_runtime hermes && configure_hermes_mcp "$bridge"
+  return 0
+}
+
+install_runtime_skills() {
+  installed_any=0
+
+  if want_runtime codex; then
+    install_skills_to "Codex" "${NEWSJACK_CODEX_SKILLS_DIR:-$HOME/.agents/skills}"
+    installed_any=1
+  fi
+
+  if want_runtime claude; then
+    install_skills_to "Claude Code" "${NEWSJACK_CLAUDE_SKILLS_DIR:-$HOME/.claude/skills}"
+    installed_any=1
+  fi
+
+  if want_runtime openclaw; then
+    install_skills_to "OpenClaw" "${NEWSJACK_OPENCLAW_SKILLS_DIR:-$HOME/.openclaw/skills}"
+    installed_any=1
+  fi
+
+  if want_runtime hermes; then
+    install_skills_to "Hermes" "${NEWSJACK_HERMES_SKILLS_DIR:-$HOME/.hermes/skills}"
+    installed_any=1
+  fi
+
+  if [ "$installed_any" = "0" ]; then
+    warn "no supported runtime detected; installing portable skills into $HOME/.agents/skills"
+    install_skills_to "portable Agent Skills" "$HOME/.agents/skills"
+  fi
+}
+
+print_next_steps() {
+  cat <<EOF
+
+newsjack installed.
+
+Installed repo: $NEWSJACK_INSTALL_DIR
+CLI shim:       $NEWSJACK_HOME/bin/newsjack
+
+Next:
+  newsjack skills
+  newsjack login   # optional Medialyst API key for MCP-backed media lists
+
+If 'newsjack' is not on PATH, add this to your shell profile:
+  export PATH="\$HOME/.newsjack/bin:\$PATH"
+EOF
+}
+
+main() {
+  tmp=$(mktemp -d "${TMPDIR:-/tmp}/newsjack.XXXXXX")
+  trap 'rm -rf "$tmp"' EXIT HUP INT TERM
+
+  src=$(fetch_source "$tmp")
+  install_source "$src"
+  install_cli
+  install_runtime_skills
+  configure_mcp
+  print_next_steps
+}
+
+main "$@"

--- a/skills/media-list-manager/README.md
+++ b/skills/media-list-manager/README.md
@@ -13,7 +13,7 @@ Load `SKILL.md` as a skill or project file, then provide the campaign angle, tar
 If your runtime supports project MCP config, the repo root `.mcp.json` points to the Medialyst MCP server. For Claude Code, run the local login helper once:
 
 ```bash
-python3 skills/media-list-manager/scripts/medialyst_auth.py login
+newsjack login
 claude --strict-mcp-config --mcp-config .mcp.json
 ```
 
@@ -24,8 +24,8 @@ The helper stores the API key under `~/.newsjack/credentials.json` and the `.mcp
 Codex does not use Claude Code's `headersHelper`. Use the stdio bridge:
 
 ```bash
-python3 skills/media-list-manager/scripts/medialyst_auth.py login
-codex mcp add medialyst -- python3 "$PWD/skills/media-list-manager/scripts/medialyst_mcp_bridge.py"
+newsjack login
+codex mcp add medialyst -- ~/.newsjack/bin/newsjack mcp-bridge
 ```
 
 ### OpenClaw
@@ -33,8 +33,8 @@ codex mcp add medialyst -- python3 "$PWD/skills/media-list-manager/scripts/media
 OpenClaw supports configured MCP stdio servers. Use the same bridge:
 
 ```bash
-python3 skills/media-list-manager/scripts/medialyst_auth.py login
-openclaw mcp set medialyst "{\"command\":\"python3\",\"args\":[\"$PWD/skills/media-list-manager/scripts/medialyst_mcp_bridge.py\"]}"
+newsjack login
+openclaw mcp set medialyst "{\"command\":\"$HOME/.newsjack/bin/newsjack\",\"args\":[\"mcp-bridge\"]}"
 ```
 
 The bridge requires Node.js because it launches `npx -y mcp-remote`.

--- a/skills/media-list-manager/SKILL.md
+++ b/skills/media-list-manager/SKILL.md
@@ -75,7 +75,7 @@ If MCP tools are missing or return auth errors, say exactly what failed and cont
 For Claude Code auth, tell users to run:
 
 ```bash
-python3 skills/media-list-manager/scripts/medialyst_auth.py login
+~/.newsjack/bin/newsjack login
 ```
 
 The project `.mcp.json` uses `headersHelper` to read that saved credential automatically.
@@ -83,7 +83,7 @@ The project `.mcp.json` uses `headersHelper` to read that saved credential autom
 For Codex, OpenClaw, or another client without `headersHelper`, use the stdio bridge after login:
 
 ```bash
-python3 skills/media-list-manager/scripts/medialyst_mcp_bridge.py
+~/.newsjack/bin/newsjack mcp-bridge
 ```
 
 Configure that script as the MCP server command. It launches `mcp-remote` and injects the saved credential without requiring the user to export an environment variable.

--- a/skills/media-list-manager/scripts/medialyst_auth.py
+++ b/skills/media-list-manager/scripts/medialyst_auth.py
@@ -118,7 +118,7 @@ def cmd_headers(_: argparse.Namespace) -> int:
     api_key, source = load_api_key()
     if not api_key:
         print(
-            "Medialyst API key not found. Run: python3 skills/media-list-manager/scripts/medialyst_auth.py login",
+            "Medialyst API key not found. Run: ~/.newsjack/bin/newsjack login",
             file=sys.stderr,
         )
         return 1

--- a/skills/media-list-manager/scripts/medialyst_mcp_bridge.py
+++ b/skills/media-list-manager/scripts/medialyst_mcp_bridge.py
@@ -22,7 +22,7 @@ def main() -> int:
     api_key, source = load_api_key()
     if not api_key:
         print(
-            "Medialyst API key not found. Run: python3 skills/media-list-manager/scripts/medialyst_auth.py login",
+            "Medialyst API key not found. Run: ~/.newsjack/bin/newsjack login",
             file=sys.stderr,
         )
         return 1

--- a/skills/newsjack-detector/SKILL.md
+++ b/skills/newsjack-detector/SKILL.md
@@ -19,7 +19,7 @@ Before using this skill, check whether `skills/ETHICS.md` and `skills/WHY-NOT-SP
 Use the local engine when the user asks to monitor, discover, or scan current hooks:
 
 ```bash
-python3 skills/newsjack-detector/scripts/newsjack_detector.py run "QUERY" --profile profile.json --save
+~/.newsjack/bin/newsjack detector run "QUERY" --profile profile.json --save
 ```
 
 Defaults:
@@ -73,7 +73,7 @@ X source tuning environment variables:
 Hourly OSS workflow:
 
 ```bash
-python3 skills/newsjack-detector/scripts/newsjack_detector.py run --profile profile.json --feed-only --save --new-only --max-age-hours 24 --emit json
+~/.newsjack/bin/newsjack detector run --profile profile.json --feed-only --save --new-only --max-age-hours 24 --emit json
 ```
 
 This is a compromise for local/agent runtimes that can only run hourly. The RSS lane is meant to catch major stories first, then test client relevance. `--new-only` uses the local monitor store to avoid re-alerting the same feed URLs every hour; `--max-age-hours` keeps the first run from dumping a full historical backlog. It is not a promise to win the first 15 minutes of a breaking story.
@@ -95,7 +95,7 @@ Pipeline:
 1. Run the detector and save candidates:
 
 ```bash
-python3 skills/newsjack-detector/scripts/newsjack_detector.py run "QUERY" --profile profile.json --sources news_search,x --lookback-days 1 --depth quick --limit 80 --min-queue-priority 40 --min-major-news 0.55 --emit json > candidates.json
+~/.newsjack/bin/newsjack detector run "QUERY" --profile profile.json --sources news_search,x --lookback-days 1 --depth quick --limit 80 --min-queue-priority 40 --min-major-news 0.55 --emit json > candidates.json
 ```
 
 For fixture debugging, prefer the observable helper in `fixtures/newsjack-detector-agent/scripts/observe-run.sh`. It writes `candidates.json`, `detector.stderr.log`, `commands.log`, `summary.json`, and `run.md` into one timestamped run folder and passes `--include-all-scored` by default. `run.md` is the beta-facing Markdown brief; JSON/log files are supporting evidence.
@@ -105,7 +105,7 @@ For fixture debugging, prefer the observable helper in `fixtures/newsjack-detect
 3. Apply decisions:
 
 ```bash
-python3 skills/newsjack-detector/scripts/newsjack_filter_apply.py --candidates candidates.json --decisions filter_decisions.json --include keep --include monitor_only --output targeted_candidates.json
+~/.newsjack/bin/newsjack filter-apply --candidates candidates.json --decisions filter_decisions.json --include keep --include monitor_only --output targeted_candidates.json
 ```
 
 4. Run the expensive rubric pass only on `targeted_candidates.json` and write the result as Markdown to `final_report.md`.
@@ -113,7 +113,7 @@ python3 skills/newsjack-detector/scripts/newsjack_filter_apply.py --candidates c
 5. Rerender the observable Markdown run report:
 
 ```bash
-python3 fixtures/newsjack-detector-agent/scripts/summarize-run.py candidates.json --output summary.json --markdown run.md
+~/.newsjack/bin/newsjack summarize-run candidates.json --output summary.json --markdown run.md
 ```
 
 When working inside the fixture timestamped run folder, pass the full paths for `candidates.json`, `summary.json`, and `run.md`. The final user-facing artifact is `run.md`, which renders structured `final_report.md` into readable recommendations when it exists and keeps detector/cheap-filter provenance in a compact appendix.

--- a/skills/newsjack-setup/SKILL.md
+++ b/skills/newsjack-setup/SKILL.md
@@ -132,8 +132,8 @@ Return a concise setup result:
   "x_news_rationale": "Enabled by default because X News returns story clusters rather than random individual posts.",
   "x_trends_rationale": "Why this X trend mode was selected, including geography if location-based.",
   "run_commands": {
-    "hourly_major_news": "python3 skills/newsjack-detector/scripts/newsjack_detector.py run --profile profile.json --feed-only --save --new-only --max-age-hours 48 --emit json",
-    "profile_relevance": "python3 skills/newsjack-detector/scripts/newsjack_detector.py run \"TOPIC\" --profile profile.json --save --emit json"
+    "hourly_major_news": "~/.newsjack/bin/newsjack detector run --profile profile.json --feed-only --save --new-only --max-age-hours 48 --emit json",
+    "profile_relevance": "~/.newsjack/bin/newsjack detector run \"TOPIC\" --profile profile.json --save --emit json"
   },
   "missing_inputs": [
     "Question or missing proof that would materially improve the profile"

--- a/skills/newsjack-setup/examples.md
+++ b/skills/newsjack-setup/examples.md
@@ -85,8 +85,8 @@
   "x_news_rationale": "Enabled by default because X News returns story clusters with hooks, summaries, entities, and clustered post IDs.",
   "x_trends_rationale": "Personalized trends are a reasonable default for a founder-led SaaS workflow; switch to location trends only for geography-specific campaigns.",
   "run_commands": {
-    "hourly_major_news": "python3 skills/newsjack-detector/scripts/newsjack_detector.py run --profile profile.json --feed-only --save --new-only --max-age-hours 48 --emit json",
-    "profile_relevance": "python3 skills/newsjack-detector/scripts/newsjack_detector.py run \"AI search visibility\" --profile profile.json --save --emit json"
+    "hourly_major_news": "~/.newsjack/bin/newsjack detector run --profile profile.json --feed-only --save --new-only --max-age-hours 48 --emit json",
+    "profile_relevance": "~/.newsjack/bin/newsjack detector run \"AI search visibility\" --profile profile.json --save --emit json"
   },
   "missing_inputs": [
     "Which search visibility metrics, customer examples, or benchmark claims can be used publicly?"


### PR DESCRIPTION
## Summary

Adds a container-first agent runtime harness for testing the Newsjack installer and setup flow against real Codex, Claude Code, Hermes, and OpenClaw binaries.

## What changed

- Added `harness/run.py` with no-token installer mode, guarded token-burning native smoke, ACP smoke, and setup-flow modes.
- Added a Docker image that installs pinned real runtime CLIs plus ACP adapters.
- Added fixture prompts, env placeholders, harness docs, and the original implementation plan.
- Added CI workflows: no-token PR installer validation and manual token-burning integration validation.

## Validation

No-token fresh-container installer checks passed for all four runtimes:

- `codex`
- `claude`
- `hermes`
- `openclaw`

Token-burning native smoke passed for all four runtimes.

Setup-flow E2E passed for all four runtimes:

- Codex via ACP adapter
- Claude via ACP adapter
- Hermes via native Anthropic fallback because `hermes acp` currently advertises OpenRouter/Hermes setup auth
- OpenClaw via ACP with an in-container local Gateway

## Notes

The CI lane refuses model-provider credentials and runs only mock detector checks. Token-burning integration requires `NEWSJACK_HARNESS_ALLOW_MODEL_CALLS=1`.
