### PR TITLE
feat(detector): feed catalog audit — drop science, vertical health, edgar 8-k, conditional GET

### DIFF
--- a/apps/cli/cmd/newsjack/detector_run.go
+++ b/apps/cli/cmd/newsjack/detector_run.go
@@ -61,6 +61,7 @@ func detectorRun(opts detectorOptions, stdout io.Writer) error {
 	sourceErrors := map[string]any{}
 	evidenceSourceCounts := map[string]int{}
 	hygieneRejections := map[string]int{}
+	var feedFetchDebug []map[string]any
 	noteItems := func(items []evidenceItem) {
 		for _, item := range items {
 			evidenceSourceCounts[item.Source]++
@@ -101,7 +102,9 @@ func detectorRun(opts detectorOptions, stdout io.Writer) error {
 		}
 	}
 	if len(feedURLs) > 0 {
-		items, errors := collectFeeds(feedURLs, opts.Depth, opts.Mock, now)
+		var items []evidenceItem
+		var errors map[string]string
+		items, errors, feedFetchDebug = collectFeedsWithStore(feedURLs, opts.Depth, opts.Mock, now, opts.Store, true)
 		if err := processItems("major_news_feed", items, errors); err != nil {
 			return err
 		}
@@ -123,6 +126,19 @@ func detectorRun(opts detectorOptions, stdout io.Writer) error {
 		}
 		runID = id
 	}
+	diagnostics := map[string]any{
+		"evidence_by_source":    evidenceSourceCounts,
+		"hygiene_rejections":    hygieneRejections,
+		"signals_by_lane":       countByLanes(allSignals),
+		"emitted_by_lane":       countByLanes(signals),
+		"lane_caps":             laneCaps,
+		"selection":             map[string]any{"mode": map[bool]string{true: "lane_caps", false: "mechanical_floor"}[laneCaps != nil], "limit": opts.Limit, "min_queue_priority": opts.MinQueuePriority, "min_major_news": opts.MinMajorNews},
+		"total_scored_signals":  len(allSignals),
+		"total_emitted_signals": len(signals),
+	}
+	if len(feedFetchDebug) > 0 {
+		diagnostics["feed_fetches"] = feedFetchDebug
+	}
 	payload := map[string]any{
 		"monitor": map[string]any{
 			"name":              nullableString(opts.MonitorName),
@@ -138,17 +154,8 @@ func detectorRun(opts detectorOptions, stdout io.Writer) error {
 			"depth":             opts.Depth,
 			"mock":              opts.Mock,
 		},
-		"signals": signals,
-		"diagnostics": map[string]any{
-			"evidence_by_source":    evidenceSourceCounts,
-			"hygiene_rejections":    hygieneRejections,
-			"signals_by_lane":       countByLanes(allSignals),
-			"emitted_by_lane":       countByLanes(signals),
-			"lane_caps":             laneCaps,
-			"selection":             map[string]any{"mode": map[bool]string{true: "lane_caps", false: "mechanical_floor"}[laneCaps != nil], "limit": opts.Limit, "min_queue_priority": opts.MinQueuePriority, "min_major_news": opts.MinMajorNews},
-			"total_scored_signals":  len(allSignals),
-			"total_emitted_signals": len(signals),
-		},
+		"signals":       signals,
+		"diagnostics":   diagnostics,
 		"source_errors": sourceErrors,
 		"store": map[string]any{
 			"saved":  opts.Save,
@@ -170,7 +177,11 @@ func detectorRun(opts detectorOptions, stdout io.Writer) error {
 				dropped = append(dropped, id)
 			}
 		}
-		payload["debug"] = map[string]any{"all_scored_signals": allSignals, "dropped_signal_ids": nonNilStrings(dropped), "include_all_scored": true}
+		debug := map[string]any{"all_scored_signals": allSignals, "dropped_signal_ids": nonNilStrings(dropped), "include_all_scored": true}
+		if len(feedFetchDebug) > 0 {
+			debug["feed_fetches"] = feedFetchDebug
+		}
+		payload["debug"] = debug
 	}
 	if opts.Emit == "brief" {
 		fmt.Fprint(stdout, detectorBrief(payload))
@@ -423,14 +434,23 @@ func collectQuery(query string, sources []string, config map[string]string, opts
 }
 
 func collectFeeds(feedURLs []string, depth string, mock bool, now time.Time) ([]evidenceItem, map[string]string) {
+	items, errors, _ := collectFeedsWithStore(feedURLs, depth, mock, now, "", false)
+	return items, errors
+}
+
+func collectFeedsWithStore(feedURLs []string, depth string, mock bool, now time.Time, store string, useStore bool) ([]evidenceItem, map[string]string, []map[string]any) {
 	if mock {
-		return mockFeedItems(now), map[string]string{}
+		return mockFeedItems(now), map[string]string{}, nil
 	}
 	limit := map[string]int{"quick": 15, "default": 30, "deep": 60}[depth]
 	var items []evidenceItem
 	errors := map[string]string{}
+	var fetches []map[string]any
 	for _, feed := range feedURLs {
-		raw, errText := collectFeed(feed, limit)
+		raw, fetchDebug, errText := collectFeedWithStore(feed, limit, store, useStore)
+		if len(fetchDebug) > 0 {
+			fetches = append(fetches, fetchDebug)
+		}
 		if errText != "" {
 			errors[feed] = errText
 		}
@@ -441,7 +461,7 @@ func collectFeeds(feedURLs []string, depth string, mock bool, now time.Time) ([]
 			}
 		}
 	}
-	return items, errors
+	return items, errors, fetches
 }
 
 func collectXTrends(profile monitorProfile, config map[string]string, opts detectorOptions, now time.Time) ([]evidenceItem, map[string]string) {

--- a/apps/cli/cmd/newsjack/detector_sources.go
+++ b/apps/cli/cmd/newsjack/detector_sources.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"sort"
 	"strconv"
@@ -81,25 +82,124 @@ func parseNewsResponse(payload map[string]any) []map[string]any {
 }
 
 func collectFeed(urlOrPath string, limit int) ([]map[string]any, string) {
+	items, _, errText := collectFeedWithStore(urlOrPath, limit, "", false)
+	return items, errText
+}
+
+func collectFeedWithStore(urlOrPath string, limit int, store string, useStore bool) ([]map[string]any, map[string]any, string) {
 	var text string
+	debug := map[string]any{"url": urlOrPath}
+	if tier := catalogTierForFeedURL(urlOrPath); tier != "" {
+		debug["tier"] = tier
+	}
 	if regexp.MustCompile(`(?i)^https?://`).MatchString(urlOrPath) {
-		resp, err := httpGetRaw(urlOrPath, map[string]string{"Accept": "application/rss+xml, application/atom+xml, text/xml, */*"}, 20*time.Second)
-		if err != nil {
-			return nil, fmt.Sprintf("%T: %v", err, err)
+		headers := map[string]string{"Accept": "application/rss+xml, application/atom+xml, text/xml, */*"}
+		if useStore {
+			state, err := feedHTTPStateFor(urlOrPath, store)
+			if err != nil {
+				debug["status"] = "cache_read_error"
+				debug["error"] = err.Error()
+				return nil, debug, fmt.Sprintf("%T: %v", err, err)
+			}
+			if state.ETag != "" {
+				headers["If-None-Match"] = state.ETag
+				debug["sent_if_none_match"] = true
+			}
+			if state.LastModified != "" {
+				headers["If-Modified-Since"] = state.LastModified
+				debug["sent_if_modified_since"] = true
+			}
 		}
-		text = resp
+		resp, err := httpGetRawResponse(urlOrPath, headers, 20*time.Second)
+		if err != nil {
+			debug["status"] = "fetch_error"
+			debug["error"] = err.Error()
+			return nil, debug, fmt.Sprintf("%T: %v", err, err)
+		}
+		debug["status_code"] = resp.StatusCode
+		if resp.StatusCode == http.StatusNotModified {
+			debug["status"] = "not_modified"
+			debug["not_modified"] = true
+			return nil, debug, ""
+		}
+		if resp.StatusCode >= 400 {
+			errText := fmt.Sprintf("HTTP %d: %s", resp.StatusCode, truncate(resp.Body, 300))
+			debug["status"] = "http_error"
+			debug["error"] = errText
+			return nil, debug, errText
+		}
+		if useStore && resp.StatusCode == http.StatusOK {
+			state := feedHTTPState{
+				ETag:         strings.TrimSpace(resp.Header.Get("ETag")),
+				LastModified: strings.TrimSpace(resp.Header.Get("Last-Modified")),
+			}
+			if state.ETag != "" {
+				debug["etag"] = true
+			}
+			if state.LastModified != "" {
+				debug["last_modified"] = true
+			}
+			if err := saveFeedHTTPState(urlOrPath, state, store); err != nil {
+				debug["cache_write_error"] = err.Error()
+			}
+		}
+		text = resp.Body
 	} else {
 		data, err := os.ReadFile(expandPath(urlOrPath))
 		if err != nil {
-			return nil, fmt.Sprintf("%T: %v", err, err)
+			debug["status"] = "read_error"
+			debug["error"] = err.Error()
+			return nil, debug, fmt.Sprintf("%T: %v", err, err)
 		}
 		text = string(data)
 	}
 	items, err := parseFeed(text, urlOrPath, limit)
 	if err != nil {
-		return nil, fmt.Sprintf("%T: %v", err, err)
+		debug["status"] = "parse_error"
+		debug["error"] = err.Error()
+		return nil, debug, fmt.Sprintf("%T: %v", err, err)
 	}
-	return items, ""
+	debug["status"] = "parsed"
+	debug["item_count"] = len(items)
+	return items, debug, ""
+}
+
+type feedCatalogForTier struct {
+	Feeds []struct {
+		URL  string `json:"url"`
+		Tier string `json:"tier"`
+	} `json:"feeds"`
+}
+
+var feedCatalogTierByURL map[string]string
+
+func catalogTierForFeedURL(feedURL string) string {
+	if feedCatalogTierByURL == nil {
+		feedCatalogTierByURL = loadFeedCatalogTiers()
+	}
+	return feedCatalogTierByURL[feedURL]
+}
+
+func loadFeedCatalogTiers() map[string]string {
+	root, err := newsjackRoot()
+	if err != nil {
+		return map[string]string{}
+	}
+	data, err := os.ReadFile(filepath.Join(root, "skills", "newsjack-detector", "references", "rss-feeds.json"))
+	if err != nil {
+		return map[string]string{}
+	}
+	var catalog feedCatalogForTier
+	if err := json.Unmarshal(data, &catalog); err != nil {
+		return map[string]string{}
+	}
+	out := map[string]string{}
+	for _, feed := range catalog.Feeds {
+		if feed.URL != "" && feed.Tier != "" {
+			out[feed.URL] = feed.Tier
+		}
+	}
+	return out
 }
 
 func parseFeed(xmlText, feedURL string, limit int) ([]map[string]any, error) {

--- a/apps/cli/cmd/newsjack/detector_store.go
+++ b/apps/cli/cmd/newsjack/detector_store.go
@@ -36,6 +36,7 @@ func initDB(override string) error {
 PRAGMA journal_mode=WAL;
 PRAGMA synchronous=NORMAL;
 CREATE TABLE IF NOT EXISTS seen_urls (url TEXT PRIMARY KEY, first_seen TEXT NOT NULL, last_seen TEXT NOT NULL, sighting_count INTEGER NOT NULL DEFAULT 1);
+CREATE TABLE IF NOT EXISTS feed_http_cache (url TEXT PRIMARY KEY, etag TEXT, last_modified TEXT, updated_at TEXT NOT NULL);
 CREATE TABLE IF NOT EXISTS monitor_runs (id INTEGER PRIMARY KEY, monitor_name TEXT, profile_json TEXT, query_json TEXT NOT NULL, generated_at TEXT NOT NULL, signal_count INTEGER NOT NULL DEFAULT 0, created_at TEXT DEFAULT (datetime('now')));
 CREATE TABLE IF NOT EXISTS signal_snapshots (id INTEGER PRIMARY KEY, run_id INTEGER REFERENCES monitor_runs(id) ON DELETE CASCADE, signal_id TEXT NOT NULL, title TEXT NOT NULL, rank_score REAL NOT NULL, payload_json TEXT NOT NULL, created_at TEXT DEFAULT (datetime('now')));
 CREATE INDEX IF NOT EXISTS idx_signal_snapshots_run ON signal_snapshots(run_id);
@@ -89,6 +90,60 @@ func seenStatus(urls []string, override string) (map[string]map[string]any, erro
 		out[u] = map[string]any{"first_seen": first, "last_seen": last, "sighting_count": count}
 	}
 	return out, rows.Err()
+}
+
+type feedHTTPState struct {
+	ETag         string
+	LastModified string
+}
+
+func feedHTTPStateFor(feedURL, override string) (feedHTTPState, error) {
+	db, err := openDB(override)
+	if err != nil {
+		return feedHTTPState{}, err
+	}
+	defer db.Close()
+	var etag, lastModified sql.NullString
+	err = db.QueryRow("SELECT etag, last_modified FROM feed_http_cache WHERE url = ?", feedURL).Scan(&etag, &lastModified)
+	if err == sql.ErrNoRows {
+		return feedHTTPState{}, nil
+	}
+	if err != nil {
+		return feedHTTPState{}, err
+	}
+	state := feedHTTPState{}
+	if etag.Valid {
+		state.ETag = etag.String
+	}
+	if lastModified.Valid {
+		state.LastModified = lastModified.String
+	}
+	return state, nil
+}
+
+func saveFeedHTTPState(feedURL string, state feedHTTPState, override string) error {
+	if state.ETag == "" && state.LastModified == "" {
+		return clearFeedHTTPState(feedURL, override)
+	}
+	db, err := openDB(override)
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	_, err = db.Exec(`INSERT INTO feed_http_cache (url, etag, last_modified, updated_at) VALUES (?, ?, ?, ?)
+ON CONFLICT(url) DO UPDATE SET etag = excluded.etag, last_modified = excluded.last_modified, updated_at = excluded.updated_at`, feedURL, nullSQLString(state.ETag), nullSQLString(state.LastModified), now)
+	return err
+}
+
+func clearFeedHTTPState(feedURL, override string) error {
+	db, err := openDB(override)
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+	_, err = db.Exec("DELETE FROM feed_http_cache WHERE url = ?", feedURL)
+	return err
 }
 
 func recordRun(monitorName string, profile map[string]any, queries []string, signals []map[string]any, seenURLs []string, override string) (int64, error) {

--- a/apps/cli/cmd/newsjack/detector_test.go
+++ b/apps/cli/cmd/newsjack/detector_test.go
@@ -3,6 +3,10 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 )
@@ -212,5 +216,157 @@ func TestParseNewsResponsePreservesPublicationMetadata(t *testing.T) {
 	}
 	if metadata["raw_source"] != "Example" {
 		t.Fatalf("raw_source=%v, want Example", metadata["raw_source"])
+	}
+}
+
+func TestRSSFeedCatalogAuditMetadata(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join(repoRootForTest(t), "skills", "newsjack-detector", "references", "rss-feeds.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	type catalogGate struct {
+		RequiredBeats []string `json:"required_beats"`
+	}
+	type catalogFeed struct {
+		ID      string       `json:"id"`
+		Name    string       `json:"name"`
+		URL     string       `json:"url"`
+		Tier    string       `json:"tier"`
+		Beats   []string     `json:"beats"`
+		UseWhen string       `json:"use_when"`
+		Notes   string       `json:"notes"`
+		Gate    *catalogGate `json:"gate"`
+	}
+	var catalog struct {
+		Version   int `json:"version"`
+		Changelog []struct {
+			Version int    `json:"version"`
+			Date    string `json:"date"`
+			Summary string `json:"summary"`
+		} `json:"changelog"`
+		DefaultFeeds []string      `json:"default_feeds"`
+		Feeds        []catalogFeed `json:"feeds"`
+	}
+	if err := json.Unmarshal(data, &catalog); err != nil {
+		t.Fatal(err)
+	}
+	if catalog.Version != 2 {
+		t.Fatalf("version=%d, want 2", catalog.Version)
+	}
+	if len(catalog.Changelog) == 0 || catalog.Changelog[0].Version != 2 || catalog.Changelog[0].Date != "2026-05-26" {
+		t.Fatalf("missing v2 changelog: %#v", catalog.Changelog)
+	}
+	if len(catalog.DefaultFeeds) != 2 || catalog.DefaultFeeds[0] != "techmeme" || catalog.DefaultFeeds[1] != "google-news-technology" {
+		t.Fatalf("default_feeds=%v, want techmeme/google-news-technology", catalog.DefaultFeeds)
+	}
+
+	feeds := map[string]catalogFeed{}
+	allowedTiers := stringSet([]string{"primary", "demoted", "gated"})
+	for _, feed := range catalog.Feeds {
+		if !allowedTiers[feed.Tier] {
+			t.Fatalf("feed %s has invalid tier %q", feed.ID, feed.Tier)
+		}
+		if feed.ID == "" || feed.Name == "" || feed.URL == "" || len(feed.Beats) == 0 || feed.UseWhen == "" || feed.Notes == "" {
+			t.Fatalf("feed %s missing required catalog fields: %#v", feed.ID, feed)
+		}
+		if feed.Tier == "gated" && (feed.Gate == nil || len(feed.Gate.RequiredBeats) == 0) {
+			t.Fatalf("gated feed %s missing gate.required_beats", feed.ID)
+		}
+		feeds[feed.ID] = feed
+	}
+	for _, dropped := range []string{"google-news-science", "google-news-health"} {
+		if _, ok := feeds[dropped]; ok {
+			t.Fatalf("%s should have been removed", dropped)
+		}
+	}
+	for _, id := range []string{"google-news-world", "google-news-us", "google-news-business"} {
+		if feeds[id].Tier != "demoted" {
+			t.Fatalf("%s tier=%q, want demoted", id, feeds[id].Tier)
+		}
+	}
+	for _, id := range []string{"memeorandum", "mediagazer"} {
+		if feeds[id].Tier != "gated" || feeds[id].Gate == nil || len(feeds[id].Gate.RequiredBeats) == 0 {
+			t.Fatalf("%s gate missing: %#v", id, feeds[id])
+		}
+	}
+	wantPrimary := map[string]string{
+		"stat-news":      "https://www.statnews.com/feed/",
+		"fda-press":      "https://www.fda.gov/about-fda/contact-fda/stay-informed/rss-feeds/press-releases/rss.xml",
+		"cms-press":      "https://www.cms.gov/newsroom/rss-feeds",
+		"endpoints-news": "https://endpts.com/feed/",
+		"sec-edgar-8k":   "https://www.sec.gov/cgi-bin/browse-edgar?action=getcurrent&type=8-K&output=atom",
+	}
+	for id, url := range wantPrimary {
+		feed, ok := feeds[id]
+		if !ok {
+			t.Fatalf("missing feed %s", id)
+		}
+		if feed.Tier != "primary" {
+			t.Fatalf("%s tier=%q, want primary", id, feed.Tier)
+		}
+		if feed.URL != url {
+			t.Fatalf("%s url=%q, want %q", id, feed.URL, url)
+		}
+	}
+}
+
+func TestCollectFeedConditionalGETPersistsETag(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if r.Header.Get("User-Agent") == "" {
+			t.Fatal("missing User-Agent")
+		}
+		switch requests {
+		case 1:
+			if got := r.Header.Get("If-None-Match"); got != "" {
+				t.Fatalf("first request If-None-Match=%q, want empty", got)
+			}
+			w.Header().Set("Content-Type", "application/rss+xml")
+			w.Header().Set("ETag", "abc")
+			_, _ = w.Write([]byte(`<?xml version="1.0"?><rss><channel><title>Test Feed</title><item><title>First item</title><link>https://example.com/first</link><description>Body</description><pubDate>Tue, 26 May 2026 13:00:00 GMT</pubDate></item></channel></rss>`))
+		case 2:
+			if got := r.Header.Get("If-None-Match"); got != "abc" {
+				t.Fatalf("second request If-None-Match=%q, want abc", got)
+			}
+			w.WriteHeader(http.StatusNotModified)
+			_, _ = w.Write([]byte(`<not-rss>`))
+		default:
+			t.Fatalf("unexpected request %d", requests)
+		}
+	}))
+	defer server.Close()
+
+	store := filepath.Join(t.TempDir(), "monitor.db")
+	items, debug, errText := collectFeedWithStore(server.URL, 10, store, true)
+	if errText != "" {
+		t.Fatalf("first fetch error=%s", errText)
+	}
+	if len(items) != 1 {
+		t.Fatalf("first fetch items=%d, want 1", len(items))
+	}
+	if debug["status"] != "parsed" {
+		t.Fatalf("first fetch debug=%#v, want parsed", debug)
+	}
+	state, err := feedHTTPStateFor(server.URL, store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state.ETag != "abc" {
+		t.Fatalf("stored etag=%q, want abc", state.ETag)
+	}
+
+	items, debug, errText = collectFeedWithStore(server.URL, 10, store, true)
+	if errText != "" {
+		t.Fatalf("second fetch error=%s", errText)
+	}
+	if len(items) != 0 {
+		t.Fatalf("second fetch items=%d, want 0", len(items))
+	}
+	if debug["status"] != "not_modified" || debug["not_modified"] != true {
+		t.Fatalf("second fetch debug=%#v, want not_modified", debug)
+	}
+	if requests != 2 {
+		t.Fatalf("requests=%d, want 2", requests)
 	}
 }

--- a/apps/cli/cmd/newsjack/http.go
+++ b/apps/cli/cmd/newsjack/http.go
@@ -43,22 +43,43 @@ func httpJSON(method, rawURL string, headers map[string]string, body any, timeou
 }
 
 func httpGetRaw(rawURL string, headers map[string]string, timeout time.Duration) (string, error) {
-	req, err := http.NewRequest("GET", rawURL, nil)
+	resp, err := httpGetRawResponse(rawURL, headers, timeout)
 	if err != nil {
 		return "", err
+	}
+	if resp.StatusCode >= 400 {
+		return "", fmt.Errorf("HTTP %d: %s", resp.StatusCode, truncate(resp.Body, 300))
+	}
+	return resp.Body, nil
+}
+
+type httpRawResponse struct {
+	StatusCode int
+	Header     http.Header
+	Body       string
+}
+
+func httpGetRawResponse(rawURL string, headers map[string]string, timeout time.Duration) (httpRawResponse, error) {
+	req, err := http.NewRequest("GET", rawURL, nil)
+	if err != nil {
+		return httpRawResponse{}, err
 	}
 	for k, v := range headers {
 		req.Header.Set(k, v)
 	}
+	setDefaultUserAgent(req)
 	client := &http.Client{Timeout: timeout}
 	resp, err := client.Do(req)
 	if err != nil {
-		return "", err
+		return httpRawResponse{}, err
 	}
 	defer resp.Body.Close()
 	data, _ := io.ReadAll(resp.Body)
-	if resp.StatusCode >= 400 {
-		return "", fmt.Errorf("HTTP %d: %s", resp.StatusCode, truncate(string(data), 300))
+	return httpRawResponse{StatusCode: resp.StatusCode, Header: resp.Header.Clone(), Body: string(data)}, nil
+}
+
+func setDefaultUserAgent(req *http.Request) {
+	if req.Header.Get("User-Agent") == "" {
+		req.Header.Set("User-Agent", fmt.Sprintf("Mozilla/5.0 (compatible; newsjack.sh/%s; +https://newsjack.sh)", version))
 	}
-	return string(data), nil
 }

--- a/skills/newsjack-detector/SKILL.md
+++ b/skills/newsjack-detector/SKILL.md
@@ -102,6 +102,7 @@ Preserve story-origin research in `origin_findings.json`. `newsjack origin-apply
 For the beta fixture, `fixtures/newsjack-detector-agent/scripts/hourly-run-all.sh` runs every configured profile and writes `index.md` plus a beta-facing `run.md` in each profile folder.
 
 Profiles may include `feed_urls`. Those feeds are used by default. The shipped catalog at `references/rss-feeds.json` is the starting point for setup and onboarding.
+Catalog entries now carry a `tier` (`primary`, `demoted`, or `gated`); the engine logs the matched tier for each fetched catalog feed in debug output.
 
 Profiles may also include `search_terms`. When present, the engine uses them for retrieval instead of raw `topics + competitors`. Keep `topics`, `competitors`, and `standing` as canonical context for matching and downstream LLM judgment; use `search_terms` for qualified retrieval strings such as `Ada customer service`, `Aura identity theft`, or `Good Move cash house buyer`.
 

--- a/skills/newsjack-detector/references/rss-feeds.json
+++ b/skills/newsjack-detector/references/rss-feeds.json
@@ -1,16 +1,29 @@
 {
-  "version": 1,
+  "version": 2,
+  "changelog": [
+    {
+      "version": 2,
+      "date": "2026-05-26",
+      "summary": "Adds feed tiers and gates, replaces broad Google health/science feeds with vertical-authority health sources, adds EDGAR 8-K Atom, and shortens default feeds."
+    }
+  ],
   "default_feeds": [
     "techmeme",
-    "google-news-technology",
-    "google-news-business"
+    "google-news-technology"
   ],
   "feeds": [
     {
       "id": "techmeme",
       "name": "Techmeme",
       "url": "https://www.techmeme.com/feed.xml",
-      "beats": ["technology", "ai", "startups", "venture", "platforms"],
+      "tier": "primary",
+      "beats": [
+        "technology",
+        "ai",
+        "startups",
+        "venture",
+        "platforms"
+      ],
       "use_when": "Default for technology, AI, SaaS, startup, platform, and developer-tool profiles.",
       "notes": "Curated tech/business front page. High precision for major tech stories."
     },
@@ -18,7 +31,13 @@
       "id": "google-news-technology",
       "name": "Google News Technology",
       "url": "https://news.google.com/rss/headlines/section/topic/TECHNOLOGY?hl=en-US&gl=US&ceid=US:en",
-      "beats": ["technology", "ai", "consumer tech", "platforms"],
+      "tier": "primary",
+      "beats": [
+        "technology",
+        "ai",
+        "consumer tech",
+        "platforms"
+      ],
       "use_when": "Use as a broad technology backstop when Techmeme may be too narrow.",
       "notes": "Broader and noisier than Techmeme."
     },
@@ -26,63 +45,101 @@
       "id": "google-news-business",
       "name": "Google News Business",
       "url": "https://news.google.com/rss/headlines/section/topic/BUSINESS?hl=en-US&gl=US&ceid=US:en",
-      "beats": ["business", "markets", "finance", "startups", "economy"],
-      "use_when": "Use for business, funding, M&A, markets, commercial real estate, and executive-change profiles.",
-      "notes": "Broad business feed; requires stricter relevance filtering."
-    },
-    {
-      "id": "google-news-science",
-      "name": "Google News Science",
-      "url": "https://news.google.com/rss/headlines/section/topic/SCIENCE?hl=en-US&gl=US&ceid=US:en",
-      "beats": ["science", "research", "space", "climate", "biotech"],
-      "use_when": "Use for research, biotech, climate, space, and science-led profiles.",
-      "notes": "Often useful for research-backed companies, less useful for generic SaaS."
-    },
-    {
-      "id": "google-news-health",
-      "name": "Google News Health",
-      "url": "https://news.google.com/rss/headlines/section/topic/HEALTH?hl=en-US&gl=US&ceid=US:en",
-      "beats": ["health", "healthcare", "biotech", "public health"],
-      "use_when": "Use for healthcare, digital health, biotech, pharma, and patient-safety profiles.",
-      "notes": "High brand-safety risk; tragedy/human-suffering blocks still apply."
+      "tier": "demoted",
+      "beats": [
+        "business",
+        "markets",
+        "finance",
+        "startups",
+        "economy"
+      ],
+      "use_when": "Use for business, funding, M&A, markets, commercial real estate, and executive-change profiles only when a better vertical source does not fit.",
+      "notes": "Broad business feed; requires stricter relevance filtering. Broad feed, expect noise."
     },
     {
       "id": "google-news-us",
       "name": "Google News U.S.",
       "url": "https://news.google.com/rss/headlines/section/topic/NATION?hl=en-US&gl=US&ceid=US:en",
-      "beats": ["us", "policy", "regulation", "courts"],
-      "use_when": "Use when U.S. policy, courts, or national regulation are central to the client.",
-      "notes": "Broad and noisy. Avoid unless the client has policy standing."
+      "tier": "demoted",
+      "beats": [
+        "us",
+        "policy",
+        "regulation",
+        "courts"
+      ],
+      "use_when": "Use when U.S. policy, courts, or national regulation are central to the client and a better vertical source does not fit.",
+      "notes": "Broad and noisy. Avoid unless the client has policy standing. Broad feed, expect noise."
     },
     {
       "id": "google-news-world",
       "name": "Google News World",
       "url": "https://news.google.com/rss/headlines/section/topic/WORLD?hl=en-US&gl=US&ceid=US:en",
-      "beats": ["world", "geopolitics", "international business", "supply chain"],
-      "use_when": "Use for geopolitics, supply chain, global markets, and international policy profiles.",
-      "notes": "High tragedy/war exposure. Use only with direct public-interest standing."
+      "tier": "demoted",
+      "beats": [
+        "world",
+        "geopolitics",
+        "international business",
+        "supply chain"
+      ],
+      "use_when": "Use for geopolitics, supply chain, global markets, and international policy profiles only when the client has direct standing.",
+      "notes": "High tragedy/war exposure. Use only with direct public-interest standing. Broad feed, expect noise."
     },
     {
       "id": "memeorandum",
       "name": "Memeorandum",
       "url": "https://www.memeorandum.com/feed.xml",
-      "beats": ["politics", "policy", "media", "washington"],
-      "use_when": "Use for U.S. politics, public affairs, policy, and media-politics profiles.",
+      "tier": "gated",
+      "beats": [
+        "politics",
+        "policy",
+        "media",
+        "washington"
+      ],
+      "gate": {
+        "required_beats": [
+          "regtech",
+          "policy",
+          "public affairs"
+        ]
+      },
+      "use_when": "Use for U.S. politics, public affairs, policy, and media-politics profiles when the client's beat overlaps the gate.",
       "notes": "Politically sensitive. Usually not appropriate for normal company newsjacking."
     },
     {
       "id": "mediagazer",
       "name": "Mediagazer",
       "url": "https://www.mediagazer.com/feed.xml",
-      "beats": ["media", "publishing", "journalism", "creator economy"],
-      "use_when": "Use for media, journalism, publishing, creator, and ad-tech profiles.",
+      "tier": "gated",
+      "beats": [
+        "media",
+        "publishing",
+        "journalism",
+        "creator economy"
+      ],
+      "gate": {
+        "required_beats": [
+          "media",
+          "journalism",
+          "publishing",
+          "agency",
+          "creator economy"
+        ]
+      },
+      "use_when": "Use for media, journalism, publishing, creator, and agency profiles when the client's beat overlaps the gate.",
       "notes": "Good companion to Techmeme for media-industry clients."
     },
     {
       "id": "ftc-press",
       "name": "FTC Press Releases",
       "url": "https://www.ftc.gov/news-events/news/press-releases/rss.xml",
-      "beats": ["consumer protection", "antitrust", "privacy", "ai regulation", "advertising"],
+      "tier": "primary",
+      "beats": [
+        "consumer protection",
+        "antitrust",
+        "privacy",
+        "ai regulation",
+        "advertising"
+      ],
       "use_when": "Use for privacy, consumer protection, advertising claims, antitrust, and AI compliance profiles.",
       "notes": "Official source; slow but high authority."
     },
@@ -90,17 +147,107 @@
       "id": "sec-press",
       "name": "SEC Press Releases",
       "url": "https://www.sec.gov/news/pressreleases.rss",
-      "beats": ["finance", "public companies", "securities", "crypto", "compliance"],
+      "tier": "primary",
+      "beats": [
+        "finance",
+        "public companies",
+        "securities",
+        "crypto",
+        "compliance"
+      ],
       "use_when": "Use for fintech, crypto, public-company compliance, and investor-market profiles.",
       "notes": "Official source; useful for same-day expert commentary."
+    },
+    {
+      "id": "sec-edgar-8k",
+      "name": "SEC EDGAR Current 8-K Filings",
+      "url": "https://www.sec.gov/cgi-bin/browse-edgar?action=getcurrent&type=8-K&output=atom",
+      "tier": "primary",
+      "beats": [
+        "finance",
+        "public companies",
+        "securities",
+        "8-k",
+        "material events"
+      ],
+      "use_when": "Use for fintech, crypto, public-company compliance, and any profile that benefits from being early on material-events disclosures.",
+      "notes": "Real-time 8-K filings stream. High volume, requires keyword/ticker filtering by the skill. Pair with `sec-press` for press-release context."
     },
     {
       "id": "govuk-news",
       "name": "GOV.UK News",
       "url": "https://www.gov.uk/search/news-and-communications.atom",
-      "beats": ["uk", "policy", "regulation", "property", "business"],
+      "tier": "primary",
+      "beats": [
+        "uk",
+        "policy",
+        "regulation",
+        "property",
+        "business"
+      ],
       "use_when": "Use for UK policy, regulated industries, property, and public-sector profiles.",
       "notes": "Broad official UK feed; requires topic filtering by the skill."
+    },
+    {
+      "id": "stat-news",
+      "name": "STAT News",
+      "url": "https://www.statnews.com/feed/",
+      "tier": "primary",
+      "beats": [
+        "healthcare",
+        "biotech",
+        "pharma",
+        "life sciences",
+        "public health"
+      ],
+      "use_when": "Use for healthcare, biotech, pharma, life-sciences, public-health, and medical-research profiles.",
+      "notes": "Vertical healthcare newsroom with stronger editorial authority than broad Google News health feeds."
+    },
+    {
+      "id": "fda-press",
+      "name": "FDA Press Releases",
+      "url": "https://www.fda.gov/about-fda/contact-fda/stay-informed/rss-feeds/press-releases/rss.xml",
+      "tier": "primary",
+      "beats": [
+        "healthcare",
+        "pharma",
+        "biotech",
+        "medical devices",
+        "drug approvals",
+        "public health"
+      ],
+      "use_when": "Use for pharma, biotech, medtech, patient-safety, drug-approval, food-safety, and FDA-regulated profiles.",
+      "notes": "Official FDA press-release feed. High authority; pair with STAT or Endpoints for industry reaction."
+    },
+    {
+      "id": "cms-press",
+      "name": "CMS Newsroom Press Releases",
+      "url": "https://www.cms.gov/newsroom/rss-feeds",
+      "tier": "primary",
+      "beats": [
+        "healthcare",
+        "medicare",
+        "medicaid",
+        "health policy",
+        "health insurance"
+      ],
+      "use_when": "Use for Medicare, Medicaid, health-policy, payer, provider, and health-insurance profiles.",
+      "notes": "Official CMS newsroom RSS feed. Includes press releases and related newsroom items; filter by client beat and CMS context."
+    },
+    {
+      "id": "endpoints-news",
+      "name": "Endpoints News",
+      "url": "https://endpts.com/feed/",
+      "tier": "primary",
+      "beats": [
+        "biotech",
+        "pharma",
+        "drug development",
+        "life sciences",
+        "healthcare business"
+      ],
+      "use_when": "Use for biotech, pharma, drug-development, life-sciences funding, and healthcare-business profiles.",
+      "notes": "Biopharma industry feed with deal, trial, executive, and regulatory context. Requires relevance filtering for company-specific profiles."
     }
   ]
 }

--- a/skills/newsjack-setup/SKILL.md
+++ b/skills/newsjack-setup/SKILL.md
@@ -41,13 +41,19 @@ General tragedy and human-suffering exclusions are not profile fields. Those liv
 
 Read `../newsjack-detector/references/rss-feeds.json` before selecting feeds.
 
-Use the catalog as the default source of feed choices. Pick feeds by beat:
+Use the catalog as the default source of feed choices. Pick feeds by beat and tier:
+
+- Prefer `primary` feeds that match the profile's beat.
+- Pick `demoted` feeds only when nothing better matches the client's beat, and warn the user: "Broad feed, expect noise".
+- Pick `gated` feeds only if the client's beat overlaps the feed's `gate.required_beats` array.
+
+Beat cheat sheet:
 
 - Tech/AI/SaaS/startups: `techmeme`, `google-news-technology`, `google-news-business`
 - Consumer privacy/data brokers: `ftc-press`, `google-news-technology`, `google-news-us`
 - UK property/regulation: `govuk-news`, UK Google News Business if supplied or manually selected
-- Healthcare/biotech: `google-news-health`, `google-news-science`
-- Finance/crypto/public-company compliance: `sec-press`, `google-news-business`
+- Healthcare/biotech/pharma: `stat-news`, `fda-press`, `cms-press`, `endpoints-news`
+- Public-company compliance / finance: `sec-press`, `sec-edgar-8k`
 - Media/publishing: `mediagazer`, `techmeme`
 - U.S. policy/public affairs: `memeorandum`, `google-news-us`
 


### PR DESCRIPTION
## Summary

### A. Catalog
- Bumped `skills/newsjack-detector/references/rss-feeds.json` to version 2 with a changelog.
- Removed `google-news-science` and `google-news-health`.
- Added `stat-news`, `fda-press`, `cms-press`, `endpoints-news`, and `sec-edgar-8k`.
- Added `tier` to every feed, demoted broad Google News feeds, gated Memeorandum/Mediagazer with `gate.required_beats`, and shortened `default_feeds` to `techmeme` + `google-news-technology`.

### B-C. Skills
- Updated setup guidance to prefer `primary`, warn on `demoted`, and require beat overlap for `gated` feeds.
- Updated the setup beat cheat sheet for healthcare/biotech/pharma and public-company compliance/finance.
- Added detector prose noting catalog feed tiers and debug tier logging.

### D. RSS Fetcher
- Added per-feed HTTP validator state in the existing detector store via `feed_http_cache`.
- Sends `If-None-Match` and `If-Modified-Since` when cached validators exist.
- Treats `304 Not Modified` as no new feed items and skips parsing.
- Stores fresh `ETag` / `Last-Modified` on `200 OK`, and clears stale validator state when a `200 OK` response omits validators.
- Adds an identifying RSS fetch User-Agent: `Mozilla/5.0 (compatible; newsjack.sh/<version>; +https://newsjack.sh)`.

### E. Tests
- Added a catalog contract test for version 2, tier/gate fields, removed Google feeds, defaults, and new entries.
- Added a conditional GET test with a stub server returning `ETag: abc` then `304` when `If-None-Match: abc` is sent.

## Feed URL Verification

- STAT: `curl -sI https://www.statnews.com/feed/` -> `HTTP/2 200`, `content-type: application/rss+xml; charset=UTF-8`
- FDA: `curl -sI https://www.fda.gov/about-fda/contact-fda/stay-informed/rss-feeds/press-releases/rss.xml` -> `HTTP/2 200`, `content-type: application/rss+xml; charset=utf-8`
- CMS: `curl -sI https://www.cms.gov/newsroom/rss-feeds` -> `HTTP/2 200`, `content-type: application/rss+xml; charset=utf-8`
  - Note: the requested `https://www.cms.gov/newsroom/press-releases/rss` route returned 404, so this uses the working CMS newsroom RSS endpoint.
- Endpoints: `curl -sIL -A 'Mozilla/5.0 (compatible; newsjack.sh/0.2.0-go; +https://newsjack.sh)' https://endpts.com/feed/` -> `301` to `https://endpoints.news/feed/`, final `HTTP/2 200`, `content-type: application/rss+xml; charset=UTF-8`
- SEC EDGAR 8-K: `curl -sI -A 'newsjack.sh/0.2.0-go (+https://newsjack.sh)' 'https://www.sec.gov/cgi-bin/browse-edgar?action=getcurrent&type=8-K&output=atom'` -> `HTTP/2 200`, `content-type: application/atom+xml`

## Related

Dossier: `~/Documents/Obsidian/elvis/projects/newsjack-sh/research/google-trends/dossier-2026-05-26.md`

Coordination note: this branch does not touch the separate `google_trends` lane work.

## Validation

```bash
$ cd apps/cli && go test ./... && go build ./...
ok  	github.com/elvisun/newsjack/apps/cli/cmd/newsjack	(cached)
# go build passed with no output
```

```bash
$ cd apps/site && pnpm lint && pnpm test
> @newsjack/site@0.1.0 lint /Users/elvissun/Documents/GitHub/newsjack-worktrees/newsjack-feed-audit/apps/site
> eslint . --max-warnings=0

> @newsjack/site@0.1.0 test /Users/elvissun/Documents/GitHub/newsjack-worktrees/newsjack-feed-audit/apps/site
> node --test

TAP version 13
1..0
# tests 0
# suites 0
# pass 0
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 6.726125
```

```bash
$ git diff --check
# no output
```
