### PR TITLE
Fix detector freshness and X lanes

### DIFF
--- a/apps/cli/cmd/newsjack/detector_command.go
+++ b/apps/cli/cmd/newsjack/detector_command.go
@@ -39,6 +39,7 @@ type detectorOptions struct {
 	Store                           string
 	MonitorName                     string
 	IncludeAllScored                bool
+	ScoredOutput                    string
 	Emit                            string
 }
 
@@ -136,12 +137,13 @@ func parseDetectorRun(args []string, stderr io.Writer) (detectorOptions, int) {
 	fs.StringVar(&opts.Store, "store", "", "Override SQLite store path")
 	fs.StringVar(&opts.MonitorName, "monitor-name", "", "Monitor name")
 	fs.BoolVar(&opts.IncludeAllScored, "include-all-scored", false, "Include all scored signals in debug output")
+	fs.StringVar(&opts.ScoredOutput, "scored-output", "", "Write all scored signals to a separate JSON artifact")
 	fs.StringVar(&opts.Emit, "emit", "json", "json or brief")
 	valueFlags := stringSet([]string{
 		"topic", "profile", "sources", "feed-url", "feed-file", "depth", "lookback-days", "max-age-hours",
 		"x-news-min-profile-match", "x-posts-min-profile-match", "profile-relevance-min-profile-match",
 		"major-news-min-profile-match", "x-trends-min-profile-match", "min-queue-priority", "min-major-news",
-		"lane-caps", "limit", "store", "monitor-name", "emit",
+		"lane-caps", "limit", "store", "monitor-name", "scored-output", "emit",
 	})
 	if err := fs.Parse(reorderIntermixedFlags(args, valueFlags)); err != nil {
 		return opts, 2

--- a/apps/cli/cmd/newsjack/detector_models.go
+++ b/apps/cli/cmd/newsjack/detector_models.go
@@ -32,7 +32,54 @@ func evidenceFromMap(m map[string]any) evidenceItem {
 }
 
 func (e evidenceItem) text() string {
-	return strings.Join(nonEmpty(e.Title, e.Excerpt, e.Author, e.Container), " ")
+	return strings.Join(nonEmpty(e.Title, e.Excerpt, e.Author, e.Container, socialMetadataText(e.Metadata)), " ")
+}
+
+func (e evidenceItem) clusterText() string {
+	return strings.Join(nonEmpty(e.Title, e.Excerpt, socialMetadataText(e.Metadata)), " ")
+}
+
+func socialMetadataText(metadata map[string]any) string {
+	if len(metadata) == 0 {
+		return ""
+	}
+	var parts []string
+	for _, key := range []string{"x_news_category", "x_news_keywords", "x_news_contexts"} {
+		appendMetadataText(&parts, metadata[key])
+	}
+	return strings.Join(parts, " ")
+}
+
+func appendMetadataText(parts *[]string, value any) {
+	switch v := value.(type) {
+	case nil:
+		return
+	case string:
+		if strings.TrimSpace(v) != "" {
+			*parts = append(*parts, strings.TrimSpace(v))
+		}
+	case []any:
+		for _, item := range v {
+			appendMetadataText(parts, item)
+		}
+	case []string:
+		for _, item := range v {
+			appendMetadataText(parts, item)
+		}
+	case map[string]any:
+		keys := make([]string, 0, len(v))
+		for key := range v {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			appendMetadataText(parts, v[key])
+		}
+	default:
+		if s := stringValue(v); s != "" {
+			*parts = append(*parts, s)
+		}
+	}
 }
 
 func (e evidenceItem) publicDict() map[string]any {
@@ -72,6 +119,14 @@ func (c signalCluster) text() string {
 	var parts []string
 	for _, item := range c.Evidence {
 		parts = append(parts, item.text())
+	}
+	return strings.Join(parts, " ")
+}
+
+func (c signalCluster) clusterText() string {
+	var parts []string
+	for _, item := range c.Evidence {
+		parts = append(parts, item.clusterText())
 	}
 	return strings.Join(parts, " ")
 }

--- a/apps/cli/cmd/newsjack/detector_profile.go
+++ b/apps/cli/cmd/newsjack/detector_profile.go
@@ -85,7 +85,6 @@ func (p monitorProfile) matchText() string {
 	parts = append(parts, p.Topics...)
 	parts = append(parts, p.Competitors...)
 	parts = append(parts, p.FeedURLs...)
-	parts = append(parts, stringListValue(p.XTrends["locations"])...)
 	parts = append(parts, p.Spokespeople...)
 	parts = append(parts, p.Standing...)
 	return strings.TrimSpace(strings.Join(parts, " "))

--- a/apps/cli/cmd/newsjack/detector_run.go
+++ b/apps/cli/cmd/newsjack/detector_run.go
@@ -45,7 +45,7 @@ func detectorRun(opts detectorOptions, stdout io.Writer) error {
 	}
 	querySources := querySources(requestedSources)
 	sources := []string{}
-	if len(queries) > 0 {
+	if len(queries) > 0 && len(querySources) > 0 {
 		if opts.Mock {
 			sources = querySources
 		} else {
@@ -114,6 +114,17 @@ func detectorRun(opts detectorOptions, stdout io.Writer) error {
 	}
 	laneCaps := parseLaneCaps(opts.LaneCaps)
 	signals := selectSignals(allSignals, opts.Limit, laneCaps, opts.MinQueuePriority, opts.MinMajorNews)
+	diagnostics := map[string]any{
+		"evidence_by_source":    evidenceSourceCounts,
+		"hygiene_rejections":    hygieneRejections,
+		"signals_by_lane":       countByLanes(allSignals),
+		"emitted_by_lane":       countByLanes(signals),
+		"lane_caps":             laneCaps,
+		"selection":             map[string]any{"mode": map[bool]string{true: "lane_caps", false: "mechanical_floor"}[laneCaps != nil], "limit": opts.Limit, "min_queue_priority": opts.MinQueuePriority, "min_major_news": opts.MinMajorNews},
+		"total_scored_signals":  len(allSignals),
+		"total_emitted_signals": len(signals),
+		"source_status":         sourceStatus(requestedSources, sources, trendRequested, len(feedURLs) > 0, evidenceSourceCounts, sourceErrors, config, opts.Mock),
+	}
 	var runID any
 	runID = nil
 	if opts.Save {
@@ -138,23 +149,30 @@ func detectorRun(opts detectorOptions, stdout io.Writer) error {
 			"depth":             opts.Depth,
 			"mock":              opts.Mock,
 		},
-		"signals": signals,
-		"diagnostics": map[string]any{
-			"evidence_by_source":    evidenceSourceCounts,
-			"hygiene_rejections":    hygieneRejections,
-			"signals_by_lane":       countByLanes(allSignals),
-			"emitted_by_lane":       countByLanes(signals),
-			"lane_caps":             laneCaps,
-			"selection":             map[string]any{"mode": map[bool]string{true: "lane_caps", false: "mechanical_floor"}[laneCaps != nil], "limit": opts.Limit, "min_queue_priority": opts.MinQueuePriority, "min_major_news": opts.MinMajorNews},
-			"total_scored_signals":  len(allSignals),
-			"total_emitted_signals": len(signals),
-		},
+		"signals":       signals,
+		"diagnostics":   diagnostics,
 		"source_errors": sourceErrors,
 		"store": map[string]any{
 			"saved":  opts.Save,
 			"run_id": runID,
 			"path":   storePathForOutput(opts.Store, opts.Save),
 		},
+	}
+	if opts.ScoredOutput != "" {
+		scored := map[string]any{
+			"version":       1,
+			"generated_at":  now.Format(time.RFC3339Nano),
+			"monitor":       payload["monitor"],
+			"signals":       allSignals,
+			"diagnostics":   diagnostics,
+			"source_errors": sourceErrors,
+		}
+		if err := os.MkdirAll(filepath.Dir(expandPath(opts.ScoredOutput)), 0o755); err != nil {
+			return err
+		}
+		if err := os.WriteFile(expandPath(opts.ScoredOutput), marshalJSON(scored), 0o644); err != nil {
+			return err
+		}
 	}
 	if opts.IncludeAllScored {
 		selected := map[string]bool{}
@@ -178,6 +196,69 @@ func detectorRun(opts detectorOptions, stdout io.Writer) error {
 		writeJSON(stdout, payload)
 	}
 	return nil
+}
+
+func sourceStatus(requestedSources, querySourcesUsed []string, trendRequested, feedsRequested bool, evidenceCounts map[string]int, sourceErrors map[string]any, config map[string]string, mock bool) map[string]any {
+	requested := stringSet(requestedSources)
+	used := stringSet(querySourcesUsed)
+	if trendRequested {
+		requested["x_trends"] = true
+		used["x_trends"] = true
+	}
+	if feedsRequested {
+		requested["major_feed"] = true
+		used["major_feed"] = true
+	}
+	out := map[string]any{}
+	for _, source := range []string{"news_search", "x_news", "x", "x_trends", "major_feed", "reddit", "hackernews"} {
+		if !requested[source] && evidenceCounts[source] == 0 {
+			continue
+		}
+		status := "not_requested"
+		if requested[source] {
+			status = "unavailable"
+			available := source == "major_feed" || mock || contains(availableSources(config, []string{source}), source)
+			if available {
+				status = "no_results"
+			}
+			if evidenceCounts[source] > 0 {
+				status = "used"
+			}
+			if sourceHasError(sourceErrors, source) {
+				status = "error"
+				if evidenceCounts[source] > 0 {
+					status = "partial_error"
+				}
+			}
+		}
+		out[source] = map[string]any{
+			"requested":      requested[source],
+			"available":      source == "major_feed" || mock || contains(availableSources(config, []string{source}), source),
+			"attempted":      used[source],
+			"evidence_count": evidenceCounts[source],
+			"status":         status,
+		}
+	}
+	return out
+}
+
+func sourceHasError(sourceErrors map[string]any, source string) bool {
+	for key, raw := range sourceErrors {
+		if key == source {
+			return true
+		}
+		if m, ok := raw.(map[string]string); ok {
+			if _, exists := m[source]; exists {
+				return true
+			}
+		}
+		if m, ok := raw.(map[string]any); ok {
+			if _, exists := m[source]; exists {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func buildQueries(opts detectorOptions, profile monitorProfile) []string {
@@ -386,14 +467,19 @@ func bearerToken(config map[string]string) string {
 	return ""
 }
 
-func mockItems(query string, now time.Time) []evidenceItem {
+func mockItems(query string, now time.Time, sources []string) []evidenceItem {
 	today := now.Format("2006-01-02")
 	h1 := sha1.Sum([]byte(query))
 	h2 := sha1.Sum([]byte(query + "x"))
-	return []evidenceItem{
-		{Source: "news_search", Title: "Regulators open inquiry tied to " + query, URL: "https://example.com/news/" + hex.EncodeToString(h1[:])[:8], Container: "Example News", PublishedAt: today, Excerpt: "Officials are examining claims and compliance practices around " + query + ".", Engagement: map[string]any{}, Metadata: map[string]any{}},
-		{Source: "x", Title: "Experts are reacting to " + query, URL: "https://x.com/example/status/" + hex.EncodeToString(h2[:])[:8], Author: "example", Container: "x.com", PublishedAt: today, Excerpt: "Thread: the " + query + " inquiry is moving faster than vendors expected.", Engagement: map[string]any{"likes": 120, "reposts": 22, "replies": 9}, Metadata: map[string]any{}},
+	requested := stringSet(sources)
+	var items []evidenceItem
+	if requested["news_search"] {
+		items = append(items, evidenceItem{Source: "news_search", Title: "Regulators open inquiry tied to " + query, URL: "https://example.com/news/" + hex.EncodeToString(h1[:])[:8], Container: "Example News", PublishedAt: today, Excerpt: "Officials are examining claims and compliance practices around " + query + ".", Engagement: map[string]any{}, Metadata: map[string]any{}})
 	}
+	if requested["x"] {
+		items = append(items, evidenceItem{Source: "x", Title: "Experts are reacting to " + query, URL: "https://x.com/example/status/" + hex.EncodeToString(h2[:])[:8], Author: "example", Container: "x.com", PublishedAt: today, Excerpt: "Thread: the " + query + " inquiry is moving faster than vendors expected.", Engagement: map[string]any{"likes": 120, "reposts": 22, "replies": 9}, Metadata: map[string]any{}})
+	}
+	return items
 }
 
 func mockFeedItems(now time.Time) []evidenceItem {
@@ -406,7 +492,7 @@ func mockFeedItems(now time.Time) []evidenceItem {
 
 func collectQuery(query string, sources []string, config map[string]string, opts detectorOptions, now time.Time) ([]evidenceItem, map[string]string) {
 	if opts.Mock {
-		return mockItems(query, now), map[string]string{}
+		return mockItems(query, now, sources), map[string]string{}
 	}
 	from, to := dateRange(opts.LookbackDays)
 	errors := map[string]string{}

--- a/apps/cli/cmd/newsjack/detector_scoring.go
+++ b/apps/cli/cmd/newsjack/detector_scoring.go
@@ -606,6 +606,11 @@ func scoreSignal(cluster signalCluster, profile monitorProfile, seen map[string]
 	sourceQuality := sourceQualityScore(cluster)
 	engagement := engagementScore(cluster)
 	profileMatch := profileMatchScore(profile, text)
+	profileTermMatches := profileMatches(profile, text)
+	sourceSet := stringSet(sources)
+	if isXTrendCluster(cluster, sourceSet) && len(profileTermMatches) == 0 {
+		profileMatch = 0
+	}
 	majorNews := majorNewsScore(cluster, age)
 	storySize := storySizeScore(cluster, sourceQuality, majorNews, engagement)
 	storySizeValue := 0.0
@@ -625,7 +630,9 @@ func scoreSignal(cluster signalCluster, profile monitorProfile, seen map[string]
 		queue = round1(100 * (0.22*freshness + 0.20*profileMatch + 0.18*sourceAgreement + 0.16*novelty + 0.14*sourceQuality + 0.10*engagement))
 	case "x_trends_unmatched":
 		queue = round1(math.Min(39.9, 100*(0.16*freshness+0.14*novelty+0.12*sourceQuality+0.10*engagement)))
-	case "x_news_unmatched", "profile_relevance_weak", "x_posts_weak":
+	case "x_news_unmatched":
+		queue = round1(math.Min(42.0, 100*(0.18*freshness+0.16*sourceAgreement+0.14*novelty+0.10*sourceQuality+0.08*engagement)))
+	case "profile_relevance_weak", "x_posts_weak":
 		queue = round1(math.Min(39.9, 100*(0.18*freshness+0.16*sourceAgreement+0.14*novelty+0.10*sourceQuality+0.08*engagement)))
 	case "x_posts":
 		queue = round1(math.Min(64.0, 100*(0.22*freshness+0.20*engagement+0.18*profileMatch+0.16*sourceAgreement+0.14*novelty+0.10*sourceQuality)))
@@ -652,7 +659,7 @@ func scoreSignal(cluster signalCluster, profile monitorProfile, seen map[string]
 		"evidence_count":  len(cluster.Evidence),
 		"seen_before":     len(urls) > 0 && allSeen(urls, seen),
 		"seen_urls":       seenSubset(urls, seen),
-		"profile_matches": profileMatches(profile, text),
+		"profile_matches": profileTermMatches,
 		"safety_flags":    safetyFlags(text, profile.Exclusions),
 	}
 	if age != nil {
@@ -688,6 +695,20 @@ func scoreSignal(cluster signalCluster, profile monitorProfile, seen map[string]
 		"routing":           routing,
 		"mechanical_scores": mechanicalScores,
 	}
+}
+
+func isXTrendCluster(cluster signalCluster, sources map[string]bool) bool {
+	if sources["x_trends"] {
+		return true
+	}
+	if len(sources) == 1 && sources["x"] {
+		for _, item := range cluster.Evidence {
+			if item.Metadata["x_signal_type"] == "query_trend" {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func signalID(title string, urls []string, text string) string {
@@ -799,7 +820,7 @@ func clusterItems(items []evidenceItem) []signalCluster {
 				placed = true
 				break
 			}
-			if jaccard(item.text(), clusters[i].text()) >= 0.32 {
+			if jaccard(item.clusterText(), clusters[i].clusterText()) >= 0.32 {
 				clusters[i].Evidence = append(clusters[i].Evidence, item)
 				placed = true
 				break

--- a/apps/cli/cmd/newsjack/detector_sources.go
+++ b/apps/cli/cmd/newsjack/detector_sources.go
@@ -320,8 +320,7 @@ func collectXTrendsRaw(config map[string]any, depth, bearer string) ([]map[strin
 		return nil, "x_trends requires X_BEARER_TOKEN or TWITTER_BEARER_TOKEN"
 	}
 	if mode == "personalized" {
-		resp := apiGet("/2/users/personalized_trends?personalized_trend.fields=trend_name%2Cpost_count%2Ccategory%2Ctrending_since", bearer)
-		return parseTrendsResponse(resp, mode, "", ""), stringValue(resp["error"])
+		return nil, "personalized x_trends requires user-context OAuth; app-only bearer tokens can use location trends"
 	}
 	if mode == "location" {
 		maxResults := map[string]int{"quick": 10, "default": 20, "deep": 50}[depth]
@@ -329,7 +328,10 @@ func collectXTrendsRaw(config map[string]any, depth, bearer string) ([]map[strin
 		var items []map[string]any
 		var errors []string
 		for i, raw := range anySlice(config["woeids"]) {
-			woeid := stringValue(raw)
+			woeid := woeidString(raw)
+			if woeid == "" {
+				continue
+			}
 			resp := apiGet("/2/trends/by/woeid/"+url.PathEscape(woeid)+"?max_trends="+strconv.Itoa(maxResults), bearer)
 			if err := stringValue(resp["error"]); err != "" {
 				errors = append(errors, woeid+": "+err)
@@ -344,6 +346,29 @@ func collectXTrendsRaw(config map[string]any, depth, bearer string) ([]map[strin
 		return items, strings.Join(errors, "; ")
 	}
 	return nil, "Unsupported x_trends mode: " + mode
+}
+
+func woeidString(raw any) string {
+	switch v := raw.(type) {
+	case float64:
+		if math.Trunc(v) == v {
+			return strconv.FormatInt(int64(v), 10)
+		}
+	case float32:
+		f := float64(v)
+		if math.Trunc(f) == f {
+			return strconv.FormatInt(int64(f), 10)
+		}
+	case int:
+		return strconv.Itoa(v)
+	case int64:
+		return strconv.FormatInt(v, 10)
+	case json.Number:
+		if i, err := v.Int64(); err == nil {
+			return strconv.FormatInt(i, 10)
+		}
+	}
+	return strings.TrimSpace(stringValue(raw))
 }
 
 func parseTrendsResponse(response map[string]any, mode, woeid, location string) []map[string]any {

--- a/apps/cli/cmd/newsjack/detector_test.go
+++ b/apps/cli/cmd/newsjack/detector_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -43,6 +45,29 @@ func TestDetectorMockRunAcceptsFlagsAfterQuery(t *testing.T) {
 	})
 }
 
+func TestDetectorRunWritesScoredOutputArtifact(t *testing.T) {
+	repo := repoRootForTest(t)
+	dir := t.TempDir()
+	scored := filepath.Join(dir, "scored_candidates.json")
+	withTempEnv(t, map[string]string{
+		"HOME":          t.TempDir(),
+		"NEWSJACK_ROOT": repo,
+	}, func() {
+		var out, errBuf bytes.Buffer
+		code := runCLI([]string{"detector", "run", "AI customer support", "--mock", "--scored-output", scored, "--emit", "json"}, &out, &errBuf)
+		if code != 0 {
+			t.Fatalf("detector code=%d stderr=%s", code, errBuf.String())
+		}
+		payload, err := readJSONMap(scored)
+		if err != nil {
+			t.Fatalf("read scored output: %v", err)
+		}
+		if got := len(signalSlice(payload["signals"])); got != 2 {
+			t.Fatalf("scored signals=%d, want 2", got)
+		}
+	})
+}
+
 func TestXSourceAvailabilityUsesBearerTokenOnly(t *testing.T) {
 	withoutBearer := configFromEnv()
 	withoutBearer["X_BEARER_TOKEN"] = ""
@@ -59,6 +84,96 @@ func TestXSourceAvailabilityUsesBearerTokenOnly(t *testing.T) {
 	if len(got) != 3 || got[0] != "x" || got[1] != "x_news" || got[2] != "x_trends" {
 		t.Fatalf("x sources with bearer=%v, want all x sources", got)
 	}
+}
+
+func TestWOEIDStringFormatsJSONNumbers(t *testing.T) {
+	if got := woeidString(float64(2459115)); got != "2459115" {
+		t.Fatalf("woeidString(float64)=%q, want 2459115", got)
+	}
+	if got := woeidString("23424975"); got != "23424975" {
+		t.Fatalf("woeidString(string)=%q, want 23424975", got)
+	}
+}
+
+func TestPersonalizedXTrendsRequiresUserContextOAuth(t *testing.T) {
+	items, errText := collectXTrendsRaw(map[string]any{"mode": "personalized"}, "quick", "bearer-token")
+	if len(items) != 0 {
+		t.Fatalf("personalized trend items=%d, want none", len(items))
+	}
+	if !strings.Contains(errText, "user-context OAuth") {
+		t.Fatalf("err=%q, want user-context OAuth guidance", errText)
+	}
+}
+
+func TestSourceStatusReportsNoResultsForAttemptedEmptySource(t *testing.T) {
+	status := sourceStatus(
+		[]string{"x_news"},
+		[]string{"x_news"},
+		false,
+		false,
+		map[string]int{},
+		map[string]any{},
+		map[string]string{"X_BEARER_TOKEN": "token"},
+		false,
+	)
+	xNews := valueOrEmptyMap(status["x_news"])
+	if xNews["status"] != "no_results" || xNews["attempted"] != true {
+		t.Fatalf("x_news status=%#v, want attempted no_results", xNews)
+	}
+}
+
+func TestSourceStatusTreatsMockSourcesAsAvailable(t *testing.T) {
+	status := sourceStatus(
+		[]string{"x_news"},
+		[]string{"x_news"},
+		false,
+		false,
+		map[string]int{},
+		map[string]any{},
+		map[string]string{},
+		true,
+	)
+	xNews := valueOrEmptyMap(status["x_news"])
+	if xNews["status"] != "no_results" || xNews["available"] != true {
+		t.Fatalf("x_news status=%#v, want mock no_results available", xNews)
+	}
+}
+
+func TestDetectorRunAllowsXTrendsOnly(t *testing.T) {
+	repo := repoRootForTest(t)
+	dir := t.TempDir()
+	profilePath := filepath.Join(dir, "profile.json")
+	profile := `{
+	  "company": "Nofar Method",
+	  "topics": ["reformer Pilates"],
+	  "x_news": {"enabled": false},
+	  "x_trends": {"mode": "location", "woeids": ["2459115"], "locations": ["New York"]}
+	}`
+	if err := os.WriteFile(profilePath, []byte(profile), 0o644); err != nil {
+		t.Fatalf("write profile: %v", err)
+	}
+	withTempEnv(t, map[string]string{
+		"HOME":          t.TempDir(),
+		"NEWSJACK_ROOT": repo,
+	}, func() {
+		var out, errBuf bytes.Buffer
+		code := runCLI([]string{"detector", "run", "--profile", profilePath, "--sources", "x_trends", "--no-x-news", "--no-profile-feeds", "--mock", "--min-queue-priority", "0", "--emit", "json"}, &out, &errBuf)
+		if code != 0 {
+			t.Fatalf("detector code=%d stderr=%s", code, errBuf.String())
+		}
+		var payload map[string]any
+		if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
+			t.Fatalf("invalid JSON: %s", out.String())
+		}
+		if got := len(signalSlice(payload["signals"])); got != 1 {
+			t.Fatalf("signals=%d, want mocked x trend; payload=%s", got, out.String())
+		}
+		status := valueOrEmptyMap(valueOrEmptyMap(payload["diagnostics"])["source_status"])
+		xTrends := valueOrEmptyMap(status["x_trends"])
+		if xTrends["status"] != "used" {
+			t.Fatalf("x_trends status=%#v, want used", xTrends)
+		}
+	})
 }
 
 func TestProfileIgnoresLegacyAssetInventory(t *testing.T) {
@@ -107,7 +222,7 @@ func TestSearchXNewsCallsXAPIDirectly(t *testing.T) {
 	})
 }
 
-func TestDemotedDetectorLanesStayBelowDefaultQueueFloor(t *testing.T) {
+func TestWeakDetectorLanesSelectionFloors(t *testing.T) {
 	now := time.Date(2026, 5, 25, 13, 0, 0, 0, time.UTC)
 	profile := monitorProfile{
 		Company:  "Clearnym",
@@ -149,6 +264,15 @@ func TestDemotedDetectorLanesStayBelowDefaultQueueFloor(t *testing.T) {
 			if lane := signalLaneValue(signal); lane != tt.wantLane {
 				t.Fatalf("lane=%s, want %s", lane, tt.wantLane)
 			}
+			if tt.source == "x_news" {
+				if priority := queuePriority(signal); priority < defaultMinQueuePriority {
+					t.Fatalf("x_news queue priority=%v, want surfaced for review", priority)
+				}
+				if !passesSelectionFloor(signal, defaultMinQueuePriority, defaultMinMajorNews) {
+					t.Fatalf("x_news did not pass selection floor: %#v", signal["routing"])
+				}
+				return
+			}
 			if priority := queuePriority(signal); priority >= defaultMinQueuePriority {
 				t.Fatalf("queue priority=%v, want below default floor %v", priority, defaultMinQueuePriority)
 			}
@@ -156,6 +280,102 @@ func TestDemotedDetectorLanesStayBelowDefaultQueueFloor(t *testing.T) {
 				t.Fatalf("demoted lane passed default selection floor: %#v", signal["routing"])
 			}
 		})
+	}
+}
+
+func TestXNewsProfileMatchUsesContextMetadata(t *testing.T) {
+	now := time.Date(2026, 5, 25, 13, 0, 0, 0, time.UTC)
+	profile := monitorProfile{
+		Topics:      []string{"computer-use agents"},
+		Competitors: []string{"Anthropic computer use"},
+		Standing:    []string{"AI agent benchmarks"},
+	}
+	item := evidenceItem{
+		Source:      "x_news",
+		Title:       "Un cluster en français sur la cybersécurité",
+		URL:         "https://x.com/search?q=anthropic",
+		PublishedAt: now.Format(time.RFC3339),
+		Metadata: map[string]any{
+			"x_news_contexts": map[string]any{
+				"entities": map[string]any{
+					"organizations": []any{"Anthropic"},
+					"products":      []any{"computer use"},
+				},
+				"topics": []any{"Technology", "AI"},
+			},
+		},
+	}
+	score := profileMatchScore(profile, item.text())
+	if score <= 0 {
+		t.Fatalf("profile match score=%v, want metadata-driven overlap", score)
+	}
+}
+
+func TestXTrendLocationMetadataDoesNotClusterUnrelatedTrends(t *testing.T) {
+	now := time.Date(2026, 5, 25, 13, 0, 0, 0, time.UTC).Format(time.RFC3339)
+	items := []evidenceItem{
+		{
+			Source:      "x_trends",
+			Title:       "Smotrich",
+			URL:         "https://x.com/search?q=Smotrich&f=live",
+			PublishedAt: now,
+			Metadata:    map[string]any{"x_signal_type": "trend", "x_trend_location": "New York", "x_trend_woeid": "2459115"},
+		},
+		{
+			Source:      "x_trends",
+			Title:       "Zendaya",
+			URL:         "https://x.com/search?q=Zendaya&f=live",
+			PublishedAt: now,
+			Metadata:    map[string]any{"x_signal_type": "trend", "x_trend_location": "New York", "x_trend_woeid": "2459115"},
+		},
+	}
+	if clusters := clusterItems(items); len(clusters) != 2 {
+		t.Fatalf("clusters=%d, want unrelated trends split: %#v", len(clusters), clusters)
+	}
+}
+
+func TestXTrendLocationConfigDoesNotCreateProfileMatch(t *testing.T) {
+	profile := monitorProfile{
+		Company: "Nofar Method",
+		Topics:  []string{"reformer Pilates"},
+		XTrends: map[string]any{"mode": "location", "locations": []any{"New York", "Miami"}},
+	}
+	item := evidenceItem{
+		Source:    "x_trends",
+		Title:     "Saylor",
+		Excerpt:   "Saylor. New York",
+		Author:    "x-trends",
+		Container: "x.com/trends",
+		Metadata:  map[string]any{"x_signal_type": "trend", "x_trend_location": "New York", "x_trend_woeid": "2459115"},
+	}
+	if score := profileMatchScore(profile, item.text()); score >= 0.05 {
+		t.Fatalf("profile match score=%v, want local trend below x_trends relevance floor", score)
+	}
+}
+
+func TestXTrendLocationOnlyOverlapIsDemoted(t *testing.T) {
+	now := time.Date(2026, 5, 25, 13, 0, 0, 0, time.UTC)
+	profile := monitorProfile{
+		Company:     "Nofar Method",
+		Description: "Boutique Pilates studio with classes in New York and Miami.",
+		Topics:      []string{"reformer Pilates"},
+		Standing:    []string{"NYC and Miami wellness trends"},
+	}
+	signal := scoreSignal(signalCluster{Evidence: []evidenceItem{{
+		Source:      "x_trends",
+		Title:       "Saylor",
+		URL:         "https://x.com/search?q=Saylor&f=live",
+		Excerpt:     "Saylor. New York",
+		Container:   "x.com/trends",
+		PublishedAt: now.Format(time.RFC3339),
+		Engagement:  map[string]any{},
+		Metadata:    map[string]any{"x_signal_type": "trend", "x_trend_location": "New York", "x_trend_woeid": "2459115"},
+	}}}, profile, map[string]map[string]any{}, now, detectorOptions{LookbackDays: 1, XTrendsMinProfileMatch: 0.05})
+	if lane := signalLaneValue(signal); lane != "x_trends_unmatched" {
+		t.Fatalf("lane=%s, want x_trends_unmatched", lane)
+	}
+	if match := floatValue(valueOrEmptyMap(signal["mechanical_scores"])["profile_match"]); match != 0 {
+		t.Fatalf("profile_match=%v, want location-only trend match zeroed", match)
 	}
 }
 

--- a/apps/cli/cmd/newsjack/filter_test.go
+++ b/apps/cli/cmd/newsjack/filter_test.go
@@ -312,6 +312,108 @@ func TestOriginApplySelectsFreshNewDevelopment(t *testing.T) {
 	}
 }
 
+func TestOriginApplyPromotesCutoffDateWithPreciseTimestampEvidence(t *testing.T) {
+	candidates := map[string]any{
+		"monitor": map[string]any{"generated_at": "2026-06-01T13:46:00Z"},
+		"signals": []any{
+			map[string]any{
+				"id":    "scmp",
+				"title": "5 new cafes and coffee shops to try in Hong Kong",
+				"evidence": []any{
+					map[string]any{"url": "https://www.scmp.com/lifestyle/food-drink/article/3355305/story?utm_source=x"},
+				},
+			},
+		},
+	}
+	origins := map[string]any{
+		"findings": []any{
+			map[string]any{
+				"signal_id":              "scmp",
+				"first_public_at":        "2026-05-31",
+				"original_url":           "https://www.scmp.com/lifestyle/food-drink/article/3355305/story",
+				"canonical_coverage_url": "https://www.scmp.com/lifestyle/food-drink/article/3355305/story",
+				"timestamp_evidence": []any{
+					map[string]any{
+						"source":       "page_meta",
+						"url":          "https://www.scmp.com/lifestyle/food-drink/article/3355305/story",
+						"published_at": "2026-05-31T22:46:35Z",
+					},
+					map[string]any{
+						"source":       "news_search",
+						"url":          "https://news.google.com/rss/articles/scmp-story",
+						"published_at": "2026-05-31T22:46:35Z",
+					},
+				},
+			},
+		},
+	}
+	payload, err := applyOriginFindings(candidates, origins, originApplyOptions{
+		RunTime:     mustParseTestTime(t, "2026-06-01T13:46:00Z"),
+		WindowHours: 24,
+	})
+	if err != nil {
+		t.Fatalf("applyOriginFindings error=%v", err)
+	}
+	signals := signalSlice(payload["signals"])
+	if len(signals) != 1 {
+		t.Fatalf("selected signals=%d, want 1; gate=%#v", len(signals), payload["freshness_gate"])
+	}
+	gate := valueOrEmptyMap(signals[0]["freshness_gate"])
+	if gate["computed_status"] != "fresh" {
+		t.Fatalf("computed_status=%v, want fresh; gate=%#v", gate["computed_status"], gate)
+	}
+	if gate["basis_field"] != "timestamp_evidence.published_at" {
+		t.Fatalf("basis_field=%v, want timestamp evidence; gate=%#v", gate["basis_field"], gate)
+	}
+}
+
+func TestOriginApplyAcceptsPrimaryAndCanonicalTimestampEvidence(t *testing.T) {
+	candidates := map[string]any{
+		"monitor": map[string]any{"generated_at": "2026-06-01T18:00:00Z"},
+		"signals": []any{
+			map[string]any{
+				"id":    "datagrail",
+				"title": "145 AI laws passed in 2025 and privacy teams aren’t catching a break",
+				"evidence": []any{
+					map[string]any{"url": "https://www.helpnetsecurity.com/2026/06/01/datagrail-ai-privacy-risks-report/"},
+				},
+			},
+		},
+	}
+	origins := map[string]any{
+		"findings": []any{
+			map[string]any{
+				"signal_id":              "datagrail",
+				"first_public_at":        "2026-06-01",
+				"original_url":           "https://www.datagrail.io/resources/interactive/data-privacy-trends-report-2026/",
+				"canonical_coverage_url": "https://www.helpnetsecurity.com/2026/06/01/datagrail-ai-privacy-risks-report/",
+				"timestamp_evidence": []any{
+					map[string]any{
+						"source":       "primary_source",
+						"url":          "https://www.datagrail.io/resources/interactive/data-privacy-trends-report-2026/",
+						"published_at": "2026-06-01",
+					},
+					map[string]any{
+						"source":       "news_search",
+						"url":          "https://www.helpnetsecurity.com/2026/06/01/datagrail-ai-privacy-risks-report/",
+						"published_at": "2026-06-01",
+					},
+				},
+			},
+		},
+	}
+	payload, err := applyOriginFindings(candidates, origins, originApplyOptions{
+		RunTime:     mustParseTestTime(t, "2026-06-01T18:00:00Z"),
+		WindowHours: 24,
+	})
+	if err != nil {
+		t.Fatalf("applyOriginFindings error=%v", err)
+	}
+	if got := len(signalSlice(payload["signals"])); got != 1 {
+		t.Fatalf("selected signals=%d, want 1; gate=%#v", got, payload["freshness_gate"])
+	}
+}
+
 func TestOriginApplyDowngradesWhenWorkerCitesOnlySurfacedURL(t *testing.T) {
 	candidates := map[string]any{
 		"monitor": map[string]any{"generated_at": "2026-05-27T19:00:00Z"},

--- a/apps/cli/cmd/newsjack/origin.go
+++ b/apps/cli/cmd/newsjack/origin.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"sort"
 	"strings"
@@ -228,6 +229,9 @@ func computeFreshnessGate(origin map[string]any, runTime, cutoff time.Time, wind
 			return freshnessGate("fresh_new_development", runTime, cutoff, windowHours, workerStatus, "new_development_at", newRaw, precision, "new_development_at is inside the freshness window")
 		}
 		if relation == "ambiguous" {
+			if promoted, ok := promotePreciseFreshTimestamp(origin, runTime, cutoff, windowHours, workerStatus, "fresh_new_development"); ok {
+				return promoted
+			}
 			return freshnessGate("freshness_unverified", runTime, cutoff, windowHours, workerStatus, "new_development_at", newRaw, precision, "new_development_at has date-only precision on the cutoff date")
 		}
 		if firstRaw == "" {
@@ -242,10 +246,60 @@ func computeFreshnessGate(origin map[string]any, runTime, cutoff time.Time, wind
 		case "stale":
 			return freshnessGate("stale", runTime, cutoff, windowHours, workerStatus, "first_public_at", firstRaw, precision, "first_public_at is before the freshness cutoff")
 		default:
+			if promoted, ok := promotePreciseFreshTimestamp(origin, runTime, cutoff, windowHours, workerStatus, "fresh"); ok {
+				return promoted
+			}
 			return freshnessGate("freshness_unverified", runTime, cutoff, windowHours, workerStatus, "first_public_at", firstRaw, precision, "first_public_at has date-only precision on the cutoff date")
 		}
 	}
 	return freshnessGate("freshness_unverified", runTime, cutoff, windowHours, workerStatus, "", "", "", "first_public_at is missing or unparseable")
+}
+
+func promotePreciseFreshTimestamp(origin map[string]any, runTime, cutoff time.Time, windowHours float64, workerStatus, status string) (map[string]any, bool) {
+	candidates := preciseOriginTimestamps(origin)
+	var fresh []originTimestampCandidate
+	for _, candidate := range candidates {
+		if candidate.parsed.Before(cutoff) {
+			return nil, false
+		}
+		if !candidate.parsed.After(runTime) {
+			fresh = append(fresh, candidate)
+		}
+	}
+	if len(fresh) == 0 {
+		return nil, false
+	}
+	sort.SliceStable(fresh, func(i, j int) bool {
+		return fresh[i].parsed.Before(fresh[j].parsed)
+	})
+	candidate := fresh[0]
+	return freshnessGate(status, runTime, cutoff, windowHours, workerStatus, candidate.field, candidate.value, "time", candidate.field+" supplies precise timestamp evidence inside the freshness window"), true
+}
+
+type originTimestampCandidate struct {
+	field  string
+	value  string
+	parsed time.Time
+	url    string
+}
+
+func preciseOriginTimestamps(origin map[string]any) []originTimestampCandidate {
+	var out []originTimestampCandidate
+	add := func(field, value, rawURL string) {
+		parsed, precision, ok := parseOriginTimestamp(value)
+		if !ok || precision != "time" {
+			return
+		}
+		out = append(out, originTimestampCandidate{field: field, value: value, parsed: parsed.UTC(), url: rawURL})
+	}
+	add("surfaced_article_published_at", stringValue(origin["surfaced_article_published_at"]), stringValue(origin["original_url"]))
+	add("canonical_coverage_published_at", stringValue(origin["canonical_coverage_published_at"]), stringValue(origin["canonical_coverage_url"]))
+	for _, raw := range anySlice(origin["timestamp_evidence"]) {
+		if m, ok := raw.(map[string]any); ok {
+			add("timestamp_evidence.published_at", stringValue(m["published_at"]), stringValue(m["url"]))
+		}
+	}
+	return out
 }
 
 func freshnessGate(status string, runTime, cutoff time.Time, windowHours float64, workerStatus, basisField, basisValue, precision, rationale string) map[string]any {
@@ -263,51 +317,43 @@ func freshnessGate(status string, runTime, cutoff time.Time, windowHours float64
 	}
 }
 
-// enforceSupportingEvidence downgrades a fresh/fresh_new_development gate to
-// freshness_unverified when the origin worker has not cited independent
-// retrieval evidence. We require at least one timestamp_evidence URL that is
-// distinct from the surfaced signal's own URLs and from the worker's reported
-// original_url. This catches the failure mode where a worker returns a fresh
-// verdict while only citing the surfaced press-release/advocacy URL back to
-// itself.
+// enforceSupportingEvidence downgrades a fresh/fresh_new_development gate when
+// the worker has only cited the surfaced detector URL back to itself. Primary
+// source plus canonical coverage is valid corroboration, even when those URLs
+// are also reported as original/canonical in the origin finding.
 func enforceSupportingEvidence(gate, finding, signal map[string]any) map[string]any {
 	status := stringValue(gate["computed_status"])
 	if status != "fresh" && status != "fresh_new_development" {
 		return gate
 	}
-	selfURLs := map[string]bool{}
-	addURL := func(raw any) {
-		s := strings.ToLower(strings.TrimSpace(stringValue(raw)))
-		if s != "" {
-			selfURLs[s] = true
-		}
-	}
-	addURL(finding["original_url"])
-	addURL(finding["canonical_coverage_url"])
+	surfacedURLs := map[string]bool{}
 	if evidence, ok := signal["evidence"].([]any); ok {
 		for _, item := range evidence {
 			if m, ok := item.(map[string]any); ok {
-				addURL(m["url"])
+				if u := normalizedURLKey(stringValue(m["url"])); u != "" {
+					surfacedURLs[u] = true
+				}
 			}
 		}
 	}
-	independentEvidence := 0
+	timestampURLs := map[string]bool{}
 	if entries, ok := finding["timestamp_evidence"].([]any); ok {
 		for _, raw := range entries {
 			m, ok := raw.(map[string]any)
 			if !ok {
 				continue
 			}
-			u := strings.ToLower(strings.TrimSpace(stringValue(m["url"])))
+			u := normalizedURLKey(stringValue(m["url"]))
 			if u == "" {
 				continue
 			}
-			if !selfURLs[u] {
-				independentEvidence++
+			timestampURLs[u] = true
+			if !surfacedURLs[u] {
+				return gate
 			}
 		}
 	}
-	if independentEvidence > 0 {
+	if len(timestampURLs) >= 2 {
 		return gate
 	}
 	downgraded := cloneMap(gate)
@@ -315,6 +361,34 @@ func enforceSupportingEvidence(gate, finding, signal map[string]any) map[string]
 	downgraded["rationale"] = "no independent timestamp_evidence: worker cited only the surfaced URL"
 	downgraded["worker_status"] = nullableString(status)
 	return downgraded
+}
+
+func normalizedURLKey(raw string) string {
+	s := strings.TrimSpace(raw)
+	if s == "" {
+		return ""
+	}
+	parsed, err := url.Parse(s)
+	if err != nil || parsed.Hostname() == "" {
+		return strings.TrimRight(strings.ToLower(s), "/")
+	}
+	parsed.Scheme = strings.ToLower(parsed.Scheme)
+	parsed.Host = strings.ToLower(parsed.Host)
+	parsed.Fragment = ""
+	path := strings.TrimRight(parsed.EscapedPath(), "/")
+	if path == "" {
+		path = "/"
+	}
+	parsed.Path = path
+	query := parsed.Query()
+	for key := range query {
+		lower := strings.ToLower(key)
+		if strings.HasPrefix(lower, "utm_") || lower == "fbclid" || lower == "gclid" || lower == "mc_cid" || lower == "mc_eid" {
+			query.Del(key)
+		}
+	}
+	parsed.RawQuery = query.Encode()
+	return parsed.String()
 }
 
 func parseOriginTimestamp(value string) (time.Time, string, bool) {

--- a/apps/cli/cmd/newsjack/render.go
+++ b/apps/cli/cmd/newsjack/render.go
@@ -128,7 +128,7 @@ func summarizeRun(payload map[string]any, inputPath string, top int) map[string]
 		},
 		"selection":                valueOrEmptyMap(diagnostics["selection"]),
 		"lanes":                    map[string]any{"scored": firstNonNil(diagnostics["signals_by_lane"], countByLanes(allScored)), "emitted": firstNonNil(diagnostics["emitted_by_lane"], countByLanes(signals)), "dropped_debug": countByLanes(dropped)},
-		"sources":                  map[string]any{"evidence_by_source": firstNonNil(diagnostics["evidence_by_source"], countEvidenceSources(signals)), "source_errors": sourceErrors},
+		"sources":                  map[string]any{"evidence_by_source": firstNonNil(diagnostics["evidence_by_source"], countEvidenceSources(signals)), "source_errors": sourceErrors, "source_status": diagnostics["source_status"]},
 		"hygiene_rejections":       valueOrEmptyMap(diagnostics["hygiene_rejections"]),
 		"coarse_relevance":         coarseRelevanceMap(payload),
 		"coarse_relevance_file":    summarizeDecisions(paths["coarse_relevance_decisions"]),
@@ -212,8 +212,8 @@ func renderSummaryMarkdown(summary map[string]any) string {
 		fmtValue(counts["selected_unique_signals"]),
 		fmtValue(counts["total_scored_signals"]),
 	))
-	if sourceErrors := intValue(counts["source_errors"], 0); sourceErrors > 0 {
-		lines = append(lines, fmt.Sprintf("**Source warnings:** %d source error(s) recorded.", sourceErrors))
+	if warning := sourceWarningText(summary); warning != "" {
+		lines = append(lines, warning)
 	}
 	finalReport := finalReportContent(summary)
 	if finalReport != "" {
@@ -248,7 +248,128 @@ func renderSummaryMarkdown(summary map[string]any) string {
 	lines = append(lines, fmt.Sprintf("- Profile: %s", mdInline(firstString(monitor["profile_name"], "(unknown)"))))
 	lines = append(lines, fmt.Sprintf("- Queries: %s", mdInline(formatList(valueOrEmptyArray(monitor["queries"]), 8))))
 	lines = append(lines, fmt.Sprintf("- Sources: %s", mdInline(formatList(valueOrEmptyArray(monitor["sources_used"]), 8))))
+	if status := sourceStatusText(summary); status != "" {
+		lines = append(lines, fmt.Sprintf("- Source status: %s", mdInline(status)))
+	}
 	return strings.TrimRight(strings.Join(lines, "\n"), "\n") + "\n"
+}
+
+func sourceWarningText(summary map[string]any) string {
+	sourceErrors := valueOrEmptyMap(valueOrEmptyMap(summary["sources"])["source_errors"])
+	if len(sourceErrors) == 0 {
+		return ""
+	}
+	var parts []string
+	for _, source := range sortedSourceErrorNames(sourceErrors) {
+		parts = append(parts, source+": "+truncate(sourceErrorDetailFor(sourceErrors, source), 140))
+	}
+	return fmt.Sprintf("**Source warnings:** %s.", mdInline(strings.Join(parts, "; ")))
+}
+
+func sortedSourceErrorNames(sourceErrors map[string]any) []string {
+	seen := map[string]bool{}
+	for key, raw := range sourceErrors {
+		if m, ok := raw.(map[string]any); ok {
+			for source := range m {
+				seen[source] = true
+			}
+			continue
+		}
+		if m, ok := raw.(map[string]string); ok {
+			for source := range m {
+				seen[source] = true
+			}
+			continue
+		}
+		seen[key] = true
+	}
+	var out []string
+	for source := range seen {
+		out = append(out, source)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func sourceErrorDetailFor(sourceErrors map[string]any, source string) string {
+	if raw, ok := sourceErrors[source]; ok {
+		return sourceErrorDetail(raw)
+	}
+	for _, raw := range sourceErrors {
+		if m, ok := raw.(map[string]any); ok {
+			if v, exists := m[source]; exists {
+				return sourceErrorDetail(v)
+			}
+		}
+		if m, ok := raw.(map[string]string); ok {
+			if v, exists := m[source]; exists {
+				return v
+			}
+		}
+	}
+	return ""
+}
+
+func sourceErrorDetail(raw any) string {
+	if s := stringValue(raw); s != "" && !strings.HasPrefix(s, "map[") {
+		return s
+	}
+	if m, ok := raw.(map[string]any); ok {
+		var parts []string
+		for _, key := range sortedAnyKeys(m) {
+			parts = append(parts, key+": "+stringValue(m[key]))
+		}
+		return strings.Join(parts, ", ")
+	}
+	if m, ok := raw.(map[string]string); ok {
+		keys := make([]string, 0, len(m))
+		for key := range m {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		var parts []string
+		for _, key := range keys {
+			parts = append(parts, key+": "+m[key])
+		}
+		return strings.Join(parts, ", ")
+	}
+	return stringValue(raw)
+}
+
+func sourceStatusText(summary map[string]any) string {
+	diagnostics := valueOrEmptyMap(firstNonNil(summary["diagnostics"], summary["detector_diagnostics"]))
+	status := valueOrEmptyMap(diagnostics["source_status"])
+	if len(status) == 0 {
+		status = valueOrEmptyMap(valueOrEmptyMap(summary["selection"])["source_status"])
+	}
+	if len(status) == 0 {
+		status = valueOrEmptyMap(valueOrEmptyMap(summary["sources"])["source_status"])
+	}
+	if len(status) == 0 {
+		return ""
+	}
+	keys := sortedAnyKeys(status)
+	var parts []string
+	for _, key := range keys {
+		m := valueOrEmptyMap(status[key])
+		state := firstString(m["status"], "unknown")
+		count := intValue(m["evidence_count"], 0)
+		if count > 0 {
+			parts = append(parts, fmt.Sprintf("%s=%s/%d", key, state, count))
+		} else {
+			parts = append(parts, fmt.Sprintf("%s=%s", key, state))
+		}
+	}
+	return strings.Join(parts, ", ")
+}
+
+func sortedAnyKeys(m map[string]any) []string {
+	keys := make([]string, 0, len(m))
+	for key := range m {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 // scanExclusionNote discloses signals withheld from the human scan so a gated
@@ -291,6 +412,7 @@ func artifactPaths(runDir string) map[string]string {
 	return map[string]string{
 		"candidates":                 filepath.Join(runDir, "candidates.json"),
 		"detector_summary":           filepath.Join(runDir, "summary.json"),
+		"scored_candidates":          filepath.Join(runDir, "scored_candidates.json"),
 		"commands":                   filepath.Join(runDir, "commands.log"),
 		"detector_stderr":            filepath.Join(runDir, "detector.stderr.log"),
 		"coarse_relevance_decisions": filepath.Join(runDir, "coarse_relevance_decisions.json"),

--- a/fixtures/newsjack-detector-agent/README.md
+++ b/fixtures/newsjack-detector-agent/README.md
@@ -66,6 +66,7 @@ runs/<timestamp>/
 ```text
 runs/<timestamp>-<slug>-profile/
   candidates.json
+  scored_candidates.json
   detector.stderr.log
   commands.log
   summary.json

--- a/fixtures/newsjack-detector-agent/profile.bluebottle.json
+++ b/fixtures/newsjack-detector-agent/profile.bluebottle.json
@@ -44,7 +44,7 @@
     "enabled": true
   },
   "x_trends": {
-    "mode": "personalized",
+    "mode": "none",
     "woeids": [],
     "locations": []
   },

--- a/fixtures/newsjack-detector-agent/profile.clearnym.json
+++ b/fixtures/newsjack-detector-agent/profile.clearnym.json
@@ -37,7 +37,7 @@
     "enabled": true
   },
   "x_trends": {
-    "mode": "personalized",
+    "mode": "none",
     "woeids": [],
     "locations": []
   },

--- a/fixtures/newsjack-detector-agent/profile.localfalcon.json
+++ b/fixtures/newsjack-detector-agent/profile.localfalcon.json
@@ -42,7 +42,7 @@
     "enabled": true
   },
   "x_trends": {
-    "mode": "personalized",
+    "mode": "none",
     "woeids": [],
     "locations": []
   },

--- a/fixtures/newsjack-detector-agent/profile.nofar-method.json
+++ b/fixtures/newsjack-detector-agent/profile.nofar-method.json
@@ -48,8 +48,8 @@
   "x_trends": {
     "mode": "location",
     "woeids": [
-      2459115,
-      2450022
+      "2459115",
+      "2450022"
     ],
     "locations": [
       "New York",

--- a/fixtures/newsjack-detector-agent/profile.property-saviour.json
+++ b/fixtures/newsjack-detector-agent/profile.property-saviour.json
@@ -39,7 +39,7 @@
   "x_trends": {
     "mode": "location",
     "woeids": [
-      23424975
+      "23424975"
     ],
     "locations": [
       "United Kingdom"

--- a/fixtures/newsjack-detector-agent/profile.simular.json
+++ b/fixtures/newsjack-detector-agent/profile.simular.json
@@ -38,7 +38,7 @@
     "enabled": true
   },
   "x_trends": {
-    "mode": "personalized",
+    "mode": "none",
     "woeids": [],
     "locations": []
   },

--- a/fixtures/newsjack-detector-agent/profile.slite.json
+++ b/fixtures/newsjack-detector-agent/profile.slite.json
@@ -41,7 +41,7 @@
     "enabled": true
   },
   "x_trends": {
-    "mode": "personalized",
+    "mode": "none",
     "woeids": [],
     "locations": []
   },

--- a/fixtures/newsjack-detector-agent/scripts/run-one-profile.sh
+++ b/fixtures/newsjack-detector-agent/scripts/run-one-profile.sh
@@ -34,6 +34,7 @@ INCLUDE_ALL_SCORED="${NEWSJACK_INCLUDE_ALL_SCORED:-1}"
 mkdir -p "$RUN_DIR"
 
 CANDIDATES="$RUN_DIR/candidates.json"
+SCORED_CANDIDATES="$RUN_DIR/scored_candidates.json"
 STDERR_LOG="$RUN_DIR/detector.stderr.log"
 SUMMARY="$RUN_DIR/summary.json"
 RUN_MARKDOWN="$RUN_DIR/run.md"
@@ -71,7 +72,7 @@ detector_args=(
 )
 
 if [[ "$INCLUDE_ALL_SCORED" != "0" && "$INCLUDE_ALL_SCORED" != "false" ]]; then
-  detector_args+=(--include-all-scored)
+  detector_args+=(--include-all-scored --scored-output "$SCORED_CANDIDATES")
 fi
 
 detector_args+=("$@" --emit json)
@@ -97,6 +98,9 @@ fi
 
 echo "wrote:"
 echo "- $CANDIDATES"
+if [[ -f "$SCORED_CANDIDATES" ]]; then
+  echo "- $SCORED_CANDIDATES"
+fi
 echo "- $SUMMARY"
 echo "- $RUN_MARKDOWN"
 echo "- $STDERR_LOG"

--- a/skills/newsjack-setup/SKILL.md
+++ b/skills/newsjack-setup/SKILL.md
@@ -26,7 +26,7 @@ Required:
 - 2-5 proof assets
 - 1-3 likely spokespeople
 - 2-5 RSS feed URLs
-- X trend preference: `personalized`, `location`, or `none`
+- X trend preference: `location` or `none` by default; `personalized` only when user-context OAuth is available
 
 Optional:
 
@@ -59,7 +59,7 @@ Enable `x_news` by default for every profile. X News has a much better shape tha
 
 Ask whether the user wants X trends during monitoring:
 
-- `personalized`: Uses the authenticated user's personalized X trends. Best default for solo PR users because it needs user-context auth and reflects their account's media/tech graph. It is biased by the account.
+- `personalized`: Uses the authenticated user's personalized X trends. Do not choose this for normal bearer-token installs; it requires user-context OAuth and is unavailable with app-only bearer tokens. It is biased by the account.
 - `location`: Uses X WOEID trends for one or more locations. Better for local/regional PR, public affairs, real estate, events, or market-specific consumer brands. Requires an app bearer token with access to the trends endpoint.
 - `none`: Best when the user wants only RSS/news search and does not want X trend noise.
 
@@ -74,7 +74,7 @@ If the user chooses `location`, ask for target geography and save both labels an
 - New York City: `2459115`
 - London: `44418`
 
-Do not make `location` the default for a generic SaaS company. Prefer `personalized` or `none` unless geography is important. If the user is unsure, choose `personalized` for founder-led/tech/media workflows and `none` for low-noise company monitoring.
+Do not make `location` the default for a generic SaaS company. Prefer `none` unless geography is important. If the user is unsure, choose `none` for low-noise company monitoring.
 
 ## Scheduling
 
@@ -104,7 +104,7 @@ This spreads load across the Newsjack/Medialyst backend so we don't get a thunde
 
 7. **Select feeds.** Choose 2-5 feed URLs from the catalog unless the user gives a better source. Explain why each feed belongs.
 
-8. **Choose X social sources.** Set `x_news.enabled` to `true` by default. Ask whether to use personalized trends, location trends, or no X trends. Explain the tradeoff briefly. Location trends should include WOEIDs.
+8. **Choose X social sources.** Set `x_news.enabled` to `true` by default. Ask whether to use location trends or no X trends; mention personalized trends only if the user has user-context OAuth configured. Explain the tradeoff briefly. Location trends should include WOEIDs.
 
 9. **Return the profile JSON and run command.** Do not write files unless the user asks you to. The user or caller can save the JSON.
 
@@ -126,7 +126,7 @@ Return a concise setup result:
       "enabled": true
     },
     "x_trends": {
-      "mode": "personalized",
+      "mode": "none",
       "woeids": [],
       "locations": []
     },

--- a/skills/newsjack-setup/examples.md
+++ b/skills/newsjack-setup/examples.md
@@ -44,7 +44,7 @@
       "enabled": true
     },
     "x_trends": {
-      "mode": "personalized",
+      "mode": "none",
       "woeids": [],
       "locations": []
     },
@@ -83,7 +83,7 @@
     }
   ],
   "x_news_rationale": "Enabled by default because X News returns story clusters with hooks, summaries, entities, and clustered post IDs.",
-  "x_trends_rationale": "Personalized trends are a reasonable default for a founder-led SaaS workflow; switch to location trends only for geography-specific campaigns.",
+  "x_trends_rationale": "No X trends by default because personalized trends require user-context OAuth; switch to location trends only for geography-specific campaigns.",
   "run_commands": {
     "hourly_major_news": "~/.newsjack/bin/newsjack detector run --profile profile.json --feed-only --save --new-only --max-age-hours 48 --emit json",
     "profile_relevance": "~/.newsjack/bin/newsjack detector run \"AI search visibility\" --profile profile.json --save --emit json"


### PR DESCRIPTION
## Summary
- Relax the deterministic freshness gate for cutoff-day date-only stories when precise timestamp evidence exists, and accept primary+canonical timestamp corroboration.
- Fix X lane behavior: location trends with bearer tokens, explicit personalized-trends OAuth guidance, numeric WOEID formatting, source diagnostics, and scored candidate artifacts.
- Broaden useful discovery while controlling noise: unmatched X News can surface for review, local X trends no longer cluster unrelated names or pass on location-only overlap, and fixture/setup defaults avoid personalized trends without user-context OAuth.

## Validation
- `git diff --check`
- `cd apps/cli && go test ./...`
- Live X location-trend probe with fixture env: source used, no source errors, unrelated trends stay below default emission.
- Live X News probe with fixture env: source used; X News-only unmatched clusters surface at queue 42.
- Fixture wrapper smoke produced `candidates.json`, `scored_candidates.json`, `summary.json`, and `run.md`.
