### PR TITLE
feat(detector): google trends rss source lane

### DIFF
--- a/apps/cli/cmd/newsjack/detector_command.go
+++ b/apps/cli/cmd/newsjack/detector_command.go
@@ -20,6 +20,7 @@ type detectorOptions struct {
 	NoProfileFeeds                  bool
 	NoXNews                         bool
 	NoXTrends                       bool
+	NoGoogleTrends                  bool
 	NoHygieneFilter                 bool
 	Depth                           string
 	LookbackDays                    int
@@ -29,6 +30,7 @@ type detectorOptions struct {
 	ProfileRelevanceMinProfileMatch float64
 	MajorNewsMinProfileMatch        float64
 	XTrendsMinProfileMatch          float64
+	GoogleTrendsMinProfileMatch     float64
 	MinQueuePriority                float64
 	MinMajorNews                    float64
 	LaneCaps                        string
@@ -102,6 +104,7 @@ func parseDetectorRun(args []string, stderr io.Writer) (detectorOptions, int) {
 		ProfileRelevanceMinProfileMatch: 0.05,
 		MajorNewsMinProfileMatch:        0.05,
 		XTrendsMinProfileMatch:          0.05,
+		GoogleTrendsMinProfileMatch:     0.05,
 		MinQueuePriority:                defaultMinQueuePriority,
 		MinMajorNews:                    defaultMinMajorNews,
 		Limit:                           20,
@@ -117,6 +120,7 @@ func parseDetectorRun(args []string, stderr io.Writer) (detectorOptions, int) {
 	fs.BoolVar(&opts.NoProfileFeeds, "no-profile-feeds", false, "Do not include feed_urls from profile")
 	fs.BoolVar(&opts.NoXNews, "no-x-news", false, "Do not auto-include x_news")
 	fs.BoolVar(&opts.NoXTrends, "no-x-trends", false, "Do not include x_trends")
+	fs.BoolVar(&opts.NoGoogleTrends, "no-google-trends", false, "Do not include google_trends")
 	fs.BoolVar(&opts.NoHygieneFilter, "no-hygiene-filter", false, "Disable deterministic hygiene filter")
 	fs.StringVar(&opts.Depth, "depth", "quick", "quick, default, or deep")
 	fs.IntVar(&opts.LookbackDays, "lookback-days", 1, "Lookback window in days")
@@ -126,6 +130,7 @@ func parseDetectorRun(args []string, stderr io.Writer) (detectorOptions, int) {
 	fs.Float64Var(&opts.ProfileRelevanceMinProfileMatch, "profile-relevance-min-profile-match", 0.05, "Demote profile query results below this score")
 	fs.Float64Var(&opts.MajorNewsMinProfileMatch, "major-news-min-profile-match", 0.05, "Demote major-feed-only stories below this score")
 	fs.Float64Var(&opts.XTrendsMinProfileMatch, "x-trends-min-profile-match", 0.05, "Demote X trends below this score")
+	fs.Float64Var(&opts.GoogleTrendsMinProfileMatch, "google-trends-min-profile-match", 0.05, "Demote Google Trends below this score")
 	fs.Float64Var(&opts.MinQueuePriority, "min-queue-priority", defaultMinQueuePriority, "Mechanical queue priority floor")
 	fs.Float64Var(&opts.MinMajorNews, "min-major-news", defaultMinMajorNews, "Major-news fallback floor")
 	fs.StringVar(&opts.LaneCaps, "lane-caps", "", "Comma-separated per-lane output caps")
@@ -140,7 +145,7 @@ func parseDetectorRun(args []string, stderr io.Writer) (detectorOptions, int) {
 	valueFlags := stringSet([]string{
 		"topic", "profile", "sources", "feed-url", "feed-file", "depth", "lookback-days", "max-age-hours",
 		"x-news-min-profile-match", "x-posts-min-profile-match", "profile-relevance-min-profile-match",
-		"major-news-min-profile-match", "x-trends-min-profile-match", "min-queue-priority", "min-major-news",
+		"major-news-min-profile-match", "x-trends-min-profile-match", "google-trends-min-profile-match", "min-queue-priority", "min-major-news",
 		"lane-caps", "limit", "store", "monitor-name", "emit",
 	})
 	if err := fs.Parse(reorderIntermixedFlags(args, valueFlags)); err != nil {

--- a/apps/cli/cmd/newsjack/detector_google_trends_test.go
+++ b/apps/cli/cmd/newsjack/detector_google_trends_test.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+const googleTrendsRSSFixture = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:ht="https://trends.google.com/trending/rss">
+  <channel>
+    <title>Daily Search Trends</title>
+    <item>
+      <title>AI outage</title>
+      <link>https://trends.google.com/trending?geo=US</link>
+      <pubDate>Tue, 26 May 2026 13:00:00 +0000</pubDate>
+      <ht:approx_traffic>100K+</ht:approx_traffic>
+      <ht:news_item>
+        <ht:news_item_title>Cloud providers recover from AI outage</ht:news_item_title>
+        <ht:news_item_url>https://example.com/ai-outage</ht:news_item_url>
+        <ht:news_item_source>Example News</ht:news_item_source>
+        <ht:news_item_snippet>AI tools were disrupted for enterprise customers.</ht:news_item_snippet>
+      </ht:news_item>
+      <ht:news_item>
+        <ht:news_item_title>Developers look for workarounds</ht:news_item_title>
+        <ht:news_item_url>https://example.org/developer-workarounds</ht:news_item_url>
+        <ht:news_item_source>Example Tech</ht:news_item_source>
+        <ht:news_item_snippet>Teams switched to backup workflows.</ht:news_item_snippet>
+      </ht:news_item>
+    </item>
+  </channel>
+</rss>`
+
+func TestParseGoogleTrendsRSSExtractsNewsItems(t *testing.T) {
+	trends, err := parseGoogleTrendsRSS(googleTrendsRSSFixture)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(trends) != 1 {
+		t.Fatalf("trends=%d, want 1", len(trends))
+	}
+	trend := trends[0]
+	if trend.Title != "AI outage" || trend.ApproxTraffic != "100K+" {
+		t.Fatalf("unexpected trend: %#v", trend)
+	}
+	if len(trend.NewsItems) != 2 {
+		t.Fatalf("news items=%d, want 2", len(trend.NewsItems))
+	}
+	if trend.NewsItems[0].Title != "Cloud providers recover from AI outage" {
+		t.Fatalf("news title=%q", trend.NewsItems[0].Title)
+	}
+	if trend.NewsItems[0].URL != "https://example.com/ai-outage" {
+		t.Fatalf("news url=%q", trend.NewsItems[0].URL)
+	}
+	if trend.NewsItems[0].Source != "Example News" {
+		t.Fatalf("news source=%q", trend.NewsItems[0].Source)
+	}
+	if trend.NewsItems[0].Snippet != "AI tools were disrupted for enterprise customers." {
+		t.Fatalf("news snippet=%q", trend.NewsItems[0].Snippet)
+	}
+
+	now := time.Date(2026, 5, 26, 14, 0, 0, 0, time.UTC)
+	items := googleTrendsEvidenceMaps(trends, "US", 24, googleTrendsRSSURL("US", 24), now)
+	if len(items) != 2 {
+		t.Fatalf("mapped items=%d, want 2", len(items))
+	}
+	if items[0]["source"] != "google_trends" || items[0]["title"] != "AI outage" {
+		t.Fatalf("unexpected mapped item: %#v", items[0])
+	}
+	if items[0]["url"] != "https://example.com/ai-outage" {
+		t.Fatalf("mapped url=%q", items[0]["url"])
+	}
+	metadata := valueOrEmptyMap(items[0]["metadata"])
+	if metadata["google_trends_approx_traffic"] != "100K+" || metadata["google_trends_geo"] != "US" {
+		t.Fatalf("metadata missing trend fields: %#v", metadata)
+	}
+	if metadata["google_trends_news_item_title"] != "Cloud providers recover from AI outage" {
+		t.Fatalf("metadata news title=%v", metadata["google_trends_news_item_title"])
+	}
+}
+
+func TestProfileRoundTripPreservesGoogleTrends(t *testing.T) {
+	repo := repoRootForTest(t)
+	profile, err := profileFromFile(filepath.Join(repo, "fixtures/newsjack-detector-agent/profile.clearnym.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if geo := googleTrendsGeo(profile.GoogleTrends); geo != "US" {
+		t.Fatalf("geo=%q, want US", geo)
+	}
+	if hours := googleTrendsHours(profile.GoogleTrends); hours != 24 {
+		t.Fatalf("hours=%d, want 24", hours)
+	}
+
+	data, err := json.Marshal(profile.publicDict())
+	if err != nil {
+		t.Fatal(err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(data, &payload); err != nil {
+		t.Fatal(err)
+	}
+	roundTripped := profileFromMap(payload)
+	if geo := googleTrendsGeo(roundTripped.GoogleTrends); geo != "US" {
+		t.Fatalf("round-trip geo=%q, want US", geo)
+	}
+	if hours := googleTrendsHours(roundTripped.GoogleTrends); hours != 24 {
+		t.Fatalf("round-trip hours=%d, want 24", hours)
+	}
+}

--- a/apps/cli/cmd/newsjack/detector_profile.go
+++ b/apps/cli/cmd/newsjack/detector_profile.go
@@ -18,6 +18,7 @@ type monitorProfile struct {
 	FeedURLs     []string
 	XNews        map[string]any
 	XTrends      map[string]any
+	GoogleTrends map[string]any
 	Spokespeople []string
 	ProofAssets  []string
 	Standing     []string
@@ -37,6 +38,7 @@ func defaultProfile() monitorProfile {
 		Exclusions:   []string{},
 		XNews:        map[string]any{"enabled": true},
 		XTrends:      map[string]any{"mode": "none", "woeids": []any{}, "locations": []any{}},
+		GoogleTrends: defaultGoogleTrendsConfig(),
 	}
 }
 
@@ -63,6 +65,7 @@ func profileFromMap(payload map[string]any) monitorProfile {
 	p.FeedURLs = stringListValue(firstValue(payload, "feed_urls", "feeds", "rss_feeds"))
 	p.XNews = dictValue(payload["x_news"], map[string]any{"enabled": true})
 	p.XTrends = dictValue(payload["x_trends"], map[string]any{"mode": "none", "woeids": []any{}, "locations": []any{}})
+	p.GoogleTrends = googleTrendsConfig(payload["google_trends"])
 	p.Spokespeople = stringListValue(firstValue(payload, "spokespeople", "experts"))
 	p.ProofAssets = stringListValue(firstValue(payload, "proof_assets", "proof"))
 	p.Standing = stringListValue(firstValue(payload, "standing", "expertise"))
@@ -89,6 +92,9 @@ func (p monitorProfile) matchText() string {
 	parts = append(parts, p.Competitors...)
 	parts = append(parts, p.FeedURLs...)
 	parts = append(parts, stringListValue(p.XTrends["locations"])...)
+	if geo := googleTrendsGeo(p.GoogleTrends); geo != "" {
+		parts = append(parts, "Google Trends "+geo)
+	}
 	parts = append(parts, p.Spokespeople...)
 	parts = append(parts, p.ProofAssets...)
 	parts = append(parts, p.Standing...)
@@ -97,17 +103,48 @@ func (p monitorProfile) matchText() string {
 
 func (p monitorProfile) publicDict() map[string]any {
 	return map[string]any{
-		"company":      nullableString(p.Company),
-		"topics":       p.Topics,
-		"competitors":  p.Competitors,
-		"search_terms": p.SearchTerms,
-		"feed_urls":    p.FeedURLs,
-		"x_news":       p.XNews,
-		"x_trends":     p.XTrends,
-		"spokespeople": p.Spokespeople,
-		"proof_assets": p.ProofAssets,
-		"standing":     p.Standing,
-		"exclusions":   p.Exclusions,
+		"company":       nullableString(p.Company),
+		"topics":        p.Topics,
+		"competitors":   p.Competitors,
+		"search_terms":  p.SearchTerms,
+		"feed_urls":     p.FeedURLs,
+		"x_news":        p.XNews,
+		"x_trends":      p.XTrends,
+		"google_trends": p.GoogleTrends,
+		"spokespeople":  p.Spokespeople,
+		"proof_assets":  p.ProofAssets,
+		"standing":      p.Standing,
+		"exclusions":    p.Exclusions,
+	}
+}
+
+func defaultGoogleTrendsConfig() map[string]any {
+	return map[string]any{"geo": "", "hours": 24}
+}
+
+func googleTrendsConfig(v any) map[string]any {
+	out := defaultGoogleTrendsConfig()
+	if m, ok := v.(map[string]any); ok {
+		for k, v := range m {
+			out[k] = v
+		}
+	}
+	out["geo"] = googleTrendsGeo(out)
+	out["hours"] = googleTrendsHours(out)
+	return out
+}
+
+func googleTrendsGeo(config map[string]any) string {
+	return strings.ToUpper(strings.TrimSpace(stringValue(config["geo"])))
+}
+
+func googleTrendsHours(config map[string]any) int {
+	hours := intValue(config["hours"], 24)
+	switch hours {
+	case 4, 24, 48, 168:
+		return hours
+	default:
+		return 24
 	}
 }
 

--- a/apps/cli/cmd/newsjack/detector_run.go
+++ b/apps/cli/cmd/newsjack/detector_run.go
@@ -38,10 +38,13 @@ func detectorRun(opts detectorOptions, stdout io.Writer) error {
 		if err != nil {
 			return err
 		}
+	} else if googleTrendsEnabled(profile, opts) {
+		requestedSources = append(requestedSources, "google_trends")
 	}
 	trendRequested := contains(requestedSources, "x_trends") && !opts.FeedOnly
-	if len(queries) == 0 && len(feedURLs) == 0 && !trendRequested {
-		return errors.New("Provide a query, --topic, --major-feeds, --feed-url, or --profile with topics/competitors.")
+	googleTrendsRequested := googleTrendsEnabled(profile, opts) && contains(requestedSources, "google_trends")
+	if len(queries) == 0 && len(feedURLs) == 0 && !trendRequested && !googleTrendsRequested {
+		return errors.New("Provide a query, --topic, --major-feeds, --feed-url, google_trends geo, or --profile with topics/competitors.")
 	}
 	querySources := querySources(requestedSources)
 	sources := []string{}
@@ -51,7 +54,7 @@ func detectorRun(opts detectorOptions, stdout io.Writer) error {
 		} else {
 			sources = availableSources(config, querySources)
 		}
-		if len(sources) == 0 {
+		if len(sources) == 0 && len(feedURLs) == 0 && !trendRequested && !googleTrendsRequested {
 			return errors.New("No requested sources are available. Configure MEDIALYST_API_KEY and xurl auth, or rerun with --mock.")
 		}
 	}
@@ -112,6 +115,12 @@ func detectorRun(opts detectorOptions, stdout io.Writer) error {
 			return err
 		}
 	}
+	if googleTrendsRequested {
+		items, errors := collectGoogleTrends(profile, opts, now)
+		if err := processItems("google_trends", items, errors); err != nil {
+			return err
+		}
+	}
 	laneCaps := parseLaneCaps(opts.LaneCaps)
 	signals := selectSignals(allSignals, opts.Limit, laneCaps, opts.MinQueuePriority, opts.MinMajorNews)
 	var runID any
@@ -123,6 +132,10 @@ func detectorRun(opts detectorOptions, stdout io.Writer) error {
 		}
 		runID = id
 	}
+	sourcesUsed := append([]string{}, sources...)
+	sourcesUsed = append(sourcesUsed, boolSlice(trendRequested, "x_trends")...)
+	sourcesUsed = append(sourcesUsed, boolSlice(googleTrendsRequested, "google_trends")...)
+	sourcesUsed = append(sourcesUsed, boolSlice(len(feedURLs) > 0, "major_feed")...)
 	payload := map[string]any{
 		"monitor": map[string]any{
 			"name":              nullableString(opts.MonitorName),
@@ -131,7 +144,7 @@ func detectorRun(opts detectorOptions, stdout io.Writer) error {
 			"queries":           nonNilStrings(queries),
 			"feed_urls":         nonNilStrings(feedURLs),
 			"sources_requested": requestedSources,
-			"sources_used":      append(append([]string{}, sources...), append(boolSlice(trendRequested, "x_trends"), boolSlice(len(feedURLs) > 0, "major_feed")...)...),
+			"sources_used":      sourcesUsed,
 			"lookback_days":     opts.LookbackDays,
 			"max_age_hours":     opts.MaxAgeHours,
 			"new_only":          opts.NewOnly,
@@ -251,11 +264,17 @@ func requestedSourcesFor(opts detectorOptions, profile monitorProfile) ([]string
 	if trendsMode != "" && trendsMode != "none" && trendsMode != "off" && trendsMode != "false" && !opts.NoXTrends && !contains(sources, "x_trends") {
 		sources = append(sources, "x_trends")
 	}
+	if googleTrendsEnabled(profile, opts) && !contains(sources, "google_trends") {
+		sources = append(sources, "google_trends")
+	}
 	if opts.NoXNews {
 		sources = removeString(sources, "x_news")
 	}
 	if opts.NoXTrends {
 		sources = removeString(sources, "x_trends")
+	}
+	if opts.NoGoogleTrends {
+		sources = removeString(sources, "google_trends")
 	}
 	return sources, nil
 }
@@ -263,7 +282,7 @@ func requestedSourcesFor(opts detectorOptions, profile monitorProfile) ([]string
 func querySources(sources []string) []string {
 	var out []string
 	for _, s := range sources {
-		if s != "x_trends" {
+		if s != "x_trends" && s != "google_trends" {
 			out = append(out, s)
 		}
 	}
@@ -271,7 +290,7 @@ func querySources(sources []string) []string {
 }
 
 var defaultSources = []string{"news_search", "x_news", "x"}
-var allSources = stringSet([]string{"news_search", "x_news", "x", "x_trends", "reddit", "hackernews"})
+var allSources = stringSet([]string{"news_search", "x_news", "x", "x_trends", "google_trends", "reddit", "hackernews"})
 
 func parseSources(raw string) ([]string, error) {
 	if strings.TrimSpace(raw) == "" {
@@ -289,6 +308,8 @@ func parseSources(raw string) ([]string, error) {
 			key = "news_search"
 		case "twitter", "x_posts":
 			key = "x"
+		case "gtrends", "google-trends", "googletrends":
+			key = "google_trends"
 		}
 		if !allSources[key] {
 			return nil, fmt.Errorf("unsupported source for v0: %s", part)
@@ -363,6 +384,8 @@ func availableSources(config map[string]string, requested []string) []string {
 			out = append(out, source)
 		case source == "x_trends" && (xurl || bearer):
 			out = append(out, source)
+		case source == "google_trends":
+			out = append(out, source)
 		case source == "reddit" || source == "hackernews":
 			out = append(out, source)
 		}
@@ -395,6 +418,21 @@ func mockFeedItems(now time.Time) []evidenceItem {
 		{Source: "major_feed", Title: "Salesforce launches free AI customer service agents for startups", URL: "https://example.com/major/salesforce-ai-agents", Container: "Example Major Feed", PublishedAt: published, Excerpt: "A major CRM vendor is targeting startup and SMB customer-support workflows with free AI agents.", Engagement: map[string]any{}, Metadata: map[string]any{"feed_title": "Example Major Feed", "feed_url": "mock://major-feed", "feed_position": 1}},
 		{Source: "major_feed", Title: "Pentagon launches task force for safe deployment of AI tools", URL: "https://example.com/major/pentagon-ai-task-force", Container: "Example Major Feed", PublishedAt: published, Excerpt: "The Pentagon is studying how to deploy leading AI tools across sensitive government workflows.", Engagement: map[string]any{}, Metadata: map[string]any{"feed_title": "Example Major Feed", "feed_url": "mock://major-feed", "feed_position": 2}},
 	}
+}
+
+func mockGoogleTrendsItems(profile monitorProfile, now time.Time) []evidenceItem {
+	geo := googleTrendsGeo(profile.GoogleTrends)
+	hours := googleTrendsHours(profile.GoogleTrends)
+	return []evidenceItem{{
+		Source:      "google_trends",
+		Title:       "AI agents",
+		URL:         "https://example.com/google-trends/ai-agents",
+		Container:   "Example News",
+		PublishedAt: now.Format(time.RFC3339Nano),
+		Excerpt:     "Example News: AI agent adoption is accelerating. Google Trends approximate traffic: 100K+.",
+		Engagement:  map[string]any{"score": 500},
+		Metadata:    map[string]any{"google_trends_title": "AI agents", "google_trends_approx_traffic": "100K+", "google_trends_geo": geo, "google_trends_hours": hours, "google_trends_news_item_title": "AI agent adoption is accelerating"},
+	}}
 }
 
 func collectQuery(query string, sources []string, config map[string]string, opts detectorOptions, now time.Time) ([]evidenceItem, map[string]string) {
@@ -474,6 +512,33 @@ func collectXTrends(profile monitorProfile, config map[string]string, opts detec
 		return items, map[string]string{"x_trends": errText}
 	}
 	return items, nil
+}
+
+func collectGoogleTrends(profile monitorProfile, opts detectorOptions, now time.Time) ([]evidenceItem, map[string]string) {
+	if !googleTrendsEnabled(profile, opts) {
+		return nil, nil
+	}
+	if opts.Mock {
+		return mockGoogleTrendsItems(profile, now), nil
+	}
+	geo := googleTrendsGeo(profile.GoogleTrends)
+	hours := googleTrendsHours(profile.GoogleTrends)
+	raw, errText := collectGoogleTrendsRSS(geo, hours, now)
+	var items []evidenceItem
+	for _, r := range raw {
+		item := evidenceFromMap(r)
+		if item.Title != "" || item.Excerpt != "" {
+			items = append(items, item)
+		}
+	}
+	if errText != "" {
+		return items, map[string]string{"google_trends": errText}
+	}
+	return items, nil
+}
+
+func googleTrendsEnabled(profile monitorProfile, opts detectorOptions) bool {
+	return !opts.NoGoogleTrends && googleTrendsGeo(profile.GoogleTrends) != ""
 }
 
 func collectSource(source, query, fromDate, toDate, depth string, config map[string]string) (items []map[string]any, errText string) {
@@ -556,6 +621,7 @@ func detectorDiagnose(sourcesRaw, store string, stdout, stderr io.Writer) int {
 		"xurl_available":            contains(availableSources(config, []string{"x"}), "x"),
 		"x_news_available":          contains(availableSources(config, []string{"x_news"}), "x_news"),
 		"x_trends_available":        contains(availableSources(config, []string{"x_trends"}), "x_trends"),
+		"google_trends_available":   contains(availableSources(config, []string{"google_trends"}), "google_trends"),
 		"twitter_bearer_configured": bearerToken(config) != "",
 		"store_path":                dbPathFromEnv(store),
 	}

--- a/apps/cli/cmd/newsjack/detector_scoring.go
+++ b/apps/cli/cmd/newsjack/detector_scoring.go
@@ -244,13 +244,14 @@ func filterItemsByHygiene(items []evidenceItem, enabled bool) ([]evidenceItem, m
 }
 
 var sourceQuality = map[string]float64{
-	"major_feed":  0.88,
-	"news_search": 0.95,
-	"x":           0.70,
-	"x_news":      0.86,
-	"x_trends":    0.68,
-	"reddit":      0.62,
-	"hackernews":  0.72,
+	"major_feed":    0.88,
+	"news_search":   0.95,
+	"google_trends": 0.74,
+	"x":             0.70,
+	"x_news":        0.86,
+	"x_trends":      0.68,
+	"reddit":        0.62,
+	"hackernews":    0.72,
 }
 
 func sourceAgreementScore(sources []string) float64 {
@@ -570,6 +571,12 @@ func signalLane(cluster signalCluster, majorNews, profileMatch float64, opts det
 		}
 		return "x_trends"
 	}
+	if sources["google_trends"] {
+		if profileMatch < opts.GoogleTrendsMinProfileMatch {
+			return "google_trends_unmatched"
+		}
+		return "google_trends"
+	}
 	if len(sources) == 1 && sources["x"] {
 		for _, item := range cluster.Evidence {
 			if item.Metadata["x_signal_type"] == "query_trend" {
@@ -616,9 +623,9 @@ func scoreSignal(cluster signalCluster, profile monitorProfile, seen map[string]
 		queue = round1(100 * (0.30*majorNews + 0.22*freshness + 0.14*novelty + 0.12*profileMatch + 0.12*sourceQuality + 0.10*sourceAgreement))
 	case "major_news_unmatched":
 		queue = round1(math.Min(39.9, 100*(0.18*majorNews+0.16*freshness+0.12*novelty+0.10*sourceQuality+0.08*sourceAgreement)))
-	case "x_news", "x_trends":
+	case "x_news", "x_trends", "google_trends":
 		queue = round1(100 * (0.24*freshness + 0.20*profileMatch + 0.18*novelty + 0.16*sourceQuality + 0.12*sourceAgreement + 0.10*engagement))
-	case "x_trends_unmatched":
+	case "x_trends_unmatched", "google_trends_unmatched":
 		queue = round1(math.Min(39.9, 100*(0.16*freshness+0.14*novelty+0.12*sourceQuality+0.10*engagement)))
 	case "x_news_unmatched", "profile_relevance_weak", "x_posts_weak":
 		queue = round1(math.Min(39.9, 100*(0.18*freshness+0.16*novelty+0.12*sourceQuality+0.10*sourceAgreement+0.08*engagement)))

--- a/apps/cli/cmd/newsjack/detector_sources.go
+++ b/apps/cli/cmd/newsjack/detector_sources.go
@@ -196,6 +196,147 @@ func feedItemDict(m map[string]string, feedTitle, feedURL string, position int) 
 	}
 }
 
+const googleTrendsRSSBase = "https://trends.google.com/trending/rss"
+
+type googleTrendsRSS struct {
+	Channel struct {
+		Items []googleTrendsRSSItem `xml:"item"`
+	} `xml:"channel"`
+}
+
+type googleTrendsRSSItem struct {
+	Title         string                    `xml:"title"`
+	Link          string                    `xml:"link"`
+	PubDate       string                    `xml:"pubDate"`
+	ApproxTraffic string                    `xml:"approx_traffic"`
+	NewsItems     []googleTrendsRSSNewsItem `xml:"news_item"`
+}
+
+type googleTrendsRSSNewsItem struct {
+	Title   string `xml:"news_item_title"`
+	URL     string `xml:"news_item_url"`
+	Source  string `xml:"news_item_source"`
+	Snippet string `xml:"news_item_snippet"`
+}
+
+func collectGoogleTrendsRSS(geo string, hours int, now time.Time) ([]map[string]any, string) {
+	feedURL := googleTrendsRSSURL(geo, hours)
+	resp, err := httpGetRaw(feedURL, map[string]string{
+		"Accept":     "application/rss+xml, application/xml, text/xml, */*",
+		"User-Agent": "newsjack/0.1 (+https://github.com/elvisun/newsjack)",
+	}, 10*time.Second)
+	if err != nil {
+		return nil, fmt.Sprintf("%T: %v", err, err)
+	}
+	trends, err := parseGoogleTrendsRSS(resp)
+	if err != nil {
+		return nil, fmt.Sprintf("%T: %v", err, err)
+	}
+	return googleTrendsEvidenceMaps(trends, geo, hours, feedURL, now), ""
+}
+
+func googleTrendsRSSURL(geo string, hours int) string {
+	values := url.Values{}
+	values.Set("geo", strings.ToUpper(strings.TrimSpace(geo)))
+	values.Set("hours", strconv.Itoa(hours))
+	return googleTrendsRSSBase + "?" + values.Encode()
+}
+
+func parseGoogleTrendsRSS(xmlText string) ([]googleTrendsRSSItem, error) {
+	var feed googleTrendsRSS
+	decoder := xml.NewDecoder(strings.NewReader(xmlText))
+	if err := decoder.Decode(&feed); err != nil {
+		return nil, err
+	}
+	var trends []googleTrendsRSSItem
+	for _, item := range feed.Channel.Items {
+		item.Title = cleanText(item.Title)
+		item.Link = strings.TrimSpace(item.Link)
+		item.PubDate = strings.TrimSpace(item.PubDate)
+		item.ApproxTraffic = cleanText(item.ApproxTraffic)
+		if item.Title == "" {
+			continue
+		}
+		var newsItems []googleTrendsRSSNewsItem
+		for _, news := range item.NewsItems {
+			news.Title = cleanText(news.Title)
+			news.URL = strings.TrimSpace(news.URL)
+			news.Source = cleanText(news.Source)
+			news.Snippet = cleanText(news.Snippet)
+			if news.Title == "" && news.URL == "" && news.Snippet == "" {
+				continue
+			}
+			newsItems = append(newsItems, news)
+		}
+		item.NewsItems = newsItems
+		trends = append(trends, item)
+	}
+	return trends, nil
+}
+
+func googleTrendsEvidenceMaps(trends []googleTrendsRSSItem, geo string, hours int, feedURL string, now time.Time) []map[string]any {
+	var out []map[string]any
+	for i, trend := range trends {
+		published := normalizeLooseDate(trend.PubDate)
+		if published == "" {
+			published = now.Format(time.RFC3339Nano)
+		}
+		approxTraffic := cleanText(trend.ApproxTraffic)
+		trafficCount := parseCountText(approxTraffic)
+		engagement := map[string]any{}
+		if trafficCount > 0 {
+			engagement["score"] = minInt(500, trafficCount)
+		}
+		if len(trend.NewsItems) == 0 {
+			out = append(out, googleTrendsEvidenceMap(trend, googleTrendsRSSNewsItem{}, geo, hours, feedURL, published, engagement, i+1, 0))
+			continue
+		}
+		for j, news := range trend.NewsItems {
+			out = append(out, googleTrendsEvidenceMap(trend, news, geo, hours, feedURL, published, engagement, i+1, j+1))
+		}
+	}
+	return out
+}
+
+func googleTrendsEvidenceMap(trend googleTrendsRSSItem, news googleTrendsRSSNewsItem, geo string, hours int, feedURL, published string, engagement map[string]any, trendPosition, newsPosition int) map[string]any {
+	newsTitle := cleanText(news.Title)
+	snippet := cleanText(news.Snippet)
+	trafficText := cleanText(trend.ApproxTraffic)
+	excerptParts := nonEmpty(newsTitle, snippet)
+	if trafficText != "" {
+		excerptParts = append(excerptParts, "Google Trends approximate traffic: "+trafficText)
+	}
+	excerpt := strings.Join(excerptParts, ". ")
+	link := strings.TrimSpace(news.URL)
+	if link == "" {
+		link = strings.TrimSpace(trend.Link)
+	}
+	metadata := map[string]any{
+		"google_trends_title":              trend.Title,
+		"google_trends_approx_traffic":     trafficText,
+		"google_trends_geo":                strings.ToUpper(strings.TrimSpace(geo)),
+		"google_trends_hours":              hours,
+		"google_trends_feed_url":           feedURL,
+		"google_trends_position":           trendPosition,
+		"google_trends_news_item_position": newsPosition,
+		"google_trends_news_item_title":    nullableString(newsTitle),
+		"google_trends_news_item_source":   nullableString(news.Source),
+		"google_trends_news_item_snippet":  nullableString(snippet),
+	}
+	return map[string]any{
+		"id":           fmt.Sprintf("GTREND%d-%d", trendPosition, newsPosition),
+		"source":       "google_trends",
+		"title":        trend.Title,
+		"url":          link,
+		"author":       nil,
+		"container":    firstString(news.Source, "Google Trends"),
+		"published_at": nullableString(published),
+		"excerpt":      excerpt,
+		"engagement":   engagement,
+		"metadata":     metadata,
+	}
+}
+
 func cleanText(value string) string {
 	text := html.UnescapeString(value)
 	text = regexp.MustCompile(`(?is)<script[^>]*>.*?</script>|<style[^>]*>.*?</style>`).ReplaceAllString(text, " ")

--- a/apps/cli/cmd/newsjack/detector_test.go
+++ b/apps/cli/cmd/newsjack/detector_test.go
@@ -55,6 +55,7 @@ func TestDemotedDetectorLanesStayBelowDefaultQueueFloor(t *testing.T) {
 		ProfileRelevanceMinProfileMatch: 0.05,
 		MajorNewsMinProfileMatch:        0.05,
 		XTrendsMinProfileMatch:          0.05,
+		GoogleTrendsMinProfileMatch:     0.05,
 	}
 
 	tests := []struct {
@@ -65,6 +66,7 @@ func TestDemotedDetectorLanesStayBelowDefaultQueueFloor(t *testing.T) {
 	}{
 		{name: "profile query", source: "news_search", wantLane: "profile_relevance_weak", sourceName: "Reuters"},
 		{name: "x news", source: "x_news", wantLane: "x_news_unmatched", sourceName: "X News"},
+		{name: "google trends", source: "google_trends", wantLane: "google_trends_unmatched", sourceName: "Google Trends"},
 		{name: "x posts", source: "x", wantLane: "x_posts_weak", sourceName: "X"},
 	}
 

--- a/fixtures/newsjack-detector-agent/profile.bluebottle.json
+++ b/fixtures/newsjack-detector-agent/profile.bluebottle.json
@@ -48,6 +48,10 @@
     "woeids": [],
     "locations": []
   },
+  "google_trends": {
+    "geo": "US",
+    "hours": 24
+  },
   "spokespeople": [
     "Coffee sourcing or roasting lead",
     "Cafe operations lead",

--- a/fixtures/newsjack-detector-agent/profile.clearnym.json
+++ b/fixtures/newsjack-detector-agent/profile.clearnym.json
@@ -41,6 +41,10 @@
     "woeids": [],
     "locations": []
   },
+  "google_trends": {
+    "geo": "US",
+    "hours": 24
+  },
   "spokespeople": [
     "Founder or CEO with consumer privacy expertise",
     "Privacy operations lead",

--- a/fixtures/newsjack-detector-agent/profile.localfalcon.json
+++ b/fixtures/newsjack-detector-agent/profile.localfalcon.json
@@ -46,6 +46,10 @@
     "woeids": [],
     "locations": []
   },
+  "google_trends": {
+    "geo": "CA",
+    "hours": 24
+  },
   "spokespeople": [
     "Founder or CEO with local SEO expertise",
     "Product lead for AI search visibility",

--- a/fixtures/newsjack-detector-agent/profile.nofar-method.json
+++ b/fixtures/newsjack-detector-agent/profile.nofar-method.json
@@ -56,6 +56,10 @@
       "Miami"
     ]
   },
+  "google_trends": {
+    "geo": "US",
+    "hours": 24
+  },
   "spokespeople": [
     "Founder or lead instructor",
     "Studio operations lead",

--- a/fixtures/newsjack-detector-agent/profile.property-saviour.json
+++ b/fixtures/newsjack-detector-agent/profile.property-saviour.json
@@ -45,6 +45,10 @@
       "United Kingdom"
     ]
   },
+  "google_trends": {
+    "geo": "GB",
+    "hours": 24
+  },
   "spokespeople": [
     "Founder or director with UK property buying expertise",
     "Property valuation lead",

--- a/fixtures/newsjack-detector-agent/profile.simular.json
+++ b/fixtures/newsjack-detector-agent/profile.simular.json
@@ -42,6 +42,10 @@
     "woeids": [],
     "locations": []
   },
+  "google_trends": {
+    "geo": "US",
+    "hours": 24
+  },
   "spokespeople": [
     "Founder or CEO with computer-use agent expertise",
     "Research lead for agent benchmarks",

--- a/fixtures/newsjack-detector-agent/profile.slite.json
+++ b/fixtures/newsjack-detector-agent/profile.slite.json
@@ -45,6 +45,10 @@
     "woeids": [],
     "locations": []
   },
+  "google_trends": {
+    "geo": "US",
+    "hours": 24
+  },
   "spokespeople": [
     "Founder or CEO with knowledge management expertise",
     "Product lead for AI search",

--- a/skills/newsjack-detector/SKILL.md
+++ b/skills/newsjack-detector/SKILL.md
@@ -28,6 +28,7 @@ Defaults:
 - `x` uses `xurl` and the official X API path. The X lane filters out low-reach single posts by default and may emit a query-volume signal when X recent counts show a topic is moving.
 - `x_news` should be enabled by default in profiles once the source is wired. It is the preferred X discovery shape because it returns story clusters rather than random individual posts.
 - `x_trends` is optional profile configuration: `personalized`, `location`, or `none`. Use location trends only when geography matters.
+- `google_trends` is optional profile configuration by country code. Google Trends RSS surfaces hourly-refreshed trending search topics for a given country. Each trend carries linked news items used as evidence.
 - `major_feed` is an RSS/Atom input lane for curated major-news feeds. Profile `feed_urls` are included automatically.
 - Optional v0 sources: `reddit`, `hackernews`.
 - The engine reads `MEDIALYST_API_KEY`, `MEDIALYST_API_BASE`, and `MEDIALYST_NEWS_PATH` from the process environment or repo-root `.env`.
@@ -36,7 +37,7 @@ Defaults:
 Useful flags:
 
 - `--sources news_search,x,reddit,hackernews`
-- `--sources news_search,x_news,x,x_trends` to include X story clusters, raw posts, and profile-selected trends.
+- `--sources news_search,x_news,x,x_trends,google_trends` to include X story clusters, raw posts, and profile-selected trends.
 - `--major-feeds` to include default curated major-news feeds when the profile has no `feed_urls`.
 - `--feed-url URL` to include an RSS/Atom feed URL or local XML file. Repeatable.
 - `--feed-file PATH` to include a text file of RSS/Atom feed URLs, one per line.
@@ -44,6 +45,7 @@ Useful flags:
 - `--no-profile-feeds` to skip profile RSS feeds for a query-only run.
 - `--no-x-news` to disable profile-default X News story clusters.
 - `--no-x-trends` to disable profile-selected X trends.
+- `--no-google-trends` to disable profile-selected Google Trends RSS.
 - `--no-hygiene-filter` to keep obvious docs/product/SEO retrieval junk for debugging.
 - `--lookback-days 1`
 - `--max-age-hours 24` to avoid backfilling obviously old source items on recurring runs. Default: `24`. This is only a mechanical source timestamp filter; it does not prove the story is new.
@@ -52,9 +54,10 @@ Useful flags:
 - `--profile-relevance-min-profile-match 0.05` to demote profile-query results below the profile-overlap threshold.
 - `--major-news-min-profile-match 0.05` to demote broad RSS stories below the profile-overlap threshold.
 - `--x-trends-min-profile-match 0.05` to demote broad X trends below the profile-overlap threshold.
+- `--google-trends-min-profile-match 0.05` to demote broad Google Trends topics below the profile-overlap threshold.
 - `--min-queue-priority 40` to emit candidates at or above this mechanical priority when no lane caps are set. Threshold-demoted lanes stay below `40` by default; lower this only for debugging the rejected pool.
 - `--min-major-news 0.55` to also emit matched `major_news` candidates above this major-news score. `major_news_unmatched` remains below the default floor unless explicitly debugged with a lower queue floor.
-- `--lane-caps x_news=8,profile_relevance=8,major_news=8,x_trends=5,x_posts=4` as an optional override for skim-only runs. Do not use lane caps for the coarse-relevance candidate pool unless you deliberately want a narrow list.
+- `--lane-caps x_news=8,profile_relevance=8,major_news=8,x_trends=5,google_trends=5,x_posts=4` as an optional override for skim-only runs. Do not use lane caps for the coarse-relevance candidate pool unless you deliberately want a narrow list.
 - `--new-only` to suppress signals whose evidence URLs are already in the monitor store.
 - `--include-all-scored` to include the full scored signal pool under `debug.all_scored_signals`. Use only for fixture/debug observability; normal product runs should keep output compact.
 - `--depth quick|default|deep`

--- a/skills/newsjack-setup/SKILL.md
+++ b/skills/newsjack-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: newsjack-setup
-description: "Set up a newsjack monitor profile for a company. Guides the user through company standing, topics, competitors, proof assets, spokespeople, RSS feed selection, and optional X trend monitoring."
+description: "Set up a newsjack monitor profile for a company. Guides the user through company standing, topics, competitors, proof assets, spokespeople, RSS feed selection, Google Trends geo, and optional X trend monitoring."
 when_to_use: "User wants to configure newsjack, create a monitor profile, onboard a client/company, choose RSS/news feeds, or prepare a profile for newsjack-detector."
 ---
 
@@ -8,7 +8,7 @@ when_to_use: "User wants to configure newsjack, create a monitor profile, onboar
 
 You are **newsjack-setup**, the onboarding skill for newsjack.sh. Your job is to create a monitor profile that `newsjack-detector` can run hourly without guessing the company, beat, or news sources.
 
-For now, setup has one deliverable: a monitor profile JSON object with relevant RSS feeds, `x_news` enabled by default, and optional X trend preferences.
+For now, setup has one deliverable: a monitor profile JSON object with relevant RSS feeds, `x_news` enabled by default, optional X trend preferences, and Google Trends geo monitoring.
 
 ## Inputs
 
@@ -26,6 +26,7 @@ Required:
 - 2-5 proof assets
 - 1-3 likely spokespeople
 - 2-5 RSS feed URLs
+- Google Trends primary country code
 - X trend preference: `personalized`, `location`, or `none`
 
 Optional:
@@ -33,6 +34,7 @@ Optional:
 - client-specific exclusions
 - geography
 - target beats
+- Google Trends hours window
 - location WOEIDs for X trends if the user chooses `location`
 
 General tragedy and human-suffering exclusions are not profile fields. Those live in detector doctrine.
@@ -76,6 +78,12 @@ If the user chooses `location`, ask for target geography and save both labels an
 
 Do not make `location` the default for a generic SaaS company. Prefer `personalized` or `none` unless geography is important. If the user is unsure, choose `personalized` for founder-led/tech/media workflows and `none` for low-noise company monitoring.
 
+## Google Trends Geo
+
+Ask for the primary country code for Google Trends monitoring using ISO-3166 alpha-2, such as `US`, `GB`, or `CA`. Ask for `hours` only if the user has a specific monitoring window; allowed values are `4`, `24`, `48`, and `168`, and the default is `24`.
+
+Default recommendations: US-focused brands use `US`; UK property, UK regulation, or UK public affairs use `GB`; Canadian local-search or Canada-focused businesses use `CA`. If the user is unsure or the brand has no geography-specific monitoring need, default to `US`.
+
 ## Process
 
 1. **Understand the company.** Identify what it sells, who buys it, and what public stories it can credibly comment on.
@@ -92,9 +100,11 @@ Do not make `location` the default for a generic SaaS company. Prefer `personali
 
 7. **Select feeds.** Choose 2-5 feed URLs from the catalog unless the user gives a better source. Explain why each feed belongs.
 
-8. **Choose X social sources.** Set `x_news.enabled` to `true` by default. Ask whether to use personalized trends, location trends, or no X trends. Explain the tradeoff briefly. Location trends should include WOEIDs.
+8. **Choose Google Trends geo.** Add `google_trends` with the primary country code and `hours: 24` unless the user selects another allowed window.
 
-9. **Return the profile JSON and run command.** Do not write files unless the user asks you to. The user or caller can save the JSON.
+9. **Choose X social sources.** Set `x_news.enabled` to `true` by default. Ask whether to use personalized trends, location trends, or no X trends. Explain the tradeoff briefly. Location trends should include WOEIDs.
+
+10. **Return the profile JSON and run command.** Do not write files unless the user asks you to. The user or caller can save the JSON.
 
 ## Output Format
 
@@ -118,6 +128,10 @@ Return a concise setup result:
       "woeids": [],
       "locations": []
     },
+    "google_trends": {
+      "geo": "US",
+      "hours": 24
+    },
     "spokespeople": ["Founder or CEO"],
     "proof_assets": ["Specific proof"],
     "standing": ["Specific standing area"],
@@ -131,6 +145,7 @@ Return a concise setup result:
   ],
   "x_news_rationale": "Enabled by default because X News returns story clusters rather than random individual posts.",
   "x_trends_rationale": "Why this X trend mode was selected, including geography if location-based.",
+  "google_trends_rationale": "Why this Google Trends country code was selected.",
   "run_commands": {
     "hourly_major_news": "~/.newsjack/bin/newsjack detector run --profile profile.json --feed-only --save --new-only --max-age-hours 48 --emit json",
     "profile_relevance": "~/.newsjack/bin/newsjack detector run \"TOPIC\" --profile profile.json --save --emit json"


### PR DESCRIPTION
## Summary
- Add a `google_trends` detector source lane backed only by `https://trends.google.com/trending/rss?geo=<ISO2>&hours=<4|24|48|168>`.
- Add profile `google_trends` config/defaults, CLI disable/threshold flags, source summaries, diagnostics, and lane scoring/demotion.
- Update setup/detector skills and backfill all 7 fixture profiles with geo-specific Google Trends config.
- Add RSS namespace parser coverage and profile serialization round-trip coverage.

Dossier: `~/Documents/Obsidian/elvis/projects/newsjack-sh/research/google-trends/dossier-2026-05-26.md`

## Validation
```console
apps/cli$ go test ./...
ok  	github.com/elvisun/newsjack/apps/cli/cmd/newsjack	0.375s

apps/cli$ go build ./...
# no output

apps/site$ pnpm lint
> @newsjack/site@0.1.0 lint /Users/elvissun/Documents/GitHub/newsjack-worktrees/newsjack-gtrends-rss/apps/site
> eslint . --max-warnings=0

apps/site$ pnpm test
> @newsjack/site@0.1.0 test /Users/elvissun/Documents/GitHub/newsjack-worktrees/newsjack-gtrends-rss/apps/site
> node --test

TAP version 13
1..0
# tests 0
# suites 0
# pass 0
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 6.830917
```
