### PR TITLE
Add Claude Code plugin manifest

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,15 @@
+{
+  "name": "newsjack",
+  "displayName": "Newsjack",
+  "version": "0.1.0",
+  "description": "Open-source operating system for agentic PR. Skills for newsjacking, pitch critique, angle generation, media lists, and more.",
+  "author": {
+    "name": "Elvis Sun",
+    "url": "https://github.com/elvisun"
+  },
+  "repository": "https://github.com/elvisun/newsjack",
+  "homepage": "https://newsjack.sh",
+  "license": "MIT",
+  "keywords": ["pr", "newsjacking", "media", "journalism", "pitch", "comms"],
+  "mcpServers": "../.mcp.json"
+}

--- a/README.md
+++ b/README.md
@@ -184,6 +184,14 @@ Alternatively, install via npm:
 npm install -g newsjack
 ```
 
+### Install as Claude Code plugin
+
+```bash
+claude plugin install elvisun/newsjack
+```
+
+This registers all newsjack skills (`/newsjack:angle-generator`, `/newsjack:meanest-editor`, etc.) and the optional Medialyst MCP server. Run `/newsjack:newsjack-setup` to create a monitor profile.
+
 ## Repo layout
 
 ```


### PR DESCRIPTION
## Summary

- Adds `.claude-plugin/plugin.json` so the repo is installable as a Claude Code plugin via `claude plugin install elvisun/newsjack`
- Registers the existing Medialyst MCP server (`.mcp.json`) in the plugin manifest
- Skills under `skills/` are auto-discovered by Claude Code's plugin loader — no additional config needed
- Adds an "Install as Claude Code plugin" section to the README

## What the plugin exposes

| Component | Count | Details |
|-----------|-------|---------|
| Skills | 12 | angle-generator, crisis-holding, fact-check, journalist-fit-check, meanest-editor, media-list-manager, newsjack-detector, newsjack-setup, newsworthiness-check, reactive-comment, story-origin-check, voice-extractor |
| MCP servers | 1 | medialyst (HTTP, uses `headersHelper` for auth) |

## Verification

`claude plugin validate` was not available in the build environment. Manual validation:

```
=== Manifest parsed OK ===
Plugin name: newsjack
MCP config OK: ['medialyst'] servers
  Skill: angle-generator -> /newsjack:angle-generator
  Skill: crisis-holding -> /newsjack:crisis-holding
  Skill: fact-check -> /newsjack:fact-check
  Skill: journalist-fit-check -> /newsjack:journalist-fit-check
  Skill: meanest-editor -> /newsjack:meanest-editor
  Skill: media-list-manager -> /newsjack:media-list-manager
  Skill: newsjack-detector -> /newsjack:newsjack-detector
  Skill: newsjack-setup -> /newsjack:newsjack-setup
  Skill: newsworthiness-check -> /newsjack:newsworthiness-check
  Skill: reactive-comment -> /newsjack:reactive-comment
  Skill: story-origin-check -> /newsjack:story-origin-check
  Skill: voice-extractor -> /newsjack:voice-extractor
Total skills: 12

=== Plugin structure valid ===
```

To verify end-to-end in a live Claude Code session:

```bash
claude plugin install elvisun/newsjack
# or from a local checkout:
claude --plugin-dir ./newsjack
```

## Notes

- No build step required — skills are plain Markdown, the MCP server is a remote HTTP endpoint
- The Medialyst MCP server uses `headersHelper` which requires the `newsjack` CLI to be installed (`curl -fsSL newsjack.sh | sh`) for auth header injection. Users who don't need Medialyst can use all 12 skills without it
- No refactoring of existing code; manifest + README section only

## Test plan

- [ ] Run `claude plugin install elvisun/newsjack` in a fresh Claude Code session
- [ ] Confirm `/newsjack:newsjack-setup` and other skill commands appear
- [ ] Confirm `medialyst` MCP server is listed in `/mcp` (requires `newsjack login` for auth)
- [ ] Confirm no load-time errors in `/plugin` UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)