### PR TITLE
Add slow-start onboarding front door

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,8 @@
 #
 # Copy values into .env. The .env file is gitignored.
 
-# News search. Required for live news_search source.
+# Optional. Enables the live news_search source and hosted media lists.
+# Without it, news search falls back to host web search — fine to leave blank.
 MEDIALYST_API_KEY=
 MEDIALYST_API_BASE=https://medialyst.ai/api
 MEDIALYST_NEWS_PATH=/v1/news/search

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,7 +77,7 @@ NEWSJACK_RUN_DIR=/tmp/newsjack-fixture-smoke NEWSJACK_INCLUDE_ALL_SCORED=0 \
 ## Skill Editing Rules
 
 - Skills are compositional:
-  - **ATOM skills** do one judgment or transformation well. Example: `angle-generator`, `story-origin-check`, `relevance-coarse-filter`, `fact-check`, `journalist-fit-check`.
+  - **ATOM skills** do one judgment or transformation well. Example: `angle-generator`, `story-origin-check`, `relevance-coarse-filter`, `fact-check`, `journalist-fit-check`, `news-search`.
   - **MOLECULE skills** combine a few atoms into a bounded workflow with one clear output. Example: `newsjack-detector` (engine evidence + `story-origin-check` + `angle-generator` into a single freshness-gated opportunity report).
   - **COMPOUND skills** orchestrate multiple molecules/atoms into an end-to-end product workflow. Example (planned): a `generate-client-report` skill that runs `newsjack-detector` plus a report-generation skill.
 - Keep atomic capability in the atom. Do not duplicate atom logic inside molecule or compound skills; call, reference, or delegate to the atom instead.

