### PR TITLE
onboarding: jitter hourly cron minute to avoid top-of-hour stampede

### DIFF
--- a/apps/cli/cmd/newsjack/monitor.go
+++ b/apps/cli/cmd/newsjack/monitor.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"hash/fnv"
 	"io"
 	"os"
 	"os/exec"
@@ -376,7 +377,7 @@ func launchSetupAgent(runtime, prompt string, stdin io.Reader, stdout, stderr io
 }
 
 func setupAgentPrompt(scheduleRuntime string) string {
-	return fmt.Sprintf("Use the installed Newsjack setup skill (newsjack-setup) to set up an hourly monitor for my company. Install the schedule in %s, not system cron. Ask only for facts you cannot infer safely. Save the monitor profile with `newsjack monitor init`, run `newsjack monitor test <slug> --mock`, and print the final run.md and schedule paths.", runtimeLabel(scheduleRuntime))
+	return fmt.Sprintf("Use the installed Newsjack setup skill (newsjack-setup) to set up an hourly monitor for my company. Install the schedule in %s, not system cron. Use deterministic cron jitter from the monitor slug: minute=(fnv32a(slug)%%59)+1, never minute 0. Ask only for facts you cannot infer safely. Save the monitor profile with `newsjack monitor init`, run `newsjack monitor test <slug> --mock`, and print the final run.md and schedule paths.", runtimeLabel(scheduleRuntime))
 }
 
 func printRuntimeList(stdout io.Writer) {
@@ -880,16 +881,18 @@ func cmdMonitorSchedule(args []string, stdout, stderr io.Writer) int {
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return fail(stderr, err)
 	}
+	suggestedMinute := suggestedScheduleMinute(slug)
 	payload := map[string]any{
-		"slug":           slug,
-		"runtime":        runtime,
-		"every":          *every,
-		"system_cron":    false,
-		"schedule_path":  monitorSchedulePath(slug),
-		"instructions":   scheduleInstructions(slug, runtime, *every),
-		"installed_at":   time.Now().UTC().Format(time.RFC3339Nano),
-		"run_command":    fmt.Sprintf("newsjack monitor run %s", shellQuote(slug)),
-		"artifact_scope": "agent_harness",
+		"slug":             slug,
+		"runtime":          runtime,
+		"every":            *every,
+		"suggested_minute": suggestedMinute,
+		"system_cron":      false,
+		"schedule_path":    monitorSchedulePath(slug),
+		"instructions":     scheduleInstructions(slug, runtime, *every),
+		"installed_at":     time.Now().UTC().Format(time.RFC3339Nano),
+		"run_command":      fmt.Sprintf("newsjack monitor run %s", shellQuote(slug)),
+		"artifact_scope":   "agent_harness",
 	}
 	if err := os.WriteFile(monitorScheduleJSONPath(slug), marshalJSON(payload), 0o644); err != nil {
 		return fail(stderr, err)
@@ -1112,24 +1115,37 @@ func selectScheduleRuntime(raw string) string {
 	}
 }
 
+func suggestedScheduleMinute(slug string) int {
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(slugify(slug)))
+	return int(h.Sum32()%59) + 1
+}
+
 func scheduleInstructions(slug, runtime, every string) string {
-	return fmt.Sprintf("Every %s, run `newsjack monitor run %s` inside %s, then use the installed newsjack-detector skill to complete LLM analysis and rerender run.md.", every, shellQuote(slug), runtime)
+	minute := suggestedScheduleMinute(slug)
+	return fmt.Sprintf("Every %s, run `newsjack monitor run %s` inside %s, then use the installed newsjack-detector skill to complete LLM analysis and rerender run.md. When installing the recurring schedule, pick a stable random minute in [1, 59], never minute 0; suggested_minute is %d from `minute = (fnv32a(slug) %% 59) + 1`. Apply the same jitter to daily and weekly schedules, and avoid common top-of-hour, midnight, and Monday-09:00 defaults. This spreads load across the Newsjack/Medialyst backend so we don't get a thundering-herd spike at the top of every hour.", every, shellQuote(slug), runtime, minute)
 }
 
 func renderScheduleMarkdown(payload map[string]any) string {
-	return fmt.Sprintf(`# Newsjack Agent Schedule
-
-- Monitor: %s
-- Runtime: %s
-- Every: %s
-- System cron installed: false
-
-%s
-
-This is an agent-harness schedule contract. Do not install this monitor in
-system cron for v1; the run must trigger the agent harness so the LLM analysis
-step can operate on the detector artifacts.
-`, payload["slug"], payload["runtime"], payload["every"], payload["instructions"])
+	return fmt.Sprintf("# Newsjack Agent Schedule\n\n"+
+		"- Monitor: %s\n"+
+		"- Runtime: %s\n"+
+		"- Every: %s\n"+
+		"- Suggested minute: %v\n"+
+		"- System cron installed: false\n\n"+
+		"%s\n\n"+
+		"## Cron Jitter\n\n"+
+		"Pick a stable random minute in [1, 59], never minute 0. Use\n"+
+		"`minute = (fnv32a(slug) %% 59) + 1`; this schedule suggests minute %v for\n"+
+		"`%s`. For hourly schedules, use that minute instead of the top of the hour.\n"+
+		"For daily or weekly schedules, use the same minute rule and avoid common\n"+
+		"midnight or Monday-09:00 defaults. This spreads load across the\n"+
+		"Newsjack/Medialyst backend so we don't get a thundering-herd spike at the top\n"+
+		"of every hour.\n\n"+
+		"This is an agent-harness schedule contract. Do not install this monitor in\n"+
+		"system cron for v1; the run must trigger the agent harness so the LLM analysis\n"+
+		"step can operate on the detector artifacts.\n",
+		payload["slug"], payload["runtime"], payload["every"], payload["suggested_minute"], payload["instructions"], payload["suggested_minute"], payload["slug"])
 }
 
 func slugify(value string) string {

--- a/apps/cli/cmd/newsjack/monitor_test.go
+++ b/apps/cli/cmd/newsjack/monitor_test.go
@@ -82,6 +82,9 @@ func TestMonitorInitTestStatusAndSchedule(t *testing.T) {
 		if schedule["system_cron"] != false {
 			t.Fatalf("system_cron=%v, want false", schedule["system_cron"])
 		}
+		if schedule["suggested_minute"] != float64(suggestedScheduleMinute("fixture-coffee")) {
+			t.Fatalf("suggested_minute=%v, want %d", schedule["suggested_minute"], suggestedScheduleMinute("fixture-coffee"))
+		}
 		schedulePath := stringValue(schedule["schedule_path"])
 		scheduleBody, readErr := os.ReadFile(schedulePath)
 		if readErr != nil {
@@ -89,6 +92,9 @@ func TestMonitorInitTestStatusAndSchedule(t *testing.T) {
 		}
 		if strings.Contains(string(scheduleBody), "crontab") || strings.Contains(string(scheduleBody), "launchd") || strings.Contains(string(scheduleBody), "systemd") {
 			t.Fatalf("schedule should not include system scheduler instructions:\n%s", scheduleBody)
+		}
+		if !strings.Contains(string(scheduleBody), "never minute 0") {
+			t.Fatalf("schedule should include cron jitter guidance:\n%s", scheduleBody)
 		}
 
 		out.Reset()
@@ -108,6 +114,32 @@ func TestMonitorInitTestStatusAndSchedule(t *testing.T) {
 			t.Fatalf("latest_run_markdown missing: %#v", status)
 		}
 	})
+}
+
+func TestSuggestedScheduleMinute(t *testing.T) {
+	slugs := []string{
+		"fixture-coffee",
+		"medialyst",
+		"acme-corp",
+		"newsjack",
+		"localfalcon",
+		"property-saviour",
+		"Blue Bottle Coffee",
+		"",
+	}
+	for _, slug := range slugs {
+		first := suggestedScheduleMinute(slug)
+		second := suggestedScheduleMinute(slug)
+		if first != second {
+			t.Fatalf("suggestedScheduleMinute(%q)=%d then %d, want deterministic", slug, first, second)
+		}
+		if first < 1 || first > 59 {
+			t.Fatalf("suggestedScheduleMinute(%q)=%d, want [1, 59]", slug, first)
+		}
+		if first == 0 {
+			t.Fatalf("suggestedScheduleMinute(%q)=0, want nonzero", slug)
+		}
+	}
 }
 
 func TestSetupDefaultsToClaudeCode(t *testing.T) {

--- a/docs/installation-path.md
+++ b/docs/installation-path.md
@@ -212,6 +212,11 @@ newsjack monitor status <slug>
 newsjack monitor open <slug>
 ```
 
+`monitor schedule` should tell the agent to use deterministic cron jitter for
+the recurring job. Pick a stable random minute in `[1, 59]`, never minute `0`;
+prefer `minute = (hash(slug) % 59) + 1`, and include the suggested minute in
+the schedule JSON so reruns do not churn existing schedules.
+
 `monitor run` should write a timestamped run folder under:
 
 ```text
@@ -237,6 +242,12 @@ Preferred scheduler targets:
 - Hermes cron
 - Claude Code Routine
 - similar agent-native scheduling in a supported harness
+
+All recurring schedules must avoid common collision points such as
+`0 * * * *`, `0 0 * * *`, and `0 9 * * 1`. Use the same deterministic jitter
+rule for hourly, daily, and weekly schedules. This spreads load across the
+Newsjack/Medialyst backend so we don't get a thundering-herd spike at the top
+of every hour.
 
 System `launchd`, user `systemd`, and `crontab` are out of scope for v1
 recurring monitors. They can run the detector, but they cannot reliably trigger

--- a/harness/scripts/run-ci-installer.sh
+++ b/harness/scripts/run-ci-installer.sh
@@ -263,10 +263,11 @@ test -f "$run_md"
 grep -q "Harness Coffee Newsjack Brief" "$run_md"
 
 newsjack monitor schedule harness-coffee --runtime claude --every 1h | tee /tmp/newsjack-monitor-schedule.json
-jq -e '.system_cron == false and .runtime == "claude" and .schedule_path' /tmp/newsjack-monitor-schedule.json >/dev/null
+jq -e '.system_cron == false and .runtime == "claude" and .schedule_path and (.suggested_minute >= 1) and (.suggested_minute <= 59)' /tmp/newsjack-monitor-schedule.json >/dev/null
 schedule_md="$(jq -r '.schedule_path' /tmp/newsjack-monitor-schedule.json)"
 test -f "$schedule_md"
 ! grep -Eq 'crontab|launchd|systemd' "$schedule_md"
+grep -q 'never minute 0' "$schedule_md"
 
 newsjack monitor status harness-coffee | tee /tmp/newsjack-monitor-status.json
 jq -e '.exists == true and .run_count == 1 and .latest_run_markdown' /tmp/newsjack-monitor-status.json >/dev/null

--- a/skills/newsjack-setup/SKILL.md
+++ b/skills/newsjack-setup/SKILL.md
@@ -76,6 +76,18 @@ If the user chooses `location`, ask for target geography and save both labels an
 
 Do not make `location` the default for a generic SaaS company. Prefer `personalized` or `none` unless geography is important. If the user is unsure, choose `personalized` for founder-led/tech/media workflows and `none` for low-noise company monitoring.
 
+## Scheduling
+
+When the user opts into an hourly schedule, generate a cron expression with a stable random minute in `[1, 59]`, never `0`.
+
+Prefer deterministic jitter per monitor: `minute = (hash(slug) % 59) + 1`. Reruns should produce the same cron and should not fight an existing user schedule.
+
+Daily and weekly schedules also need jitter. Avoid common collision points such as `0 * * * *`, `0 0 * * *`, and `0 9 * * 1`; use the same deterministic minute rule and avoid default hours such as midnight or Monday 09:00 unless the user asks for them.
+
+Apply this for OpenClaw cron, Hermes cron, Claude Code Routine, Codex, and any other scheduler runtime.
+
+This spreads load across the Newsjack/Medialyst backend so we don't get a thundering-herd spike at the top of every hour.
+
 ## Process
 
 1. **Understand the company.** Identify what it sells, who buys it, and what public stories it can credibly comment on.


### PR DESCRIPTION
Newsjack onboarding and `monitor schedule` now tell agents to install recurring schedules with deterministic per-monitor jitter in minutes `[1, 59]`, never minute `0`, and include a `suggested_minute` hint from the monitor slug. This spreads hourly installs across the Newsjack/Medialyst backend instead of stampeding the top of the hour while keeping reruns stable.

Files touched:
- [x] `skills/newsjack-setup/SKILL.md`
- [x] `apps/cli/cmd/newsjack/monitor.go`
- [x] `apps/cli/cmd/newsjack/monitor_test.go`
- [x] `docs/installation-path.md`
- [x] `harness/scripts/run-ci-installer.sh`
