### PR TITLE
Fix CI after Python harness removal

### DIFF
--- a/.github/workflows/agent-harness-ci.yml
+++ b/.github/workflows/agent-harness-ci.yml
@@ -14,8 +14,36 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Build harness image
-        run: docker build -f harness/Dockerfile -t newsjack-agent-harness:local .
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: apps/cli/go.mod
+          cache-dependency-path: apps/cli/go.sum
 
-      - name: Test all runtime install targets
-        run: python3 harness/run.py --mode ci-installer --runtime all --local-source
+      - name: Test Go CLI
+        working-directory: apps/cli
+        run: go test ./...
+
+      - name: Build Go CLI
+        working-directory: apps/cli
+        run: go build -buildvcs=false -o "$RUNNER_TEMP/newsjack" ./cmd/newsjack
+
+      - name: Run mock detector smoke
+        run: |
+          "$RUNNER_TEMP/newsjack" detector run "AI search visibility" --mock --limit 1 --emit json
+
+      - name: Smoke local installer without tokens
+        shell: bash
+        run: |
+          tmp_home="$(mktemp -d)"
+          HOME="$tmp_home" \
+            NEWSJACK_SOURCE_DIR="$PWD" \
+            NEWSJACK_RUNTIMES=all \
+            NEWSJACK_INSTALL_MCP=0 \
+            sh ./install.sh
+          test -x "$tmp_home/.newsjack/bin/newsjack"
+          test -d "$tmp_home/.agents/skills/newsjack-detector"
+          HOME="$tmp_home" "$tmp_home/.newsjack/bin/newsjack" skills list
+
+      - name: Build harness runtime image
+        run: docker build -f harness/Dockerfile -t newsjack-agent-harness:local .

--- a/.github/workflows/agent-harness-integration.yml
+++ b/.github/workflows/agent-harness-integration.yml
@@ -37,6 +37,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # TODO: Reintroduce this workflow as Go or shell orchestration around the
+      # newsjack binary. See docs/agent-runtime-harness-plan.md and
+      # docs/go-cli-port-plan.md.
       - name: Write integration env file
         shell: bash
         run: |
@@ -51,18 +54,11 @@ jobs:
             echo "NEWSJACK_HARNESS_ALLOW_MODEL_CALLS=1"
           } > harness/.env.local
 
-      - name: Build harness image
-        run: docker build -f harness/Dockerfile -t newsjack-agent-harness:local .
-
-      - name: Run integration harness
+      - name: Skip legacy runtime harness
         shell: bash
         run: |
-          source_flag="--local-source"
-          if [ "${{ inputs.production_path }}" = "true" ]; then
-            source_flag="--production-path"
-          fi
-          python3 harness/run.py \
-            --mode "${{ inputs.mode }}" \
-            --runtime "${{ inputs.runtime }}" \
-            --env-file harness/.env.local \
-            "$source_flag"
+          echo "::notice title=Agent runtime integration skipped::The Python harness runner was removed in the Go-only CLI cleanup. Token-burning runtime coverage will stay disabled until it is rebuilt as Go or shell orchestration around newsjack."
+          echo "Requested runtime: ${{ inputs.runtime }}"
+          echo "Requested mode: ${{ inputs.mode }}"
+          echo "Requested production path: ${{ inputs.production_path }}"
+          echo "Secret wiring preserved in harness/.env.local for the future Go/shell harness."


### PR DESCRIPTION
Summary:
- Replaced Agent Harness CI's deleted Python runner call with Go CLI setup, test, build, mock detector smoke, temp-home installer smoke, and the existing harness runtime image build.
- Updated the workflow_dispatch integration workflow to preserve secret env-file wiring while clearly skipping until runtime integration is rebuilt as Go or shell orchestration around newsjack.

Failing run: https://github.com/elvisun/newsjack/actions/runs/26433771311

Verification:
- (cd apps/cli && go test ./...)
- built apps/cli to a temp newsjack binary and ran detector run "AI search visibility" --mock --limit 1 --emit json
- ./bin/newsjack detector run "AI search visibility" --mock --limit 1 --emit json
- temp-home NEWSJACK_SOURCE_DIR install.sh smoke with NEWSJACK_RUNTIMES=all and NEWSJACK_INSTALL_MCP=0
- docker build -f harness/Dockerfile -t newsjack-agent-harness:local .
- (cd apps/site && pnpm lint)
- (cd apps/site && pnpm test)