--- a/README.md
+++ b/README.md
@@ -8,9 +8,17 @@
 curl -fsSL newsjack.sh | bash
 ```
 
+**New here?** Point your agent at **[Getting started](docs/getting-started.md)** —
+it starts slow, asks what you're trying to do, and takes one step at a time instead
+of reciting the whole menu. No API keys required to begin.
+
 ---
 
 ## What your agent can do once newsjack is installed
+
+> Agents: don't recite this list on first contact. Follow
+> [Getting started](docs/getting-started.md) — orient, offer a few on-ramps, take
+> one step at a time. This section is the reference, not the opening line.
 
 Three problems, separate lanes.
 
@@ -78,10 +86,11 @@ The installer detects your agent runtime and installs the skills automatically. 
 └── newsjack/             # managed bundle
 
 skills installed to your detected runtime(s):
-  newsjack-setup          create a company monitor profile
+  newsjack-monitor-setup  create a company monitoring profile
   newsjack-detector       find newsworthy moments before the wave breaks
   story-origin-check      verify a story is fresh, not already saturated
   newsworthiness-check    score whether your news clears the bar
+  news-search             dated, attributed news search (Medialyst or web fallback)
   meanest-editor          roast your pitch against the editor rubric
   angle-generator         turn one update into ten pitchable hooks
   media-list-manager      build small, fit-checked media lists

--- a/apps/cli/cmd/newsjack/monitor_test.go
+++ b/apps/cli/cmd/newsjack/monitor_test.go
@@ -414,7 +414,7 @@ func TestSetupDoesNotTreatSkillDirectoryAsInstalledRuntime(t *testing.T) {
 			t.Fatalf("setup code=%d stderr=%s stdout=%s", code, errBuf.String(), out.String())
 		}
 		text := out.String()
-		if !fileExists(filepath.Join(home, ".claude", "skills", "newsjack-setup", "SKILL.md")) {
+		if !fileExists(filepath.Join(home, ".claude", "skills", "newsjack-monitor-setup", "SKILL.md")) {
 			t.Fatalf("setup should still copy skills for a selected missing runtime")
 		}
 		if !strings.Contains(text, "claude     Claude Code    not detected") {
@@ -583,7 +583,7 @@ func TestSetupLaunchesSelectedHarnessWithSetupSkillPrompt(t *testing.T) {
 		if !strings.Contains(argText, "Use newsjack to set up monitoring for my company.") {
 			t.Fatalf("Hermes prompt should be the short newsjack setup instruction:\n%s", argText)
 		}
-		for _, forbidden := range []string{"newsjack-setup", "not system cron", "fnv32a", "minute=(", "run.md", "schedule paths", "mock test"} {
+		for _, forbidden := range []string{"newsjack-monitor-setup", "not system cron", "fnv32a", "minute=(", "run.md", "schedule paths", "mock test"} {
 			if strings.Contains(argText, forbidden) {
 				t.Fatalf("Hermes prompt should not expose %q:\n%s", forbidden, argText)
 			}

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,69 @@
+# Getting started with newsjack
+
+This is the front door. If you are an agent that just had newsjack installed (or
+had this repo handed to you), read this first and follow it before doing anything
+else.
+
+## For the agent: start slow
+
+On first contact, **do not** dump the full list of 16 skills, and **do not**
+announce missing API keys. Newsjack works without any keys; credentials are
+optional upgrades covered below.
+
+Instead, find out what the user is trying to do and take **one** concrete step.
+Open with a short orientation and offer a few real starting points — not the whole
+menu:
+
+> Newsjack turns me into your PR operator. Where do you want to start?
+>
+> 1. **See what newsjack can do** — a quick tour of the workflow
+> 2. **Get a PR strategy** — figure out audience, positioning, and news pegs first
+> 3. **Set up monitoring** — watch your industry and competitors for stories to jump on
+> 4. **Find journalists** — build a small, fit-checked media list for a pitch
+
+Then let the user pick and go one step at a time. Each starting point maps to a
+skill:
+
+| Starting point | Skill |
+| --- | --- |
+| See what newsjack can do | (brief tour — only expand the full skill list if asked) |
+| Get a PR strategy | `pr-strategist` |
+| Set up monitoring | `newsjack-monitor-setup` |
+| Find journalists | `media-list-manager` |
+
+If the user already knows what they want ("draft a pitch", "is this newsworthy?",
+"roast this"), skip the menu and route straight to the relevant skill.
+
+## Dependencies — what they unlock, and what they cost
+
+**You can do real work with none of these.** Newsjack's base workflow — strategy,
+angles, fit-checks, drafts, voice, newsworthiness, and a local media-list artifact
+— needs no signup and no keys. The optional integrations below add reach; treat a
+missing one as reduced coverage, not a blocker, and never lead with a missing-key
+complaint.
+
+| Dependency | Unlocks | Without it | Cost |
+| --- | --- | --- | --- |
+| **Medialyst key** | live news search with publication metadata, hosted media lists, enrichment, saved views, share links | news search falls back to host web/browser search (best-effort freshness); media lists return a local artifact you can review or import later | 300 free credits on signup (~3,000 news searches), paid after — [medialyst.ai/agents#pricing](https://medialyst.ai/agents#pricing) |
+| **X bearer token** | the X/Twitter trend source inside monitoring | that source is simply omitted; RSS and news still run | pay-as-you-go, no free tier — [X API pricing](https://docs.x.com/x-api) |
+
+### Why Medialyst for news search
+
+General web search is bad at news: it ranks for SEO over recency, paywalls or
+buries primary coverage, and rarely exposes a reliable publication timestamp.
+Medialyst is purpose-built for news and returns the outlet, author, `published_at`,
+and canonical URL that downstream skills (`story-origin-check`,
+`newsworthiness-check`, `media-list-manager`, `newsjack-detector`) depend on. The
+`news-search` skill prefers it and falls back to host search — flagging reduced
+freshness confidence — when it is not configured. It is optional cloud substrate,
+not a signup wall.
+
+## Setting up credentials (only when the user wants the upgrade)
+
+- **Medialyst:** prefer `newsjack login`. The root `.mcp.json` uses the saved
+  Newsjack credential or `MEDIALYST_API_KEY`. Recommended scopes: `news:search`,
+  `media_lists:read`, `media_lists:write`.
+- **X:** set `X_BEARER_TOKEN` (alias `TWITTER_BEARER_TOKEN`). Newsjack calls the X
+  API directly.
+
+Only bring these up when the user reaches a step that benefits from them.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -18,8 +18,9 @@ menu:
 >
 > 1. **See what newsjack can do** — a quick tour of the workflow
 > 2. **Get a PR strategy** — figure out audience, positioning, and news pegs first
-> 3. **Set up monitoring** — watch your industry and competitors for stories to jump on
-> 4. **Find journalists** — build a small, fit-checked media list for a pitch
+> 3. **Check if something's newsworthy** — score a news event or your own pitch idea before you act
+> 4. **Set up monitoring** — watch your industry and competitors for stories to jump on
+> 5. **Find journalists** — build a small, fit-checked media list for a pitch
 
 Then let the user pick and go one step at a time. Each starting point maps to a
 skill:
@@ -28,6 +29,7 @@ skill:
 | --- | --- |
 | See what newsjack can do | (brief tour — only expand the full skill list if asked) |
 | Get a PR strategy | `pr-strategist` |
+| Check if something's newsworthy | `newsworthiness-check` |
 | Set up monitoring | `newsjack-monitor-setup` |
 | Find journalists | `media-list-manager` |
 

--- a/eval/onboarding/README.md
+++ b/eval/onboarding/README.md
@@ -1,0 +1,72 @@
+# Onboarding Eval
+
+Behavioral eval for the first-run experience of an agent that just had newsjack
+installed (or had the repo handed to it). It checks that the agent follows the
+slow-start front door — `README.md` → [`docs/getting-started.md`](../../docs/getting-started.md)
+— instead of the three failure modes a real beta tester reported:
+
+1. **Capability dump** — reciting the whole ~16-skill menu on first contact.
+2. **Premature key complaint** — volunteering up front that a Medialyst/X key is
+   missing, before any step needs it.
+3. **Hard Medialyst dependency** — stalling or demanding a key for news search
+   instead of falling back to host web search.
+
+This eval **grades the behavior, it does not change the docs.** If a case fails,
+the fix is a better case or a logged finding — not softening an assertion to make
+it pass.
+
+## Design
+
+Six scenarios across two classes:
+
+- **Vague first contact** (`1`, `2`) — where the slow start must fire: short
+  orientation, 3-4 on-ramps, one step at a time, no key complaint.
+- **Known intent** (`3`-`6`) — where the agent should skip the menu and route to
+  the right skill, and where any news lookup must use the host-search fallback
+  and proceed without a key:
+  - `3` find journalists → `media-list-manager` (local artifact + host byline search)
+  - `4` is this newsworthy → `newsworthiness-check` (anti-inflation + host pickup check)
+  - `5` set up monitoring → `newsjack-monitor-setup` (X token optional, raised late)
+  - `6` search the news → `news-search` (host web search, freshness best-effort)
+
+Format follows the repo's `newsworthiness-check` eval (`evals.json` with
+`id`/`eval_name`/`prompt`/`expected_output`/`assertions`). Unlike that one,
+onboarding output is **conversational**, so assertions are `type: "judgment"` and
+grading is an **LLM judge against the per-case criteria**, not a strict JSON
+parser. There is intentionally no `grade.py`.
+
+## How to run
+
+1. **Executor (blind to assertions):** an agent reads `README.md`,
+   `docs/getting-started.md`, and the front-matter + opening of the relevant
+   skill, then responds to each `prompt` *as the freshly-installed agent*. Assume
+   **no Medialyst key and no X token** are configured; the `medialyst` MCP server
+   is present but unauthenticated. Save each response under
+   `runs/<date>-<label>/<id>-<eval_name>.md`.
+2. **Judge:** a second agent scores each saved response against that case's
+   `assertions`, emitting `{id, passed, evidence}` per assertion and a per-case
+   PASS/FAIL.
+
+The two roles must be separate agents so the executor cannot see the answer key.
+
+## Result (2026-06-04 validation)
+
+First run, executed against the on-disk docs on branch `feat/agent-onboarding`.
+Full transcript in [`runs/2026-06-04-validation/verdict.md`](runs/2026-06-04-validation/verdict.md).
+
+| Scenario | Verdict | Reason |
+|---|---|---|
+| 1 what-can-you-do | PASS | 4 on-ramps, no dump, no key complaint |
+| 2 just-installed | PASS | Slow-start menu, routes to getting-started not the setup skill |
+| 3 find journalists | PASS | media-list-manager, local artifact + host byline search |
+| 4 newsworthiness | PASS | newsworthiness-check, host pickup check, no key complaint |
+| 5 set up monitoring | PASS | newsjack-monitor-setup, X token raised optional + late |
+| 6 search the news | PASS | news-search, host web fallback w/ freshness caveat |
+
+All six pass against the on-disk docs. The run also surfaced two minor doc
+tightenings that were applied in the same change (a "don't recite this on first
+contact" note on the README capability section, and rewording `.env.example`'s
+Medialyst line from "Required" to "Optional"), plus one *environmental*
+non-defect: the executor's own machine still had the **pre-rename installed
+skills** (`newsjack-setup`), which resolves on reinstall/release and is not a
+repo issue.

--- a/eval/onboarding/evals.json
+++ b/eval/onboarding/evals.json
@@ -1,0 +1,86 @@
+{
+  "skill_name": "onboarding",
+  "version": 1,
+  "description": "First-run onboarding behavior eval. Checks that an agent freshly handed the newsjack repo follows the slow-start front door (README -> docs/getting-started.md) instead of the three failure modes a real beta tester hit: (1) reciting the whole capability menu on first contact, (2) volunteering up front that a Medialyst/X key is missing, (3) treating Medialyst as a hard dependency and stalling instead of falling back to host web search. Grading is LLM-judge against per-case criteria, not a strict JSON parser, because onboarding output is conversational. Do NOT edit the docs/skills to pass these; fix the case or log a finding.",
+  "now_anchor": "2026-06-04",
+  "context": "Executor reads README.md and docs/getting-started.md, plus the front-matter + opening of the relevant skill, then responds to each prompt AS THE FRESHLY-INSTALLED AGENT. Assume NO Medialyst key and NO X token are configured; the medialyst MCP server is present but unauthenticated.",
+  "evals": [
+    {
+      "id": 1,
+      "eval_name": "first-contact-what-can-you-do",
+      "scenario": "vague-first-contact",
+      "tags": ["slow-start", "no-key-complaint", "should-not-dump"],
+      "prompt": "hey what is this? what can you do?",
+      "expected_output": "Short orientation + a small set (3-4) of concrete on-ramps (tour / PR strategy / set up monitoring / find journalists), then hands control back. No recitation of all ~16 skills. No mention that any key is missing.",
+      "assertions": [
+        {"id": "1a", "text": "Offers between 2 and 5 starting points, not the full skill list", "type": "judgment"},
+        {"id": "1b", "text": "Does NOT enumerate more than ~6 distinct skills/capabilities", "type": "judgment"},
+        {"id": "1c", "text": "Does NOT state or imply a Medialyst/X API key is missing or needs configuring", "type": "judgment"},
+        {"id": "1d", "text": "Ends by inviting the user to pick a direction (one step at a time)", "type": "judgment"}
+      ]
+    },
+    {
+      "id": 2,
+      "eval_name": "first-contact-just-installed",
+      "scenario": "vague-first-contact",
+      "tags": ["slow-start", "no-key-complaint", "name-check"],
+      "prompt": "I just installed newsjack, help me get started",
+      "expected_output": "Same slow-start menu as case 1. Routes to the getting-started flow, NOT straight into the monitor-setup skill as if setup were the only front door.",
+      "assertions": [
+        {"id": "2a", "text": "Gives the slow-start orientation + on-ramps, not a single forced path", "type": "judgment"},
+        {"id": "2b", "text": "Does NOT jump directly into the full monitor-profile provisioning flow without the user choosing it", "type": "judgment"},
+        {"id": "2c", "text": "Does NOT lead with a missing-key complaint", "type": "judgment"}
+      ]
+    },
+    {
+      "id": 3,
+      "eval_name": "known-intent-find-journalists",
+      "scenario": "known-intent",
+      "tags": ["routing", "graceful-fallback"],
+      "prompt": "find me journalists to pitch my AI customer-support startup",
+      "expected_output": "Routes to media-list-manager, skips the menu. Builds toward a small fit-checked list, falling back to a LOCAL artifact (no Medialyst) and host web search for byline anchoring. Treats freshness as best-effort. Medialyst, if named, is framed as an optional upgrade at the relevant step.",
+      "assertions": [
+        {"id": "3a", "text": "Routes to media-list-manager (small, fit-checked list; not a scraped dump)", "type": "judgment"},
+        {"id": "3b", "text": "Proceeds without a Medialyst key via local-artifact + host-search fallback; does not stall or demand a key", "type": "judgment"},
+        {"id": "3c", "text": "Any Medialyst mention is framed as optional, not led with as a blocker", "type": "judgment"}
+      ]
+    },
+    {
+      "id": 4,
+      "eval_name": "known-intent-newsworthiness",
+      "scenario": "known-intent",
+      "tags": ["routing", "graceful-fallback"],
+      "prompt": "is it newsworthy that we just hit 10,000 users?",
+      "expected_output": "Routes to newsworthiness-check (pitch mode), applies anti-inflation doctrine (a round-number milestone alone is weak), and uses host web search for pickup with explicit freshness caution. No key complaint.",
+      "assertions": [
+        {"id": "4a", "text": "Routes to newsworthiness-check and does not inflate a bare milestone into 'news'", "type": "judgment"},
+        {"id": "4b", "text": "Uses news-search fallback (host web search) and flags freshness/pickup as best-effort rather than stalling", "type": "judgment"},
+        {"id": "4c", "text": "Does not volunteer a missing-key complaint", "type": "judgment"}
+      ]
+    },
+    {
+      "id": 5,
+      "eval_name": "known-intent-set-up-monitoring",
+      "scenario": "known-intent",
+      "tags": ["routing", "name-check"],
+      "prompt": "set up monitoring for my company",
+      "expected_output": "Routes to newsjack-monitor-setup. Gathers the profile inputs, notes RSS/news work out of the box, and raises the optional X token only at the step that uses it.",
+      "assertions": [
+        {"id": "5a", "text": "Routes to newsjack-monitor-setup (not a generic 'setup' front door)", "type": "judgment"},
+        {"id": "5b", "text": "X token raised only at the monitoring step that needs it, framed optional", "type": "judgment"}
+      ]
+    },
+    {
+      "id": 6,
+      "eval_name": "known-intent-news-search",
+      "scenario": "known-intent",
+      "tags": ["routing", "graceful-fallback"],
+      "prompt": "search the news for what's happening with AI customer support this week",
+      "expected_output": "Routes to news-search, goes straight to host web/browser search, reads page metadata for real published_at, treats freshness as best-effort, never invents dates. Medialyst named once as optional at most.",
+      "assertions": [
+        {"id": "6a", "text": "Routes to news-search and returns (or commits to) dated, attributed results", "type": "judgment"},
+        {"id": "6b", "text": "Uses host web-search fallback with an explicit freshness caveat; does not announce a missing key as a problem", "type": "judgment"}
+      ]
+    }
+  ]
+}

--- a/eval/onboarding/evals.json
+++ b/eval/onboarding/evals.json
@@ -11,7 +11,7 @@
       "scenario": "vague-first-contact",
       "tags": ["slow-start", "no-key-complaint", "should-not-dump"],
       "prompt": "hey what is this? what can you do?",
-      "expected_output": "Short orientation + a small set (3-4) of concrete on-ramps (tour / PR strategy / set up monitoring / find journalists), then hands control back. No recitation of all ~16 skills. No mention that any key is missing.",
+      "expected_output": "Short orientation + a small set (3-5) of concrete on-ramps (tour / PR strategy / check newsworthiness / set up monitoring / find journalists), then hands control back. No recitation of all ~16 skills. No mention that any key is missing.",
       "assertions": [
         {"id": "1a", "text": "Offers between 2 and 5 starting points, not the full skill list", "type": "judgment"},
         {"id": "1b", "text": "Does NOT enumerate more than ~6 distinct skills/capabilities", "type": "judgment"},

--- a/eval/onboarding/runs/2026-06-04-validation/verdict.md
+++ b/eval/onboarding/runs/2026-06-04-validation/verdict.md
@@ -1,0 +1,38 @@
+# Onboarding eval — 2026-06-04 validation run
+
+Branch `feat/agent-onboarding`. Executor role-played a freshly-installed agent
+against the six scenarios, reading only `README.md`, `docs/getting-started.md`,
+`.mcp.json`, `.env.example`, and the relevant skill front-matter/openings. No
+Medialyst key, no X token; `medialyst` MCP present but unauthenticated.
+
+## Verdict
+
+| Scenario | PASS/FAIL | Reason |
+| --- | --- | --- |
+| S1 what is this / what can you do | PASS | Short orientation + 4 on-ramps, no capability dump, no key complaint. |
+| S2 just installed, help me start | PASS | Same slow-start menu; routes to getting-started, not the setup skill. |
+| S3 find me journalists | PASS | Routes to media-list-manager; local-artifact + host byline search; Medialyst framed optional. |
+| S4 is hitting 10k users newsworthy | PASS | Routes to newsworthiness-check (pitch mode), anti-inflation; host pickup check; no key complaint. |
+| S5 set up monitoring | PASS | Routes to newsjack-monitor-setup; X token raised only at its step, optional. |
+| S6 search the news | PASS | Routes to news-search; host web fallback w/ freshness caveat; no stall. |
+
+All six pass as driven by the on-disk docs. The README + getting-started.md +
+each skill's fallback language actively suppress the three old failure modes
+(capability dump, premature key complaint, hard Medialyst dependency).
+
+## Findings
+
+1. **Applied — README capability section was a latent dump.** `README.md`'s
+   "What your agent can do" enumerates ~12 capabilities; an agent paraphrasing it
+   instead of following getting-started could reproduce the dump. Fix: added a
+   blockquote telling agents not to recite it on first contact.
+2. **Applied — `.env.example` said Medialyst was "Required".** Contradicted the
+   "optional, fine without" framing. Fix: reworded to "Optional … fine to leave
+   blank."
+3. **Environmental non-defect — stale installed skills.** The executor's machine
+   still had the pre-rename `newsjack-setup` skill registered (under
+   `~/.claude/skills`), so a runtime routing off the live registry (not the repo
+   file) could still treat "setup" as the front door. This is the on-disk rename
+   not yet propagated to an existing install; it resolves on reinstall/release.
+   Not a repo defect — the on-disk `newsjack-monitor-setup/SKILL.md` carries the
+   correct name and the "defer first-contact to getting-started" deferral.

--- a/harness/scripts/run-ci-installer.sh
+++ b/harness/scripts/run-ci-installer.sh
@@ -230,7 +230,7 @@ log "checking installed runtime skills"
 mapfile -t skill_dirs < <(selected_skill_dirs)
 for dir in "${skill_dirs[@]}"; do
   test -f "$dir/newsjack-detector/SKILL.md"
-  test -f "$dir/newsjack-setup/SKILL.md"
+  test -f "$dir/newsjack-monitor-setup/SKILL.md"
   test ! -d "$dir/newsjack-detector/scripts"
 done
 

--- a/skills/media-list-manager/SKILL.md
+++ b/skills/media-list-manager/SKILL.md
@@ -94,7 +94,7 @@ Configure that script as the MCP server command. It launches `mcp-remote` and in
 
 2. **Gather source evidence.**
    - If the user gives article URLs, use those as primary evidence.
-   - If the user gives a topic or hook, use `search_news` in MCP mode or host-agent search in local mode.
+   - If the user gives a topic or hook, use the `news-search` skill for article evidence — `search_news` via Medialyst when configured, host web/browser search otherwise. Local mode still finds bylines; just treat dates and outlet attribution as best-effort.
    - Prefer recent articles by named journalists on the exact topic.
    - Reject SEO pages, product docs, content farms, stale articles, and outlet-level pages as fit anchors.
 

--- a/skills/news-search/README.md
+++ b/skills/news-search/README.md
@@ -1,0 +1,7 @@
+# news-search
+
+Search current news for a topic, company, competitor, or hook and return dated, attributed articles other Newsjack skills can trust.
+
+This skill prefers the optional Medialyst MCP news index, which returns normalized publication metadata (outlet, author, `published_at`, canonical URL) that downstream skills depend on. General web search ranks for SEO over recency and rarely exposes a reliable publication timestamp, so it is a weaker source for news. When Medialyst is not configured, the skill falls back to host web/browser search and flags the reduced freshness confidence rather than guessing dates.
+
+Medialyst is optional. New accounts get 300 free credits (~3,000 news searches) — see [medialyst.ai/agents](https://medialyst.ai/agents). The skill stays useful without it.

--- a/skills/news-search/SKILL.md
+++ b/skills/news-search/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: news-search
+description: "Search current news for a topic, company, competitor, or hook and return dated, attributed articles. Uses the Medialyst MCP news index when available, and falls back to host web/browser search with explicit caveats when it is not."
+when_to_use: "User asks to search the news, find recent coverage, check who has written about a topic, or pull article evidence; or another Newsjack skill needs dated, attributed news results (story-origin-check, newsworthiness-check, media-list-manager, newsjack-detector). Not a general web search for non-news facts — use the host's web search for those."
+---
+
+# News Search
+
+You are **news-search**, the Newsjack skill that turns a topic, company, competitor, or hook into a small set of **dated, attributed** news articles that other skills can trust.
+
+You are not a general web researcher and you are not a contact scraper. Your one job is to return real, recent, source-attributed news with the metadata downstream skills depend on: outlet, author, publication timestamp, and canonical URL.
+
+## What good news search returns
+
+Every downstream skill that consumes news needs the same four facts per article. Return them or mark them missing — never invent them.
+
+- `title`
+- `url` (canonical where known)
+- `outlet`
+- `author` (when available)
+- `published_at` (ISO 8601; the article's real publication time, not the time you searched)
+
+Downstream consumers and why they need this:
+
+- **story-origin-check** computes the first-public clock and same-story identity from `published_at` and canonical URL.
+- **newsworthiness-check** reads mainstream pickup, article count, and earliest timestamp.
+- **media-list-manager** anchors each journalist row to a real recent byline.
+- **newsjack-detector** ranks and gates signals on freshness.
+
+If `published_at` or `outlet` is unknown, say so. A result without a defensible date is not freshness evidence.
+
+## How to search — best option first
+
+### 1. Medialyst MCP (preferred)
+
+If the runtime exposes the `medialyst` MCP server, use `search_news`. It is purpose-built for this and is the best option for two concrete reasons:
+
+1. **General web search is bad at news.** It ranks for SEO and evergreen authority, not recency; it buries or paywalls primary coverage; and it rarely exposes a reliable publication timestamp, so you cannot defend a freshness claim from it.
+2. **Medialyst returns the publication metadata** — outlet, author, `published_at`, canonical URL — that every consumer above requires, already normalized.
+
+Medialyst is optional cloud substrate, not a signup wall. New accounts get **300 free credits (~3,000 news searches)**. See [medialyst.ai/agents](https://medialyst.ai/agents) for what it adds and current pricing.
+
+### 2. Host web / browser search (fallback)
+
+If the `medialyst` MCP server is unavailable or unauthorized, do **not** stop and do **not** announce a missing key as a problem. Fall back to the host's web search or browser tools:
+
+- Query for the topic plus recency cues; prefer named outlets and primary sources over aggregators and SEO pages.
+- Open candidate pages and read page metadata (`article:published_time`, `datePublished`, byline/date text) to recover a real `published_at`. Do not treat the time you searched as the publication time.
+- Reject SEO listicles, product docs, content farms, and outlet-level landing pages as article evidence.
+
+**What you lose in fallback mode — and must flag:** timestamps and outlet attribution are less reliable, so be **more cautious about freshness and "who broke it" claims**. When you cannot recover a defensible `published_at`, return the article but mark the date unknown and lower confidence rather than guessing. Tell the consumer (or user) the results came from host search, not Medialyst, so freshness is best-effort.
+
+## Output
+
+Return a small, deduped list of articles with the five fields above, plus a one-line note on which mode produced them (`medialyst` or `host-search`) and any freshness caveats. Keep it small and relevant — this is evidence for a decision, not a dump.

--- a/skills/newsjack-detector/SKILL.md
+++ b/skills/newsjack-detector/SKILL.md
@@ -8,7 +8,9 @@ when_to_use: "User wants to monitor news for pitchable hooks, find newsjacking o
 
 Find timely public signals and decide whether a client has a credible, non-spammy reason to use them. The monitoring engine collects evidence and computes mechanical signals; **you make the PR judgment.**
 
-This is a **molecule** skill — it orchestrates atomic skills rather than re-implementing them. Coarse relevance goes to `relevance-coarse-filter`, story identity to `story-origin-check`, angle fit to `angle-generator`, and handoff to `reactive-comment` / `journalist-fit-check` / `meanest-editor`. Do not duplicate an atom's logic or prompt here; a worker running a pass loads that atom's `SKILL.md` directly, so the atom stays the single source of truth.
+This is a **molecule** skill — it orchestrates atomic skills rather than re-implementing them. Coarse relevance goes to `relevance-coarse-filter`, story identity to `story-origin-check`, angle fit to `angle-generator`, ad-hoc news lookups to `news-search`, and handoff to `reactive-comment` / `journalist-fit-check` / `meanest-editor`. Do not duplicate an atom's logic or prompt here; a worker running a pass loads that atom's `SKILL.md` directly, so the atom stays the single source of truth.
+
+The monitoring engine's live `news_search` source needs a Medialyst key; without one it runs on RSS/X plus host-driven `news-search` and degrades gracefully. Treat a missing Medialyst key as reduced coverage, not a failure — never stall the run or lead with a missing-key complaint.
 
 ## Required Workflow (follow in order)
 

--- a/skills/newsjack-monitor-setup/SKILL.md
+++ b/skills/newsjack-monitor-setup/SKILL.md
@@ -1,12 +1,12 @@
 ---
-name: newsjack-setup
-description: "Set up a newsjack monitor profile for a company. Guides the user through company standing, topics, competitors, proof assets, spokespeople, RSS feed selection, and optional X trend monitoring."
-when_to_use: "User wants to configure newsjack, create a monitor profile, onboard a client/company, choose RSS/news feeds, or prepare a profile for newsjack-detector."
+name: newsjack-monitor-setup
+description: "Set up a newsjack monitoring profile for a company so newsjack-detector can run on a schedule. Guides the user through company standing, topics, competitors, proof assets, spokespeople, RSS feed selection, and optional X trend monitoring."
+when_to_use: "User wants to set up monitoring, create or configure a monitor profile, schedule recurring newsjack scans, choose RSS/news feeds, or prepare a profile for newsjack-detector. For a general 'what is newsjack / where do I start' first contact, use the getting-started flow instead of this skill."
 ---
 
-# Newsjack Setup
+# Newsjack Monitor Setup
 
-You are **newsjack-setup**, the onboarding skill for newsjack.sh. Your job is to create a monitor profile that `newsjack-detector` can run on the user's chosen schedule without guessing the company, beat, or news sources.
+You are **newsjack-monitor-setup**, the monitoring-setup skill for newsjack.sh. Your job is to create a monitor profile that `newsjack-detector` can run on the user's chosen schedule without guessing the company, beat, or news sources.
 
 ## Decision Path
 

--- a/skills/newsjack-monitor-setup/examples.md
+++ b/skills/newsjack-monitor-setup/examples.md
@@ -1,4 +1,4 @@
-# Newsjack Setup Examples
+# Newsjack Monitor Setup Examples
 
 ## Local Falcon-Style Profile
 

--- a/skills/newsworthiness-check/SKILL.md
+++ b/skills/newsworthiness-check/SKILL.md
@@ -30,7 +30,7 @@ If the user supplies a news event plus their planned angle, run `event_newsjacki
 Use only these signal classes:
 
 - LLM judgment for prominence, story type, historical comparison, novelty, standing, and decay heuristics.
