### PR TITLE
detector: precision + dedup pipeline (cluster, triage, split freshness, honest report)

### DIFF
--- a/apps/cli/cmd/newsjack/cluster.go
+++ b/apps/cli/cmd/newsjack/cluster.go
@@ -1,0 +1,295 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+	"time"
+)
+
+type clusterOptions struct {
+	TitleOverlap float64 // overlap-coefficient threshold on significant title tokens
+	MinShared    int     // minimum shared significant title tokens to merge
+	DropStale    bool
+	WindowHours  float64
+	StaleMaxBand string // highest story-size band still eligible for stale pre-gate drop
+}
+
+// cmdCluster collapses same-story signals into clusters before the expensive
+// story-origin retrieval pass runs. Only one representative per cluster is
+// carried forward in "signals"; the other pickups are recorded in
+// "clustered_duplicates" so retrieval and freshness gating run once per story,
+// not once per syndicated copy. With --drop-stale it also deterministically
+// pre-gates low-value, clearly-old signals so they never reach retrieval.
+func cmdCluster(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("cluster", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	candidatesPath := fs.String("candidates", "", "Relevant candidates JSON")
+	outputPath := fs.String("output", "", "Output path")
+	titleOverlap := fs.Float64("title-overlap", 0.6, "Overlap-coefficient threshold on significant title tokens to treat two signals as the same story")
+	minShared := fs.Int("min-shared-tokens", 2, "Minimum shared significant title tokens required to merge two signals")
+	dropStale := fs.Bool("drop-stale", false, "Deterministically pre-gate low-story-size signals whose detector decay is well outside the window")
+	windowHours := fs.Float64("window-hours", 24.0, "Freshness window in hours (used only to label the stale pre-gate)")
+	staleMaxBand := fs.String("stale-max-band", "moderate", "Highest story-size band eligible for the stale pre-gate drop (low|moderate|high|major); larger stories always get researched")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if *candidatesPath == "" {
+		return fail(stderr, errors.New("--candidates is required"))
+	}
+	candidates, err := readJSONMap(*candidatesPath)
+	if err != nil {
+		return fail(stderr, err)
+	}
+	output := clusterCandidates(candidates, clusterOptions{
+		TitleOverlap: *titleOverlap,
+		MinShared:    *minShared,
+		DropStale:    *dropStale,
+		WindowHours:  *windowHours,
+		StaleMaxBand: strings.ToLower(strings.TrimSpace(*staleMaxBand)),
+	})
+	data := marshalJSON(output)
+	if *outputPath != "" {
+		if err := os.WriteFile(expandPath(*outputPath), data, 0o644); err != nil {
+			return fail(stderr, err)
+		}
+	} else {
+		stdout.Write(data)
+	}
+	return 0
+}
+
+var storySizeBandRank = map[string]int{"unknown": 0, "low": 1, "moderate": 2, "high": 3, "major": 4}
+
+// staleDecayBuckets are detector decay buckets that are unambiguously older than
+// a 24h window. We never auto-drop "unknown" — only verifiably old buckets.
+var staleDecayBuckets = map[string]bool{"week": true, "month": true}
+
+type clusterGroup struct {
+	signals   []map[string]any
+	urlKeys   map[string]bool
+	seedTitle map[string]bool // significant title tokens of the seed signal
+}
+
+func clusterCandidates(candidates map[string]any, opts clusterOptions) map[string]any {
+	if opts.MinShared <= 0 {
+		opts.MinShared = 2
+	}
+	signals := signalSlice(candidates["signals"])
+	// Stable input order so clustering is deterministic regardless of map iteration.
+	sort.SliceStable(signals, func(i, j int) bool {
+		return stringValue(signals[i]["id"]) < stringValue(signals[j]["id"])
+	})
+
+	var groups []*clusterGroup
+	for _, signal := range signals {
+		urlKeys := signalURLKeys(signal)
+		titleToks := significantTitleTokens(stringValue(signal["title"]))
+		placed := false
+		for _, g := range groups {
+			oc, inter := overlapCoefficient(titleToks, g.seedTitle)
+			if shareURLKey(urlKeys, g.urlKeys) || (oc >= opts.TitleOverlap && inter >= opts.MinShared) {
+				g.signals = append(g.signals, signal)
+				for k := range urlKeys {
+					g.urlKeys[k] = true
+				}
+				placed = true
+				break
+			}
+		}
+		if !placed {
+			groups = append(groups, &clusterGroup{
+				signals:   []map[string]any{signal},
+				urlKeys:   cloneStringSet(urlKeys),
+				seedTitle: titleToks,
+			})
+		}
+	}
+
+	representatives := []map[string]any{}
+	duplicates := []map[string]any{}
+	preGated := []map[string]any{}
+	bandCounts := map[string]int{}
+	for idx, g := range groups {
+		rep := pickRepresentative(g.signals)
+		clusterID := stringValue(rep["id"])
+		memberIDs := make([]string, 0, len(g.signals))
+		for _, s := range g.signals {
+			if id := stringValue(s["id"]); id != "" && id != clusterID {
+				memberIDs = append(memberIDs, id)
+			}
+		}
+		sort.Strings(memberIDs)
+		clusterMeta := map[string]any{
+			"cluster_id":      clusterID,
+			"cluster_index":   idx,
+			"cluster_size":    len(g.signals),
+			"role":            "representative",
+			"member_count":    len(memberIDs),
+			"member_ids":      memberIDs,
+			"duplicate_count": len(memberIDs),
+		}
+		band := signalStorySizeBandValue(rep)
+		bandCounts[band]++
+		if opts.DropStale && staleEligible(rep, band, opts.StaleMaxBand) {
+			s := summarySignal(rep)
+			s["cluster"] = clusterMeta
+			s["pre_gate_reason"] = "stale_low_value"
+			s["pre_gate_rationale"] = fmt.Sprintf("decay_bucket=%s is outside the %gh window and story_size band=%s is at or below the stale-max-band; skipped expensive story-origin retrieval", signalDecayBucket(rep), opts.WindowHours, band)
+			preGated = append(preGated, s)
+		} else {
+			withCluster := cloneMap(rep)
+			withCluster["cluster"] = clusterMeta
+			representatives = append(representatives, withCluster)
+		}
+		for _, s := range g.signals {
+			if stringValue(s["id"]) == clusterID {
+				continue
+			}
+			dup := summarySignal(s)
+			dup["cluster_id"] = clusterID
+			dup["representative_id"] = clusterID
+			duplicates = append(duplicates, dup)
+		}
+	}
+
+	return map[string]any{
+		"version":      1,
+		"generated_at": time.Now().UTC().Format(time.RFC3339Nano),
+		"monitor":      valueOrEmptyMap(candidates["monitor"]),
+		"signals":      representatives,
+		"clustering": map[string]any{
+			"input_signal_count":   len(signals),
+			"cluster_count":        len(groups),
+			"representative_count": len(representatives),
+			"duplicate_count":      len(duplicates),
+			"pre_gated_count":      len(preGated),
+			"title_overlap":        opts.TitleOverlap,
+			"min_shared_tokens":    opts.MinShared,
+			"drop_stale":           opts.DropStale,
+			"stale_max_band":       opts.StaleMaxBand,
+			"story_size_bands":     sortedCountMap(bandCounts),
+		},
+		"clustered_duplicates": duplicates,
+		"pre_gated_stale":      preGated,
+		"coarse_relevance":     candidates["coarse_relevance"],
+		"detector_diagnostics": valueOrEmptyMap(candidates["detector_diagnostics"]),
+		"source_errors":        valueOrEmptyMap(candidates["source_errors"]),
+	}
+}
+
+// pickRepresentative chooses the signal that should carry the story forward:
+// highest queue priority, then largest story size, then lowest id for stability.
+func pickRepresentative(signals []map[string]any) map[string]any {
+	best := signals[0]
+	bestQ := queuePriority(best)
+	bestS, _ := signalStorySizeScore(best)
+	for _, s := range signals[1:] {
+		q := queuePriority(s)
+		size, _ := signalStorySizeScore(s)
+		switch {
+		case q > bestQ:
+			best, bestQ, bestS = s, q, size
+		case q == bestQ && size > bestS:
+			best, bestQ, bestS = s, q, size
+		case q == bestQ && size == bestS && stringValue(s["id"]) < stringValue(best["id"]):
+			best = s
+		}
+	}
+	return best
+}
+
+func staleEligible(signal map[string]any, band, staleMaxBand string) bool {
+	if !staleDecayBuckets[signalDecayBucket(signal)] {
+		return false
+	}
+	maxRank, ok := storySizeBandRank[staleMaxBand]
+	if !ok {
+		maxRank = storySizeBandRank["moderate"]
+	}
+	return storySizeBandRank[band] <= maxRank
+}
+
+func signalDecayBucket(signal map[string]any) string {
+	return strings.ToLower(stringValue(valueOrEmptyMap(signal["features"])["decay_bucket"]))
+}
+
+func signalStorySizeBandValue(signal map[string]any) string {
+	if band := strings.ToLower(stringValue(valueOrEmptyMap(signal["story_size"])["band"])); band != "" {
+		return band
+	}
+	if score, ok := signalStorySizeScore(signal); ok {
+		return storySizeBand(score * 100.0)
+	}
+	return "unknown"
+}
+
+func signalURLKeys(signal map[string]any) map[string]bool {
+	out := map[string]bool{}
+	for _, raw := range anySlice(signal["evidence"]) {
+		if m, ok := raw.(map[string]any); ok {
+			if k := normalizedURLKey(stringValue(m["url"])); k != "" {
+				out[k] = true
+			}
+		}
+	}
+	return out
+}
+
+// clusterStopwords are common headline filler that should not count as a shared
+// "anchor" between two same-story headlines.
+var clusterStopwords = stringSet(strings.Fields("the a an of to in on for and or with as at by from is are be new this that its has have will into over after amid out get said says how why what can also more their our your you not but its it's about up down off launches launch unveils announces reveals brings makes adds gets sets first amid"))
+
+// significantTitleTokens returns the distinctive lowercase tokens of a title:
+// length >= 3, not a stopword. Cross-outlet headlines about the same event share
+// their key nouns (entities, products, actions) even when the rest differs.
+func significantTitleTokens(title string) map[string]bool {
+	out := map[string]bool{}
+	for tok := range tokens(title) {
+		if len(tok) >= 3 && !clusterStopwords[tok] {
+			out[tok] = true
+		}
+	}
+	return out
+}
+
+func shareURLKey(a, b map[string]bool) bool {
+	for k := range a {
+		if b[k] {
+			return true
+		}
+	}
+	return false
+}
+
+// overlapCoefficient returns |a∩b| / min(|a|,|b|) and the intersection size.
+// Unlike Jaccard it is not diluted by one headline carrying many extra words,
+// so a short shared core of entities still scores high.
+func overlapCoefficient(a, b map[string]bool) (float64, int) {
+	if len(a) == 0 || len(b) == 0 {
+		return 0, 0
+	}
+	inter := 0
+	for t := range a {
+		if b[t] {
+			inter++
+		}
+	}
+	min := len(a)
+	if len(b) < min {
+		min = len(b)
+	}
+	return float64(inter) / float64(min), inter
+}
+
+func cloneStringSet(in map[string]bool) map[string]bool {
+	out := make(map[string]bool, len(in))
+	for k := range in {
+		out[k] = true
+	}
+	return out
+}

--- a/apps/cli/cmd/newsjack/cluster_test.go
+++ b/apps/cli/cmd/newsjack/cluster_test.go
@@ -1,0 +1,87 @@
+package main
+
+import "testing"
+
+func sig(id, title, url string, queue float64, band, decay string) map[string]any {
+	return map[string]any{
+		"id":    id,
+		"title": title,
+		"evidence": []any{
+			map[string]any{"source": "news_search", "title": title, "url": url, "excerpt": title},
+		},
+		"routing":    map[string]any{"queue_priority": queue},
+		"story_size": map[string]any{"band": band, "score": 50.0},
+		"features":   map[string]any{"decay_bucket": decay},
+	}
+}
+
+func TestClusterCollapsesSameStoryAndKeepsDistinct(t *testing.T) {
+	candidates := map[string]any{
+		"signals": []any{
+			sig("a", "Nvidia unveils RTX Spark superchip for Windows PCs", "https://nyt.com/a", 60, "high", "24hr"),
+			sig("b", "Nvidia unveils RTX Spark superchip for Windows PCs today", "https://bbc.com/b", 55, "high", "24hr"),
+			sig("c", "Connecticut enacts new data privacy delete act", "https://ct.gov/c", 50, "moderate", "24hr"),
+		},
+	}
+	out := clusterCandidates(candidates, clusterOptions{TitleOverlap: 0.6})
+	reps := signalSlice(out["signals"])
+	if len(reps) != 2 {
+		t.Fatalf("representatives=%d, want 2 (one NVIDIA cluster + the distinct CT story); reps=%#v", len(reps), reps)
+	}
+	dups, _ := out["clustered_duplicates"].([]map[string]any)
+	if len(dups) != 1 {
+		t.Fatalf("duplicates=%d, want 1", len(dups))
+	}
+	// The NVIDIA representative must be the higher-queue signal "a".
+	for _, r := range reps {
+		cl := valueOrEmptyMap(r["cluster"])
+		if numberOr(cl["cluster_size"]) == 2 && stringValue(r["id"]) != "a" {
+			t.Fatalf("NVIDIA representative=%s, want a (highest queue priority)", stringValue(r["id"]))
+		}
+	}
+}
+
+func TestClusterSharedURLForcesSameCluster(t *testing.T) {
+	shared := "https://wire.example.com/story"
+	candidates := map[string]any{
+		"signals": []any{
+			sig("a", "Totally different headline one", shared, 60, "moderate", "24hr"),
+			sig("b", "Completely unrelated wording two", shared, 40, "moderate", "24hr"),
+		},
+	}
+	out := clusterCandidates(candidates, clusterOptions{TitleOverlap: 0.9})
+	if reps := signalSlice(out["signals"]); len(reps) != 1 {
+		t.Fatalf("representatives=%d, want 1 (shared evidence URL collapses them)", len(reps))
+	}
+}
+
+func TestClusterStalePreGateDropsOldLowValueOnly(t *testing.T) {
+	candidates := map[string]any{
+		"signals": []any{
+			sig("old_small", "Old minor trend piece", "https://x.com/1", 45, "moderate", "week"),
+			sig("old_big", "Old but major story", "https://x.com/2", 45, "major", "month"),
+			sig("fresh_small", "Fresh minor item", "https://x.com/3", 45, "low", "24hr"),
+		},
+	}
+	out := clusterCandidates(candidates, clusterOptions{TitleOverlap: 0.6, DropStale: true, WindowHours: 24, StaleMaxBand: "moderate"})
+	reps := signalSlice(out["signals"])
+	pre, _ := out["pre_gated_stale"].([]map[string]any)
+	if len(pre) != 1 || stringValue(pre[0]["signal_id"]) != "old_small" {
+		t.Fatalf("pre_gated=%#v, want exactly old_small", pre)
+	}
+	repIDs := map[string]bool{}
+	for _, r := range reps {
+		repIDs[stringValue(r["id"])] = true
+	}
+	if !repIDs["old_big"] {
+		t.Fatalf("old_big (major story) must be researched, not pre-gated; reps=%v", repIDs)
+	}
+	if !repIDs["fresh_small"] {
+		t.Fatalf("fresh_small must be researched (recent decay); reps=%v", repIDs)
+	}
+}
+
+func numberOr(v any) float64 {
+	f, _ := numberValue(v)
+	return f
+}

--- a/apps/cli/cmd/newsjack/detector_command.go
+++ b/apps/cli/cmd/newsjack/detector_command.go
@@ -20,6 +20,7 @@ type detectorOptions struct {
 	NoProfileFeeds                  bool
 	NoXNews                         bool
 	NoXTrends                       bool
+	DemoteUnmatchedX                bool
 	NoHygieneFilter                 bool
 	Depth                           string
 	LookbackDays                    int
@@ -118,6 +119,7 @@ func parseDetectorRun(args []string, stderr io.Writer) (detectorOptions, int) {
 	fs.BoolVar(&opts.NoProfileFeeds, "no-profile-feeds", false, "Do not include feed_urls from profile")
 	fs.BoolVar(&opts.NoXNews, "no-x-news", false, "Do not auto-include x_news")
 	fs.BoolVar(&opts.NoXTrends, "no-x-trends", false, "Do not include x_trends")
+	fs.BoolVar(&opts.DemoteUnmatchedX, "demote-unmatched-x", false, "Recurring-precision mode: cap unmatched X News/Trends below the default queue floor so they only surface via the large-story recall guard")
 	fs.BoolVar(&opts.NoHygieneFilter, "no-hygiene-filter", false, "Disable deterministic hygiene filter")
 	fs.StringVar(&opts.Depth, "depth", "quick", "quick, default, or deep")
 	fs.IntVar(&opts.LookbackDays, "lookback-days", 1, "Lookback window in days")

--- a/apps/cli/cmd/newsjack/detector_scoring.go
+++ b/apps/cli/cmd/newsjack/detector_scoring.go
@@ -631,7 +631,11 @@ func scoreSignal(cluster signalCluster, profile monitorProfile, seen map[string]
 	case "x_trends_unmatched":
 		queue = round1(math.Min(39.9, 100*(0.16*freshness+0.14*novelty+0.12*sourceQuality+0.10*engagement)))
 	case "x_news_unmatched":
-		queue = round1(math.Min(42.0, 100*(0.18*freshness+0.16*sourceAgreement+0.14*novelty+0.10*sourceQuality+0.08*engagement)))
+		xNewsCap := 42.0
+		if opts.DemoteUnmatchedX {
+			xNewsCap = 39.9
+		}
+		queue = round1(math.Min(xNewsCap, 100*(0.18*freshness+0.16*sourceAgreement+0.14*novelty+0.10*sourceQuality+0.08*engagement)))
 	case "profile_relevance_weak", "x_posts_weak":
 		queue = round1(math.Min(39.9, 100*(0.18*freshness+0.16*sourceAgreement+0.14*novelty+0.10*sourceQuality+0.08*engagement)))
 	case "x_posts":

--- a/apps/cli/cmd/newsjack/filter_test.go
+++ b/apps/cli/cmd/newsjack/filter_test.go
@@ -464,8 +464,8 @@ func TestOriginApplyDowngradesWhenWorkerCitesOnlySurfacedURL(t *testing.T) {
 		t.Fatalf("rejected=%d, want 1; gate=%#v", len(rejected), gate)
 	}
 	rg := valueOrEmptyMap(rejected[0]["freshness_gate"])
-	if rg["computed_status"] != "freshness_unverified" {
-		t.Fatalf("computed_status=%v, want freshness_unverified; gate=%#v", rg["computed_status"], rg)
+	if rg["computed_status"] != "unverified_no_corroboration" {
+		t.Fatalf("computed_status=%v, want unverified_no_corroboration; gate=%#v", rg["computed_status"], rg)
 	}
 	if rg["worker_status"] != "fresh" {
 		t.Fatalf("worker_status=%v, want fresh (preserved); gate=%#v", rg["worker_status"], rg)

--- a/apps/cli/cmd/newsjack/main.go
+++ b/apps/cli/cmd/newsjack/main.go
@@ -90,6 +90,8 @@ func runCLIWithIO(args []string, stdin io.Reader, stdout, stderr io.Writer) int 
 		return cmdMonitor(args[1:], stdout, stderr)
 	case "filter-apply":
 		return cmdFilterApply(args[1:], stdout, stderr)
+	case "cluster":
+		return cmdCluster(args[1:], stdout, stderr)
 	case "origin-apply":
 		return cmdOriginApply(args[1:], stdout, stderr)
 	case "render-run":

--- a/apps/cli/cmd/newsjack/origin.go
+++ b/apps/cli/cmd/newsjack/origin.go
@@ -232,7 +232,7 @@ func computeFreshnessGate(origin map[string]any, runTime, cutoff time.Time, wind
 			if promoted, ok := promotePreciseFreshTimestamp(origin, runTime, cutoff, windowHours, workerStatus, "fresh_new_development"); ok {
 				return promoted
 			}
-			return freshnessGate("freshness_unverified", runTime, cutoff, windowHours, workerStatus, "new_development_at", newRaw, precision, "new_development_at has date-only precision on the cutoff date")
+			return freshnessGate("unverified_boundary", runTime, cutoff, windowHours, workerStatus, "new_development_at", newRaw, precision, "new_development_at has date-only precision straddling the cutoff date")
 		}
 		if firstRaw == "" {
 			return freshnessGate("stale", runTime, cutoff, windowHours, workerStatus, "new_development_at", newRaw, precision, "new_development_at is before the freshness cutoff")
@@ -249,10 +249,10 @@ func computeFreshnessGate(origin map[string]any, runTime, cutoff time.Time, wind
 			if promoted, ok := promotePreciseFreshTimestamp(origin, runTime, cutoff, windowHours, workerStatus, "fresh"); ok {
 				return promoted
 			}
-			return freshnessGate("freshness_unverified", runTime, cutoff, windowHours, workerStatus, "first_public_at", firstRaw, precision, "first_public_at has date-only precision on the cutoff date")
+			return freshnessGate("unverified_boundary", runTime, cutoff, windowHours, workerStatus, "first_public_at", firstRaw, precision, "first_public_at has date-only precision straddling the cutoff date")
 		}
 	}
-	return freshnessGate("freshness_unverified", runTime, cutoff, windowHours, workerStatus, "", "", "", "first_public_at is missing or unparseable")
+	return freshnessGate("unverified_no_timestamp", runTime, cutoff, windowHours, workerStatus, "", "", "", "first_public_at is missing or unparseable")
 }
 
 func promotePreciseFreshTimestamp(origin map[string]any, runTime, cutoff time.Time, windowHours float64, workerStatus, status string) (map[string]any, bool) {
@@ -357,8 +357,8 @@ func enforceSupportingEvidence(gate, finding, signal map[string]any) map[string]
 		return gate
 	}
 	downgraded := cloneMap(gate)
-	downgraded["computed_status"] = "freshness_unverified"
-	downgraded["rationale"] = "no independent timestamp_evidence: worker cited only the surfaced URL"
+	downgraded["computed_status"] = "unverified_no_corroboration"
+	downgraded["rationale"] = "fewer than two independent corroborating sources: worker cited only the surfaced URL"
 	downgraded["worker_status"] = nullableString(status)
 	return downgraded
 }

--- a/apps/cli/cmd/newsjack/pipeline_precision_test.go
+++ b/apps/cli/cmd/newsjack/pipeline_precision_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDemoteUnmatchedXLowersBelowFloor(t *testing.T) {
+	now := time.Date(2026, 5, 25, 13, 0, 0, 0, time.UTC)
+	profile := monitorProfile{Company: "Clearnym", Topics: []string{"data broker removal"}}
+	item := evidenceItem{
+		Source:      "x_news",
+		Title:       "Coffee shops face rising import prices",
+		URL:         "https://example.com/coffee-xnews",
+		Excerpt:     "Independent cafes are tracking higher bean costs.",
+		Container:   "X News",
+		PublishedAt: now.Add(-1 * time.Hour).Format(time.RFC3339),
+		Metadata:    map[string]any{},
+	}
+	base := detectorOptions{LookbackDays: 1, XNewsMinProfileMatch: 0.05, XTrendsMinProfileMatch: 0.05, XPostsMinProfileMatch: 0.08}
+
+	def := scoreSignal(signalCluster{Evidence: []evidenceItem{item}}, profile, map[string]map[string]any{}, now, base)
+	if signalLaneValue(def) != "x_news_unmatched" {
+		t.Fatalf("lane=%s, want x_news_unmatched", signalLaneValue(def))
+	}
+	if queuePriority(def) < defaultMinQueuePriority {
+		t.Fatalf("default x_news_unmatched=%v, want surfaced (>= %v)", queuePriority(def), defaultMinQueuePriority)
+	}
+
+	demoteOpts := base
+	demoteOpts.DemoteUnmatchedX = true
+	dem := scoreSignal(signalCluster{Evidence: []evidenceItem{item}}, profile, map[string]map[string]any{}, now, demoteOpts)
+	if queuePriority(dem) >= defaultMinQueuePriority {
+		t.Fatalf("demoted x_news_unmatched=%v, want below default floor %v", queuePriority(dem), defaultMinQueuePriority)
+	}
+}
+
+func TestOriginBoundaryStatus(t *testing.T) {
+	candidates := map[string]any{
+		"monitor": map[string]any{"generated_at": "2026-05-27T19:00:00Z"},
+		"signals": []any{map[string]any{"id": "s1", "title": "Boundary story",
+			"evidence": []any{map[string]any{"source": "news_search", "url": "https://a.com/x"}}}},
+	}
+	origins := map[string]any{"findings": []any{map[string]any{
+		"signal_id": "s1", "first_public_at": "2026-05-26", // date-only on the cutoff day
+	}}}
+	payload, err := applyOriginFindings(candidates, origins, originApplyOptions{
+		RunTime: mustParseTestTime(t, "2026-05-27T19:00:00Z"), WindowHours: 24})
+	if err != nil {
+		t.Fatalf("err=%v", err)
+	}
+	rejected, _ := valueOrEmptyMap(payload["freshness_gate"])["rejected_signals"].([]map[string]any)
+	if len(rejected) != 1 {
+		t.Fatalf("rejected=%d, want 1", len(rejected))
+	}
+	if got := stringValue(valueOrEmptyMap(rejected[0]["freshness_gate"])["computed_status"]); got != "unverified_boundary" {
+		t.Fatalf("computed_status=%s, want unverified_boundary", got)
+	}
+}
+
+func TestOriginNoTimestampStatus(t *testing.T) {
+	candidates := map[string]any{
+		"monitor": map[string]any{"generated_at": "2026-05-27T19:00:00Z"},
+		"signals": []any{map[string]any{"id": "s1", "title": "No timestamp story",
+			"evidence": []any{map[string]any{"source": "news_search", "url": "https://a.com/x"}}}},
+	}
+	origins := map[string]any{"findings": []any{map[string]any{
+		"signal_id": "s1", "first_public_at": nil, "same_story_assessment": "unclear",
+	}}}
+	payload, err := applyOriginFindings(candidates, origins, originApplyOptions{
+		RunTime: mustParseTestTime(t, "2026-05-27T19:00:00Z"), WindowHours: 24})
+	if err != nil {
+		t.Fatalf("err=%v", err)
+	}
+	rejected, _ := valueOrEmptyMap(payload["freshness_gate"])["rejected_signals"].([]map[string]any)
+	if len(rejected) != 1 {
+		t.Fatalf("rejected=%d, want 1", len(rejected))
+	}
+	if got := stringValue(valueOrEmptyMap(rejected[0]["freshness_gate"])["computed_status"]); got != "unverified_no_timestamp" {
+		t.Fatalf("computed_status=%s, want unverified_no_timestamp", got)
+	}
+}

--- a/fixtures/newsjack-detector-agent/scripts/build_report.py
+++ b/fixtures/newsjack-detector-agent/scripts/build_report.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Compile final_report.md for a detector run dir.
+
+Story-first report. Every story shows ONE main link (the detector-surfaced
+source of record) plus related links (clustered duplicate pickups + any
+canonical the research worker proposed). Every link carries a date and a
+provenance tag, so worker-introduced links are never laundered into the
+report as established coverage. Usage: build_report.py RUN_DIR
+"""
+import json, os, re, sys
+
+CLIENTS = {"bluebottle": "Blue Bottle Coffee", "clearnym": "Clearnym", "localfalcon": "Local Falcon",
+           "nofar-method": "Nofar Method", "property-saviour": "Property Saviour", "simular": "Simular", "slite": "Slite"}
+# Domains that are aggregators / low-authority republishers, not a source of record.
+AGGREGATORS = ("kucoin.com", "startupfortune.com", "vocal.media", "x.com", "twitter.com",
+               "bitget.com", "stocktitan", "markets.businessinsider", "einpresswire", "manilatimes")
+GATE_LABEL = {
+    "stale": "Stale — older than 24h, or a newer pickup of an older original",
+    "unverified_no_corroboration": "Unverified — fewer than 2 independent corroborating sources",
+    "unverified_no_timestamp": "Unverified — no first-public timestamp recovered",
+    "unverified_boundary": "Unverified — date-only clock straddling the cutoff",
+}
+
+
+def load(run, name):
+    p = os.path.join(run, name)
+    return json.load(open(p)) if os.path.exists(p) else None
+
+
+def norm_url(u):
+    u = (u or "").strip().lower()
+    u = re.sub(r"^https?://", "", u)
+    u = re.sub(r"[?#].*$", "", u)
+    return u.rstrip("/")
+
+
+def domain(u):
+    m = re.sub(r"^https?://", "", (u or "").strip().lower())
+    return m.split("/")[0].removeprefix("www.")
+
+
+def mdlink(t, u):
+    t = (t or "").strip().replace("[", "(").replace("]", ")") or domain(u)
+    return f"[{t}]({u})" if u else (t or "")
+
+
+def evidence_index(candidates):
+    """signal_id -> list of surfaced evidence dicts (real provenance)."""
+    idx = {}
+    for s in (candidates.get("signals") or []):
+        idx[s["id"]] = s.get("evidence") or []
+    return idx
+
+
+def main_and_related(rep, dups, ev_idx, story_origin):
+    """Return (main_link, related_links, surfaced_url_set, source_count)."""
+    rep_ev = ev_idx.get(rep["id"], rep.get("evidence") or [])
+    surfaced = []
+    for e in rep_ev:
+        surfaced.append({"title": e.get("title") or e.get("container"), "url": e.get("url"),
+                         "src": e.get("container") or e.get("source"), "date": e.get("published_at"),
+                         "prov": "surfaced"})
+    # cluster duplicates (same story, other outlets) — surfaced, pull dates from candidates
+    related = []
+    for d in dups:
+        for u in (d.get("evidence_urls") or []):
+            de = next((e for e in ev_idx.get(d.get("signal_id"), []) if e.get("url") == u), {})
+            related.append({"title": d.get("signal_title"), "url": u,
+                            "src": de.get("container") or (d.get("sources") or ["?"])[0],
+                            "date": de.get("published_at"), "prov": "surfaced duplicate"})
+    surfaced_urls = {norm_url(x["url"]) for x in surfaced + related if x["url"]}
+    # main link = source of record: prefer a non-aggregator surfaced source, else first surfaced
+    main = None
+    for x in surfaced:
+        if x["url"] and not any(a in domain(x["url"]) for a in AGGREGATORS):
+            main = x
+            break
+    if main is None and surfaced:
+        main = surfaced[0]
+    # any extra surfaced beyond main -> related
+    for x in surfaced:
+        if x is not main:
+            related.append(x)
+    # worker-proposed canonical / original -> related, flagged unverified if not surfaced
+    so = story_origin or {}
+    for url, datekey, label in [
+        (so.get("canonical_coverage_url"), so.get("canonical_coverage_published_at"), so.get("canonical_coverage_source") or "canonical"),
+        (so.get("original_url"), so.get("first_public_at"), so.get("original_source") or "original"),
+    ]:
+        if not url:
+            continue
+        if norm_url(url) in surfaced_urls:
+            continue  # already shown as a real surfaced link
+        if any(norm_url(url) == norm_url(r["url"]) for r in related):
+            continue
+        related.append({"title": label, "url": url, "src": domain(url), "date": datekey,
+                        "prov": "proposed by research — UNVERIFIED"})
+    # distinct surfaced source domains
+    src_domains = {domain(x["url"]) for x in surfaced if x["url"]} | {domain(r["url"]) for r in related if r["url"] and r["prov"].startswith("surfaced")}
+    return main, related, len(src_domains)
+
+
+def fmt_link(x):
+    date = x.get("date") or "no date"
+    tag = x["prov"]
+    if tag.startswith("proposed"):
+        date = f"{date} — date unverified"
+    dom = domain(x["url"]) if x.get("url") else x.get("src")
+    return f"{mdlink(x.get('title'), x.get('url'))} — {dom}, {date} · `{tag}`"
+
+
+def build(run):
+    name = os.path.basename(run).split("_", 1)[1]
+    client = CLIENTS.get(name, name)
+    candidates = load(run, "candidates.json") or {}
+    clustered = load(run, "clustered_candidates.json") or {}
+    targeted = load(run, "targeted_candidates.json") or {}
+    triaged = (load(run, "triaged_candidates.json") or {}).get("triaged", [])
+    ev_idx = evidence_index(candidates)
+    clm = clustered.get("clustering", {})
+    sel = {s["id"]: s for s in (targeted.get("signals") or [])}
+    dups_by_rep = {}
+    for d in (clustered.get("clustered_duplicates") or []):
+        dups_by_rep.setdefault(d.get("representative_id"), []).append(d)
+    rej = (targeted.get("freshness_gate") or {}).get("rejected_signals") or []
+    adv = [t for t in triaged if t.get("gate") == "advance"]
+    drop = [t for t in triaged if t.get("gate") == "drop"]
+
+    P = [f"# {client} — Newsjack Detector Report", ""]
+    P.append(f"**Funnel:** {len(candidates.get('signals') or [])} candidates → "
+             f"{clm.get('representative_count','?')} story representatives "
+             f"({clm.get('duplicate_count',0)} duplicates collapsed) → {len(sel)} fresh → "
+             f"**{len(adv)} advanced by standing triage**.")
+    P.append("")
+    P.append("## Top News Today")
+    P.append("")
+    if not adv:
+        P.append(f"**Nothing cleared the standing gate this window.** See Watch / Not A Fit." if sel
+                 else "**Nothing cleared the freshness gate this window.**")
+    for i, t in enumerate(adv, 1):
+        sid = t["signal_id"]; s = sel.get(sid, {}); so = s.get("story_origin") or {}
+        dups = dups_by_rep.get(sid, [])
+        main, related, nsrc = main_and_related(s, dups, ev_idx, so)
+        cf = t.get("consolidated_from") or []
+        note = f" _(consolidates {len(cf)+1} same-event pickups)_" if cf else (f" _(collapses {len(dups)+1} pickups)_" if dups else "")
+        P.append(f"### {i}. {t.get('signal_title') or s.get('title','')}{note}")
+        # standing + freshness with BOTH dates for new-development
+        gate = (s.get("freshness_gate") or {}).get("computed_status")
+        fp = so.get("first_public_at")
+        if gate == "fresh_new_development":
+            P.append(f"- **Freshness:** `{gate}` — first public **{fp}**; new development **{so.get('new_development_at')}**: {so.get('new_development')}")
+        else:
+            P.append(f"- **Freshness:** `{gate}` — first public **{fp}**")
+        P.append(f"- **Standing:** `{t.get('standing')}` — {t.get('standing_rationale','')}"
+                 + ("  _(proof-gated)_" if t.get("proof_gated") else ""))
+        flag = " ⚠ **single source**" if nsrc <= 1 else ""
+        if main and any(a in domain(main['url']) for a in AGGREGATORS):
+            flag += " ⚠ **source of record is an aggregator**"
+        P.append(f"- **Main source:** {fmt_link(main) if main else '_none surfaced_'}")
+        P.append(f"- **Provenance:** {nsrc} surfaced source domain(s){flag}")
+        if related:
+            P.append("- **Related coverage:**")
+            for r in related:
+                P.append(f"  - {fmt_link(r)}")
+        # angles
+        ang = load(run, f"angles.{sid[:8]}.json")
+        if ang and ang.get("angles"):
+            P.append("- **angle-generator angles:**")
+            for a in ang["angles"]:
+                js = a.get("journalist_shape") or {}
+                P.append(f"  - *{a.get('headline_frame')}* — {(js.get('beat_description') or '')[:110]} _(decay {(a.get('decay') or {}).get('stage')})_")
+        P.append("")
+    if drop:
+        P.append("**Also fresh — dropped by triage:**")
+        for t in drop:
+            P.append(f"- **[NOT A FIT]** {t.get('signal_title','')[:80]} — `{t.get('drop_reason')}`: {t.get('standing_rationale','')[:130]}")
+        P.append("")
+
+    P.append("## Watch / Not A Fit")
+    P.append("")
+    from collections import defaultdict
+    g = defaultdict(list)
+    for r in rej:
+        g[(r.get("freshness_gate") or {}).get("computed_status")].append(r)
+    any_w = False
+    for st in ("stale", "unverified_no_corroboration", "unverified_boundary", "unverified_no_timestamp"):
+        items = g.get(st) or []
+        if not items:
+            continue
+        any_w = True
+        P.append(f"**{GATE_LABEL.get(st, st)}** ({len(items)})")
+        for r in items:
+            so = r.get("story_origin") or {}
+            link = so.get("canonical_coverage_url") or (so.get("evidence_urls") or r.get("evidence_urls") or [None])[0]
+            P.append(f"- {mdlink(r.get('signal_title'), link)} — first public {so.get('first_public_at') or 'unverified'}")
+        P.append("")
+    if not any_w:
+        P.append("_Nothing gated out this window._")
+    open(os.path.join(run, "final_report.md"), "w").write("\n".join(P))
+    return len(adv), len(drop), len(rej)
+
+
+if __name__ == "__main__":
+    run = sys.argv[1]
+    a, d, r = build(run)
+    print(f"{os.path.basename(run)}: advanced={a} dropped={d} gated={r}")

--- a/skills/newsjack-detector/SKILL.md
+++ b/skills/newsjack-detector/SKILL.md
@@ -75,8 +75,10 @@ RUN_DIR/
   candidates.json              # 1. detector output
   coarse_relevance_decisions.json   # 2. coarse pass
   relevant_candidates.json     # 3. filter-apply
-  origin_findings.json         # 4. story-origin pass
+  clustered_candidates.json    # 3b. cluster — same-story dedup + stale pre-gate
+  origin_findings.json         # 4. story-origin pass (representatives only)
   targeted_candidates.json     # 5. origin-apply (freshness authority)
+  triaged_candidates.json      # 5b. newsjack-triage — standing + consolidation
   final_report.md              # 7. compiled report
   run.md                       # 8. rerendered — THE human-facing artifact
   detector.stderr.log  commands.log  summary.json
@@ -98,24 +100,36 @@ Only `run.md` is human-facing; the rest are provenance.
    ~/.newsjack/bin/newsjack filter-apply --candidates candidates.json --decisions coarse_relevance_decisions.json --include keep --include monitor_only --output relevant_candidates.json
    ```
 
-4. **Story-origin pass** on `relevant_candidates.json` → `origin_findings.json`. Each worker loads `skills/story-origin-check/SKILL.md` and applies it per signal: decide same-story vs material-new-development, recover `first_public_at`, `original_url`, and canonical major coverage. It must **not** compute `fresh`/`stale`. Merge the per-signal results into one `findings` array, keyed by `signal_id`. The story-origin pass needs retrieval — see `references/harness-routing.md` for what to do when a low-cost worker cannot search or open pages.
+3b. **Cluster same-story signals before the expensive retrieval pass:**
+
+   ```bash
+   ~/.newsjack/bin/newsjack cluster --candidates relevant_candidates.json --drop-stale --window-hours 24 --output clustered_candidates.json
+   ```
+
+   The Go CLI collapses syndicated pickups / near-duplicate headlines of the **same public event** into one representative (it shares findings, so 15 NVIDIA-GTC copies cost one story-origin retrieval, not 15) and records the rest in `clustered_duplicates`. `--drop-stale` deterministically pre-gates low-story-size signals whose detector decay is clearly outside the window (`week`/`month`) into `pre_gated_stale`, so they skip retrieval entirely; large stories (`high`/`major`) are always researched regardless of age. Run story-origin on `clustered_candidates.json` (representatives only). Disclose how many duplicates and stale items were collapsed.
+
+4. **Story-origin pass** on `clustered_candidates.json` (representatives) → `origin_findings.json`. Each worker loads `skills/story-origin-check/SKILL.md` and applies it per signal: decide same-story vs material-new-development, recover `first_public_at`, `original_url`, and canonical major coverage. It must **not** compute `fresh`/`stale`, must return **one finding per signal (never skip)**, and must cite **≥2 independent corroborating sources** to support a fresh clock. Merge the per-signal results into one `findings` array, keyed by `signal_id`. Validate the count against the input and re-run any gaps. The story-origin pass needs retrieval — see `references/harness-routing.md`.
 
 5. **Apply the deterministic freshness gate:**
 
    ```bash
-   ~/.newsjack/bin/newsjack origin-apply --candidates relevant_candidates.json --origins origin_findings.json --window-hours 24 --output targeted_candidates.json
+   ~/.newsjack/bin/newsjack origin-apply --candidates clustered_candidates.json --origins origin_findings.json --window-hours 24 --output targeted_candidates.json
    ```
 
-   The Go CLI is the freshness authority — it computes `freshness_gate.computed_status` from the run timestamp and cutoff. If an LLM labels May 8 fresh for a May 25 run, `origin-apply` marks it stale.
+   The Go CLI is the freshness authority — it computes `freshness_gate.computed_status` from the run timestamp and cutoff. If an LLM labels May 8 fresh for a May 25 run, `origin-apply` marks it stale. Non-fresh signals carry a specific reason: `stale`, `unverified_no_corroboration` (worker cited <2 independent sources — a pipeline/worker-quality miss), `unverified_boundary` (date-only clock straddling the cutoff), or `unverified_no_timestamp` (no clock recovered). Distinguish these in the report and in metrics: `unverified_no_corroboration` means *we* didn't verify, not that the story is old.
 
-6. **Angle generation** on the high-priority fresh candidates in `targeted_candidates.json`. `angle-generator` is the atomic fit step: a candidate is useful only if it yields at least one honest, journalist-shaped angle. Reject/downgrade candidates that return zero viable angles, duplicate/slop angles, or no specific journalist shape.
+5b. **Standing triage** on the selected fresh signals in `targeted_candidates.json` → `triaged_candidates.json`. Load `skills/newsjack-triage/SKILL.md`: re-consolidate any same-story representatives that slipped through, assign `strong`/`partial`/`none` standing with a journalist-shape sanity check, and advance only distinct, has-standing stories. This is the standing gate the engine cannot make — it replaces ad-hoc orchestrator judgment so the decision is auditable. `none`-standing items go straight to Watch / Not A Fit.
 
-7. **Compile `final_report.md`** — story-first and skimmable:
-   - `## Top News Today`: current stories in priority order — story size, link, fit status, and three suggested `angle-generator` angles for each non-rejected story.
-   - `## Top Positioning Angles`: the strongest ways the client can enter, each anchored to specific news item(s) and story size.
-   - `## Watch / Not A Fit`: relevant-but-not-ready and rejected items with a plain reason.
+6. **Angle generation** on the **advanced** candidates in `triaged_candidates.json`. `angle-generator` is the atomic fit step: a candidate is useful only if it yields at least one honest, journalist-shaped angle. Reject/downgrade candidates that return zero viable angles, duplicate/slop angles, or no specific journalist shape.
 
-   Links must be clickable Markdown, not backticked or bare URLs. Do not present mechanical rank as a final fit verdict; do not mix story headlines and angle headlines without labeling which is which.
+7. **Compile `final_report.md`** — story-first and skimmable. The fixture's `scripts/build_report.py` is the reference implementation:
+   - `## Top News Today`: each advanced story shows freshness (with **both** the first-public date *and* the new-development date for `fresh_new_development`), standing, the angle-generator angles, and — critically — its **link provenance**:
+     - **One main source = the source of record**: the article the detector actually surfaced, with its real `published_at`. Flag it when the provenance is thin (`⚠ single source`, `⚠ source of record is an aggregator`).
+     - **Related coverage** underneath: the clustered duplicate pickups (real, dated, tagged `surfaced duplicate`) plus any `canonical_coverage_url`/`original_url` the story-origin worker *proposed*. A proposed link is shown with its date marked **unverified** and tagged `proposed by research — UNVERIFIED`. **Never promote a worker-proposed link into the main-source position** — it has no provenance until a source actually surfaced it. This is the anti-laundering rule: a fabricated-looking authoritative link (e.g. an NVIDIA newsroom URL the worker attached to a single KuCoin pickup) must read as unverified, not as established coverage.
+   - Every link — main and related — carries a date; dates that are only the worker's claim are marked unverified, never shown as fact.
+   - `## Watch / Not A Fit`: gated and triage-dropped items with the plain reason and date.
+
+   Links must be clickable Markdown, not backticked or bare URLs. Do not present mechanical rank as a final fit verdict.
 
 8. **Render the run report.** `render-run` is a deterministic formatter — it decides nothing, but it will **not** render a coarse-rejected or hard-safety-flagged signal into the human brief, and it discloses how many it withheld.
 
@@ -133,12 +147,14 @@ For recurring scheduled output, a signal is not surfaceable until its Go-compute
 
 Recurring output rules:
 
-- Surface only `fresh` or `fresh_new_development`. Reject `stale`. Reject when the first-public timestamp cannot be verified inside the last 24 hours, with reason `freshness_unverified`.
+- Surface only `fresh` or `fresh_new_development`. Reject `stale` and every `unverified_*` status. The unverified statuses are distinct on purpose: `unverified_no_corroboration` (worker cited <2 independent sources — a *pipeline* miss, often re-runnable), `unverified_boundary` (date-only clock straddling the cutoff), `unverified_no_timestamp` (no clock recovered). Report them separately so worker-quality misses are not mistaken for genuinely old stories.
+- Run with `--demote-unmatched-x` so unmatched X News/Trends clusters fall below the queue floor unless the large-story recall guard lifts them. X News surfaces for review by default; recurring precision wants it demoted unless it is a genuinely large story.
+- Cluster (step 3b) before retrieval and prefer `--drop-stale` so syndicated duplicates and clearly-old low-value items never burn story-origin retrieval.
 - Do **not** reset the clock for AOL, Yahoo, MSN, Apple News, partner syndication, wire pickup, SEO rewrites, or "published today" pages whose canonical/source story is older.
 - A newer article restarts the clock only if it adds a concrete new public fact: official action, filing, statement, data/report publication, material company update, new local impact, or another independently coverable development.
 - Prefer `story_origin.canonical_coverage_url` as the report's main link — the major/most authoritative same-story coverage, not the random pickup that triggered retrieval.
 
-`origin-apply` attaches `story_origin` and the deterministic `freshness_gate` to selected and rejected signals. If the first-public timestamp can't be verified, write `first_public_at: null` and explain the gap; `origin-apply` computes `freshness_unverified`.
+`origin-apply` attaches `story_origin` and the deterministic `freshness_gate` to selected and rejected signals. If the first-public timestamp can't be verified, write `first_public_at: null` and explain the gap; `origin-apply` computes the appropriate `unverified_*` status.
 
 ## Handoff
 
@@ -152,8 +168,9 @@ Recurring output rules:
 Before reporting the run complete:
 
 - `coarse_relevance_decisions.json` has exactly one decision per emitted candidate (unless `--allow-missing`).
-- `origin_findings.json` has exactly one finding per relevant candidate (unless `--allow-missing`).
-- `targeted_candidates.json` was produced by `origin-apply`.
+- `clustered_candidates.json` was produced by `cluster`; story-origin ran on its representatives, and the run disclosed how many duplicates/stale items were collapsed.
+- `origin_findings.json` has exactly one finding per clustered representative (unless `--allow-missing`) — count validated, gaps re-run.
+- `targeted_candidates.json` was produced by `origin-apply`; `triaged_candidates.json` was produced by `newsjack-triage` and only its advanced items went to `angle-generator`.
 - `final_report.md` was written from `targeted_candidates.json`, not raw `candidates.json`.
 - `run.md` was rendered (via `render-run`) from the gated pool (`relevant_candidates.json`) after `final_report.md` existed — never from raw `candidates.json`.
 - The `run.md` candidate scan contains **no** coarse-rejected or hard-safety-flagged signal; if `render-run` reports withheld signals, that disclosure line is present.
@@ -214,7 +231,7 @@ Return exactly this JSON object. No prose before or after it. Every opportunity 
       "signal_title": "Rejected public signal",
       "reason": "no_client_standing",
       "first_publication": {
-        "status": "stale | freshness_unverified | null",
+        "status": "stale | unverified_no_corroboration | unverified_boundary | unverified_no_timestamp | null",
         "first_public_at": "ISO timestamp, YYYY-MM-DD, or null",
         "original_url": "https://... or null",
         "canonical_coverage_url": "https://... or null"
@@ -235,5 +252,5 @@ Return exactly this JSON object. No prose before or after it. Every opportunity 
 ```
 
 - Allowed verdicts: `pitch_now`, `develop_angle`, `monitor`, `reject`.
-- Allowed rejection reasons: `stale`, `freshness_unverified`, `single_source`, `no_client_standing`, `no_journalist_shape`, `off_beat`, `already_seen`, `weak_signal`, `no_viable_angle`.
+- Allowed rejection reasons: `stale`, `freshness_unverified` (umbrella; or the specific `unverified_no_corroboration` / `unverified_boundary` / `unverified_no_timestamp`), `single_source`, `no_client_standing`, `no_journalist_shape`, `off_beat`, `already_seen`, `weak_signal`, `no_viable_angle`.
 - Allowed brand-safety block reasons: `tragedy_or_human_suffering`, `client_exclusion`, `regulated_claim_risk`, `fabrication_risk`.

--- a/skills/newsjack-detector/rubric.md
+++ b/skills/newsjack-detector/rubric.md
@@ -28,7 +28,7 @@ Before assigning `pitch_now`, `develop_angle`, or `monitor`, inspect `freshness_
 - `fresh` - eligible for normal judgment.
 - `fresh_new_development` - eligible, but the angle must be about the new development, not the older background story.
 - `stale` - reject as stale.
-- `freshness_unverified` or missing - reject as `freshness_unverified` for recurring scheduled output.
+- `unverified_no_corroboration`, `unverified_boundary`, `unverified_no_timestamp`, or missing - reject for recurring scheduled output. Track the reason: `unverified_no_corroboration` is a worker/pipeline miss (the clock may be fine, just under-sourced — re-runnable), while `unverified_boundary`/`unverified_no_timestamp` reflect genuinely thin evidence.
 
 Do not reset the clock because an aggregator, syndication partner, or secondary outlet republished an older article.
 

--- a/skills/newsjack-triage/SKILL.md
+++ b/skills/newsjack-triage/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: newsjack-triage
+description: "Consolidate freshness-gated newsjack signals and assign client standing before angle generation. Collapses any remaining same-story duplicates, decides strong/partial/none standing with a journalist-shape sanity check, and passes only distinct, has-standing stories forward. Never writes angles or pitches."
+when_to_use: "Run as the standing-triage stage of the newsjack-detector pipeline, after the deterministic freshness gate (origin-apply) and before angle-generator. Use whenever a pool of fresh candidate signals needs standing judgment and final same-story consolidation before expensive angle work."
+---
+
+# Newsjack Triage
+
+You are **newsjack-triage**, the standing gate of the newsjacking pipeline. The deterministic engine has already decided which signals are *fresh*. Your job is the PR judgment the engine cannot make: **does the client have honest standing to enter this story, and is it actually a distinct story?**
+
+This skill inherits the ethical floor from `skills/ETHICS.md` and `skills/WHY-NOT-SPAM.md`. If local instructions conflict with that doctrine, the doctrine wins. You refuse manufactured relevance: "this is about AI and the client uses AI" is **not** standing.
+
+You do **not**: write angles, name journalists, draft copy, recompute freshness, or re-rank by mechanical score. Angle fit belongs to `angle-generator`; you decide whether a candidate is even worth sending there.
+
+## Inputs
+
+`targeted_candidates.json` from `origin-apply` (the freshness-gated, selected `fresh`/`fresh_new_development` signals). For each signal you receive:
+
+- `signal_id`, `title`, `story_origin` (canonical coverage, first-public clock, new development)
+- `story_size` band, `freshness_gate.computed_status`
+- `cluster` metadata when the engine's `cluster` step ran (`cluster_id`, `cluster_size`, `member_ids`) — same-story pickups are already collapsed to one representative
+- the client profile (company, topics, competitors, standing terms, regulators/customers/categories, spokespeople)
+
+## Process
+
+1. **Re-consolidate.** The engine `cluster` step collapses same-story pickups upstream, but verify: if two surviving representatives are obviously the *same public event* (same actors + same action + same facts), merge them, keep the one with the stronger canonical coverage, and record the merge. Report the consolidation so the downstream report shows *stories*, not *articles*.
+
+2. **Assign standing** per `skills/newsjack-detector/rubric.md` (Standing section). Decide one of:
+   - `strong` — client operates directly in the affected market, or the signal names the client's category, customers, regulators, technology, or a named competitor in a way the client can speak to concretely.
+   - `partial` — adjacent expertise; the client can explain impact or a narrower slice but not the core event.
+   - `none` — the only bridge is a broad theme ("it's about AI / privacy / property and we do that too"), a keyword collision, or wrong geography/jurisdiction/audience.
+
+3. **Journalist-shape sanity check.** Even with standing, ask whether a *specific* reporter shape plausibly cares now (exact beat, not "tech reporter"). If no honest shape exists, downgrade toward `none`.
+
+4. **Decide the gate.** `strong`/`partial` with a plausible shape → `advance` (goes to `angle-generator`). `none`, or standing-but-no-shape → `drop` with a rejection reason. When standing is real but the client clearly has no first-party proof or spokesperson and the story is small, you may `advance` but flag `proof_gated: true` so the report leads with the human ask.
+
+5. **Stay honest about volume.** If most of the pool is `none`, say so. Do not advance marginal items to manufacture activity — that is the spray-and-pray pattern the doctrine forbids.
+
+## Output
+
+Return only JSON. No prose before or after.
+
+```json
+{
+  "triaged": [
+    {
+      "signal_id": "engine signal id",
+      "signal_title": "Observed signal",
+      "gate": "advance | drop",
+      "standing": "strong | partial | none",
+      "standing_rationale": "What gives the client standing, or what is missing.",
+      "journalist_shape_exists": true,
+      "proof_gated": false,
+      "consolidated_from": ["other signal_ids merged into this one"],
+      "cluster_size": 1,
+      "drop_reason": "no_client_standing | no_journalist_shape | off_beat | duplicate | weak_signal | null"
+    }
+  ],
+  "summary": {
+    "input_count": 0,
+    "advanced_count": 0,
+    "dropped_count": 0,
+    "standing_counts": {"strong": 0, "partial": 0, "none": 0}
+  }
+}
+```
+
+Allowed `gate`: `advance`, `drop`. Allowed `drop_reason`: `no_client_standing`, `no_journalist_shape`, `off_beat`, `duplicate`, `weak_signal`, or `null` when advancing.
+
+## Handoff
+
+- `advance` candidates → `angle-generator` (one payload per advanced story). A candidate is only worth pitching if it then yields at least one honest, journalist-shaped angle; zero viable angles downgrades it back to `drop` in the report.
+- `drop` candidates → the report's **Watch / Not A Fit** section with the plain reason.
+
+Write the object into `triaged_candidates.json` for the detector pipeline to consume before angle generation.

--- a/skills/story-origin-check/SKILL.md
+++ b/skills/story-origin-check/SKILL.md
@@ -145,6 +145,14 @@ Return only JSON:
 
 `canonical_coverage_url` should be same-story coverage, not just topically similar coverage. If no major/canonical article can be defended, use the original URL when it is credible; otherwise return `null` and explain the gap.
 
+## Output Discipline
+
+These rules are enforced downstream; violating them silently corrupts the freshness gate.
+
+- **One finding per input signal. Never skip a signal.** Relevance is judged by a later stage, not here. If a signal looks off-topic, unverifiable, or junk, still emit a finding for it with `same_story_assessment: "unclear"`, `first_public_at: null`, and low confidence. Returning fewer findings than inputs is a contract violation; the orchestrator validates the count and re-runs gaps.
+- **Two independent sources to support a fresh clock.** A `first_public_at` inside the window is only honored by `origin-apply` when `timestamp_evidence` contains **at least two independent corroborating URLs** that are not just the surfaced article citing itself. If you only have the surfaced URL, the gate will return `unverified_no_corroboration` — so populate `timestamp_evidence` with the real primary source, wire, or canonical coverage you actually found, or leave the clock unproven.
+- Date-only timestamps straddling the cutoff resolve to `unverified_boundary`; a missing/unparseable clock resolves to `unverified_no_timestamp`. Both are correct outcomes when the evidence genuinely is not there — do not invent precision to force a `fresh` result.
+
 ## Handoff
 
 Write these objects into `origin_findings.json` for `newsjack origin-apply` to attach as `story_origin` on the same signal. Downstream reports should cite `canonical_coverage_url` as the main story link when present, while preserving `original_url` and `first_public_at` for freshness auditing.


### PR DESCRIPTION
## Why

Two reactive-newsjack failures surfaced in eval: (1) the report laundered worker-fabricated canonical links (e.g. an NVIDIA-newsroom URL attached to a single KuCoin pickup, mis-dated) into credible-looking coverage, and (2) a 4-month-old story surfaced as `fresh_new_development` because a worker minted a "new development" out of an analysis piece. Root cause: consequential, surface-deciding fields rode a single low-cost worker's unverified word, and the report hid the evidence a human reviewer needs.

## What

**Engine (`apps/cli`)**
- **`cluster`** — collapse same-story pickups to one representative before the expensive story-origin pass (shared evidence URL, or title overlap-coefficient >=0.6 with >=2 shared significant tokens). `--drop-stale` pre-gates clearly-old low-band signals. Conservative/high-precision; broad semantic consolidation is left to triage.
- **`--demote-unmatched-x`** — recurring-precision cap for unmatched X lanes (default off; preserves the tested "x_news surfaces for review" behaviour).
- **origin-apply** — split `freshness_unverified` into `unverified_no_corroboration` / `unverified_boundary` / `unverified_no_timestamp`.
- Tests: `cluster_test.go`, `pipeline_precision_test.go`; `filter_test.go` updated. `go test ./...` green, `go vet` clean.

**Skills**
- **`newsjack-triage`** (new atom) — assign strong/partial/none standing, consolidate remaining same-story, advance only distinct has-standing stories. Auditable; replaces ad-hoc orchestrator judgment.
- **story-origin-check** — one finding per signal (never skip); >=2 corroborating sources to support a fresh clock.
- **newsjack-detector** — pipeline + rubric updated for the new stages/statuses and report contract.

**Report (`fixtures/.../scripts/build_report.py`)**
- Each story = one main source (detector-surfaced source of record, real date, flagged single-source/aggregator) + related coverage (clustered duplicates + worker-proposed canonicals tagged `proposed by research - UNVERIFIED`). Worker links never promoted to the main slot; every link dated; fresh_new_development shows both first-public and new-development dates.

## Validation

Re-ran the 7-profile fixture pipeline end-to-end. The three failure cases now wear their weakness on their face. Audited a later fresh run: 0 worker-proposed links in any main slot, 0 coarse-reject leakage, split statuses firing, triage honest (one client advanced zero rather than manufacture activity).

Generated with Claude Code.