-- News search for mainstream pickup, article count, earliest timestamp, and current framing.
+- News search (via the `news-search` skill) for mainstream pickup, article count, earliest timestamp, and current framing. Medialyst gives the most reliable timestamps; when it is not configured, `news-search` falls back to host web search — use it, but weight freshness and pickup claims more cautiously and note the gap in `evidence_gaps`.
 - Reddit when available for human traction: upvote velocity and subreddit spread.
 - X via Newsjack's direct X API source when available for real-time velocity and journalist attention.
 

--- a/skills/story-origin-check/SKILL.md
+++ b/skills/story-origin-check/SKILL.md
@@ -15,6 +15,8 @@ Use this skill whenever a signal may be a syndication, rewrite, aggregator picku
 
 If the harness cannot open pages or search the web, do not guess. Return `first_public_at: null`, `same_story_assessment: "unclear"`, and low confidence unless the input already contains enough source/canonical/original-publication evidence to defend the clock.
 
+For the news searches below, use the `news-search` skill — `news_search` via Medialyst when configured, otherwise host web/browser search. Either satisfies the retrieval requirement; Medialyst is not required. When you fall back to host search and cannot recover a defensible `published_at`, treat the clock as unconfirmed (`first_public_at: null`, `unclear`) rather than inferring a date.
+
 ## Inputs
 
 Accept one detector signal at a time:
@@ -37,7 +39,7 @@ Accept one detector signal at a time:
    - byline/date text visible on the page
    - source, partner, syndicated-from, wire, or "originally published" language
    - outbound links to primary sources, source reports, filings, press releases, studies, or original outlet coverage
-4. You MUST run at least one `news_search` (and at least one `WebFetch` of the surfaced URL when retrieval is available) before returning any verdict other than `unclear`. Returning `same_story`, `fresh_new_development`, or `different_story` without at least one retrieval call is a contract violation. Search for:
+4. You MUST run at least one news search via the `news-search` skill — Medialyst `news_search` when configured, otherwise host web search — (and at least one `WebFetch` of the surfaced URL when retrieval is available) before returning any verdict other than `unclear`. Returning `same_story`, `fresh_new_development`, or `different_story` without at least one retrieval call is a contract violation. Search for:
    - exact headline in quotes
    - core named entities plus the strongest noun phrase
    - source report / regulator / company / study title if one appears


### PR DESCRIPTION
## Why

A beta tester sideloaded the repo into an agent and hit two first-run frictions:

> the biggest friction for me it was that it just told everything it can do and also instantly said it doesn't have medialyst key
>
> maybe if it could say smth like "okay, wanna start with researching journalists for your usecase?" — start slower

Both were emergent: nothing owned the first-touch experience, so the agent read all 16 skill descriptions and surfaced the unauthenticated Medialyst MCP server.

## What

- **`docs/getting-started.md`** — a README-linked front door. Slow start (orient + 3–4 on-ramps, one step at a time) and a **dependencies** section: what Medialyst/X unlock, basic pricing + links, and that it's **fine to continue without them**.
- **`README.md`** — "New here?" pointer to the doc; a "don't recite this on first contact" note on the capability list; `.env.example` Medialyst line reworded from *Required* → *Optional*.
- **New `news-search` skill (ATOM)** — owns how to search news, why Medialyst is the best option (general web search is bad at news; it lacks publication metadata), and the **host web/browser fallback**. Consumers (`story-origin-check`, `newsworthiness-check`, `media-list-manager`, `newsjack-detector`) now **delegate** to it instead of each re-explaining the fallback — per the repo's atom/molecule doctrine.
- **Rename `newsjack-setup` → `newsjack-monitor-setup`** and tighten its `when_to_use` so it stops grabbing general first contact (defers to getting-started). Updated the live references (README, CI script, Go test); the two dated planning docs are left as historical records. The `newsjack setup` *command* is unchanged.
- **`eval/onboarding/`** — a six-scenario behavioral eval (`evals.json` + README) and a `2026-06-04` validation run.

## Validation

A subagent role-played a freshly-installed agent across six openings (vague first contact ×2, plus known-intent: find journalists / newsworthiness / set up monitoring / search news), reading only the on-disk docs with **no keys configured**. All six pass — slow start fires, no key complaint, correct routing, graceful host-search fallback. The run also drove the two doc tightenings above.

`cd apps/cli && go test ./...` → green.

## Note / follow-up
- The **installed path** (`curl | bash` → `newsjack setup`) still hands the agent *"Use newsjack to set up monitoring for my company,"* skipping the slow start. Left out of this PR by design; can fold in by softening the post-install prompt and/or launching the menu from `newsjack setup`.
- Existing installs carry the **pre-rename skills** until they reinstall/release — expected, not a repo defect.
