### PR TITLE
Harden npm release pipeline

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -1,6 +1,8 @@
 name: npm release
 
 on:
+  release:
+    types: [published]
   workflow_dispatch:
     inputs:
       version:
@@ -8,14 +10,23 @@ on:
         required: true
         type: string
       source_ref:
-        description: Source ref to build from. Defaults to main for already-tagged releases.
+        description: Source ref to build from. Defaults to the version tag.
         required: false
-        default: main
+        default: ''
         type: string
+      allow_ref_mismatch:
+        description: Allow source_ref to differ from the version tag. Use only for explicit backfills.
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
   id-token: write
+
+concurrency:
+  group: npm-release-${{ github.event.release.tag_name || inputs.version || github.ref_name }}
+  cancel-in-progress: false
 
 jobs:
   npm:
@@ -23,10 +34,64 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
+      - name: Resolve release inputs
+        id: release
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_SOURCE_REF: ${{ inputs.source_ref }}
+          INPUT_ALLOW_REF_MISMATCH: ${{ inputs.allow_ref_mismatch }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ "$EVENT_NAME" == "release" ]]; then
+            version="$RELEASE_TAG"
+            source_ref="$RELEASE_TAG"
+            allow_ref_mismatch=false
+          else
+            version="$INPUT_VERSION"
+            source_ref="$INPUT_SOURCE_REF"
+            if [[ -z "$source_ref" ]]; then
+              source_ref="$version"
+            fi
+            allow_ref_mismatch="${INPUT_ALLOW_REF_MISMATCH:-false}"
+          fi
+
+          [[ "$version" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z.-]*)?$ ]]
+          npm_version="${version#v}"
+
+          {
+            echo "version=$version"
+            echo "source_ref=$source_ref"
+            echo "allow_ref_mismatch=$allow_ref_mismatch"
+            echo "npm_version=$npm_version"
+          } >>"$GITHUB_OUTPUT"
+
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          ref: ${{ inputs.source_ref }}
+          ref: ${{ steps.release.outputs.source_ref }}
+
+      - name: Validate release source
+        env:
+          VERSION: ${{ steps.release.outputs.version }}
+          SOURCE_REF: ${{ steps.release.outputs.source_ref }}
+          ALLOW_REF_MISMATCH: ${{ steps.release.outputs.allow_ref_mismatch }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch --force --tags origin "refs/tags/${VERSION}:refs/tags/${VERSION}"
+
+          tag_commit="$(git rev-list -n 1 "$VERSION")"
+          head_commit="$(git rev-parse HEAD)"
+
+          if [[ "$head_commit" != "$tag_commit" && "$ALLOW_REF_MISMATCH" != "true" ]]; then
+            echo "::error title=Release source mismatch::${SOURCE_REF} resolves to ${head_commit}, but ${VERSION} resolves to ${tag_commit}."
+            echo "Use the version tag as source_ref, or set allow_ref_mismatch=true only for an intentional backfill."
+            exit 1
+          fi
 
       - uses: actions/setup-go@v6
         with:
@@ -39,26 +104,53 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           package-manager-cache: false
 
-      - name: Validate version
+      - name: Install current npm CLI
+        run: npm install -g npm@latest
+
+      - name: Check npm version availability
+        env:
+          NPM_VERSION: ${{ steps.release.outputs.npm_version }}
         shell: bash
         run: |
           set -euo pipefail
-          [[ "${{ inputs.version }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z.-]*)?$ ]]
+          npm ping --registry https://registry.npmjs.org
+
+          packages=(
+            newsjack-linux-arm64
+            newsjack-linux-x64
+            newsjack-darwin-arm64
+            newsjack-darwin-x64
+            newsjack
+          )
+
+          published=()
+          for package in "${packages[@]}"; do
+            if npm view "${package}@${NPM_VERSION}" version --registry https://registry.npmjs.org >/dev/null 2>&1; then
+              published+=("${package}@${NPM_VERSION}")
+            fi
+          done
+
+          if ((${#published[@]} > 0)); then
+            printf '::error title=Already published::These versions already exist on npm: %s\n' "${published[*]}"
+            exit 1
+          fi
 
       - name: Run CLI tests
         working-directory: apps/cli
         run: go test ./...
 
       - name: Build npm packages
-        run: NEWSJACK_VERSION="${{ inputs.version }}" NEWSJACK_NPM_DIST=.tmp/newsjack-npm node scripts/build-npm-packages.mjs
+        run: NEWSJACK_VERSION="${{ steps.release.outputs.version }}" NEWSJACK_NPM_DIST=.tmp/newsjack-npm node scripts/build-npm-packages.mjs
+
+      - name: Verify npm package contents
+        run: node scripts/verify-npm-packages.mjs .tmp/newsjack-npm "${{ steps.release.outputs.version }}"
 
       - name: Publish npm packages
         env:
-          NEWSJACK_VERSION: ${{ inputs.version }}
+          NEWSJACK_VERSION: ${{ steps.release.outputs.version }}
         shell: bash
         run: |
           set -euo pipefail
-          npm install -g npm@latest
 
           npm_tag=latest
           if [[ "${NEWSJACK_VERSION}" == *-* ]]; then
@@ -77,3 +169,22 @@ jobs:
           publish .tmp/newsjack-npm/newsjack-darwin-arm64
           publish .tmp/newsjack-npm/newsjack-darwin-x64
           publish .tmp/newsjack-npm/newsjack
+
+      - name: Verify published versions
+        env:
+          NPM_VERSION: ${{ steps.release.outputs.npm_version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          packages=(
+            newsjack-linux-arm64
+            newsjack-linux-x64
+            newsjack-darwin-arm64
+            newsjack-darwin-x64
+            newsjack
+          )
+
+          for package in "${packages[@]}"; do
+            published="$(npm view "${package}@${NPM_VERSION}" version --registry https://registry.npmjs.org)"
+            test "$published" = "$NPM_VERSION"
+          done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
       - 'v*'
 
 permissions:
+  actions: write
   contents: write
 
 jobs:
@@ -56,3 +57,14 @@ jobs:
             --title "Newsjack ${GITHUB_REF_NAME}" \
             --notes "Newsjack ${GITHUB_REF_NAME}" \
             "${prerelease_args[@]}"
+
+      - name: Queue npm release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh workflow run npm-release.yml \
+            --ref "${GITHUB_REF_NAME}" \
+            -f version="${GITHUB_REF_NAME}" \
+            -f source_ref="${GITHUB_REF_NAME}"

--- a/docs/release-playbook.md
+++ b/docs/release-playbook.md
@@ -51,6 +51,7 @@ Required gates:
 - The repo has been audited for secrets/private artifacts.
 - The repo is public before validating unauthenticated release downloads.
 - You have permission to push tags and create GitHub Releases.
+- GitHub Actions can dispatch workflows with the repository `GITHUB_TOKEN`.
 - The local tree is clean:
 
 ```bash
@@ -67,7 +68,38 @@ NEWSJACK_VERSION=v0.1.0-test NEWSJACK_RELEASE_DIST=.tmp/newsjack-release-test \
   node scripts/build-release-dist.mjs
 NEWSJACK_VERSION=v0.1.0-test NEWSJACK_NPM_DIST=.tmp/newsjack-npm-test \
   node scripts/build-npm-packages.mjs
+node scripts/verify-npm-packages.mjs .tmp/newsjack-npm-test v0.1.0-test
 ```
+
+## Required npm Setup
+
+The npm workflow uses trusted publishing only. Do not add an `NPM_TOKEN` for
+normal releases.
+
+Trusted publishing must be configured on npm for:
+
+```text
+newsjack
+newsjack-linux-arm64
+newsjack-linux-x64
+newsjack-darwin-arm64
+newsjack-darwin-x64
+```
+
+Each package should trust:
+
+```text
+Publisher: GitHub Actions
+Owner: elvisun
+Repository: newsjack
+Workflow filename: npm-release.yml
+Allowed action: npm publish
+Environment: unset
+```
+
+If npm returns `ENEEDAUTH`, check the trusted publisher fields first. The
+workflow filename must be exactly `npm-release.yml`, and GitHub-hosted runners
+must be used so npm can validate the OIDC token.
 
 ## Local Release Smoke
 
@@ -146,10 +178,13 @@ git tag -a v0.1.0 -m "v0.1.0"
 git push origin v0.1.0
 ```
 
-3. Watch the release workflow:
+3. Watch the release workflow. It builds GitHub Release assets, creates the
+   release, then queues `npm-release.yml` for the same tag:
 
 ```bash
 gh run list --workflow release.yml --limit 5
+gh run watch
+gh run list --workflow npm-release.yml --limit 5
 gh run watch
 ```
 
@@ -172,31 +207,29 @@ newsjack_linux_amd64.tar.gz
 newsjack_linux_arm64.tar.gz
 ```
 
-Publish npm packages with the manual npm workflow after the GitHub Release
-assets are published. For a tag that already exists, such as a release cut
-before the npm workflow was added, build from `main` while setting the package
-version to the existing tag:
+The npm workflow publishes the five npm packages after checking that the exact
+version is not already present on npm, running CLI tests, building packages,
+running `npm pack --dry-run`, and smoking the generated `newsjack` wrapper.
+
+For a future tag that somehow was not published to npm, run the npm workflow
+manually from that same tag:
 
 ```bash
-gh workflow run npm-release.yml -f version=v0.1.5 -f source_ref=main
+gh workflow run npm-release.yml --ref v0.1.5 -f version=v0.1.5 -f source_ref=v0.1.5
 gh run watch
 ```
 
-The npm workflow uses trusted publishing only. Do not add an `NPM_TOKEN` for
-normal releases.
+For a historical tag that predates this npm workflow or its verification
+scripts, run from `main` only if you intentionally accept that the package
+provenance points at `main` instead of the original tag:
 
-Trusted publishing is configured on npm for:
-
-```text
-newsjack
-newsjack-linux-arm64
-newsjack-linux-x64
-newsjack-darwin-arm64
-newsjack-darwin-x64
+```bash
+gh workflow run npm-release.yml --ref main \
+  -f version=v0.1.5 \
+  -f source_ref=main \
+  -f allow_ref_mismatch=true
+gh run watch
 ```
-
-Each package trusts GitHub Actions in `elvisun/newsjack` with workflow file
-`npm-release.yml` and `npm publish` permission.
 
 Verify npm:
 

--- a/scripts/build-npm-packages.mjs
+++ b/scripts/build-npm-packages.mjs
@@ -369,6 +369,9 @@ writeJSON(
       bin: {
         newsjack: "bin/newsjack",
       },
+      publishConfig: {
+        access: "public",
+      },
       engines: {
         node: ">=18",
       },

--- a/scripts/verify-npm-packages.mjs
+++ b/scripts/verify-npm-packages.mjs
@@ -1,0 +1,134 @@
+import { execFileSync } from "node:child_process";
+import {
+  accessSync,
+  constants,
+  readFileSync,
+  statSync,
+} from "node:fs";
+import { join, resolve } from "node:path";
+
+const outRoot = resolve(process.argv[2] || ".tmp/newsjack-npm");
+const releaseVersion = process.argv[3] || process.env.NEWSJACK_VERSION || "";
+
+const targets = [
+  {
+    packageName: "newsjack-linux-arm64",
+    nodeOS: "linux",
+    nodeArch: "arm64",
+  },
+  {
+    packageName: "newsjack-linux-x64",
+    nodeOS: "linux",
+    nodeArch: "x64",
+  },
+  {
+    packageName: "newsjack-darwin-arm64",
+    nodeOS: "darwin",
+    nodeArch: "arm64",
+  },
+  {
+    packageName: "newsjack-darwin-x64",
+    nodeOS: "darwin",
+    nodeArch: "x64",
+  },
+];
+
+function npmVersionFrom(version) {
+  const npmVersion = version.replace(/^v/, "");
+  if (!/^\d+\.\d+\.\d+(?:-[0-9A-Za-z][0-9A-Za-z.-]*)?(?:\+[0-9A-Za-z][0-9A-Za-z.-]*)?$/.test(npmVersion)) {
+    throw new Error(`release version must be publishable semver, got ${version}`);
+  }
+  return npmVersion;
+}
+
+function readJSON(path) {
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function assertExecutable(path) {
+  const stats = statSync(path);
+  assert(stats.isFile(), `${path} must be a file`);
+  accessSync(path, constants.X_OK);
+}
+
+function packDryRun(packageDir) {
+  const raw = execFileSync("npm", ["pack", "--dry-run", "--json", packageDir], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "inherit"],
+  });
+  const result = JSON.parse(raw);
+  assert(Array.isArray(result) && result.length === 1, `unexpected npm pack output for ${packageDir}`);
+  return new Set(result[0].files.map((file) => file.path));
+}
+
+function assertCommonMetadata(pkg, packageName, npmVersion) {
+  assert(pkg.name === packageName, `${packageName}: package name mismatch`);
+  assert(pkg.version === npmVersion, `${packageName}: package version mismatch`);
+  assert(pkg.license === "MIT", `${packageName}: license mismatch`);
+  assert(pkg.repository?.url === "git+https://github.com/elvisun/newsjack.git", `${packageName}: repository.url mismatch`);
+  assert(pkg.bugs?.url === "https://github.com/elvisun/newsjack/issues", `${packageName}: bugs.url mismatch`);
+}
+
+const npmVersion = npmVersionFrom(releaseVersion);
+
+for (const target of targets) {
+  const packageDir = join(outRoot, target.packageName);
+  const pkg = readJSON(join(packageDir, "package.json"));
+  assertCommonMetadata(pkg, target.packageName, npmVersion);
+  assert(pkg.publishConfig?.access === "public", `${target.packageName}: publishConfig.access must be public`);
+  assert(pkg.os?.length === 1 && pkg.os[0] === target.nodeOS, `${target.packageName}: os mismatch`);
+  assert(pkg.cpu?.length === 1 && pkg.cpu[0] === target.nodeArch, `${target.packageName}: cpu mismatch`);
+  assertExecutable(join(packageDir, "bin", "newsjack"));
+
+  const files = packDryRun(packageDir);
+  assert(files.has("bin/newsjack"), `${target.packageName}: npm pack is missing bin/newsjack`);
+  assert(files.has("package.json"), `${target.packageName}: npm pack is missing package.json`);
+}
+
+const mainPackageDir = join(outRoot, "newsjack");
+const mainPkg = readJSON(join(mainPackageDir, "package.json"));
+assertCommonMetadata(mainPkg, "newsjack", npmVersion);
+assert(mainPkg.bin?.newsjack === "bin/newsjack", "newsjack: bin.newsjack mismatch");
+assert(mainPkg.publishConfig?.access === "public", "newsjack: publishConfig.access must be public");
+assert(mainPkg.engines?.node === ">=18", "newsjack: engines.node mismatch");
+
+for (const target of targets) {
+  assert(
+    mainPkg.optionalDependencies?.[target.packageName] === npmVersion,
+    `newsjack: optional dependency ${target.packageName} must equal ${npmVersion}`,
+  );
+}
+
+const manifest = readJSON(join(mainPackageDir, "skills-manifest.json"));
+assert(manifest.version === releaseVersion, "newsjack: skills manifest release version mismatch");
+assert(manifest.npm_version === npmVersion, "newsjack: skills manifest npm version mismatch");
+assert(manifest.distribution === "npm", "newsjack: skills manifest distribution mismatch");
+assertExecutable(join(mainPackageDir, "bin", "newsjack"));
+
+const mainFiles = packDryRun(mainPackageDir);
+for (const expectedFile of [
+  "bin/newsjack",
+  "skills-manifest.json",
+  "VERSION",
+  "COMMIT",
+  ".newsjack-npm",
+  "package.json",
+]) {
+  assert(mainFiles.has(expectedFile), `newsjack: npm pack is missing ${expectedFile}`);
+}
+
+execFileSync(join(mainPackageDir, "bin", "newsjack"), ["version"], {
+  env: {
+    ...process.env,
+    NEWSJACK_NO_AUTO_UPDATE: "1",
+  },
+  stdio: "inherit",
+});
+
+console.log(`Verified Newsjack npm packages for ${releaseVersion} in ${outRoot}.`);


### PR DESCRIPTION
## Summary

Hardens the npm publish path so Newsjack releases are safer to publish and easier to verify.

## Motivation

The npm packages are published through trusted publishing, but the current flow is easy to miss after a GitHub Release and does not preflight duplicate versions or validate generated package contents before `npm publish`.

## Implementation notes

- Queues `npm-release.yml` automatically from the tag-driven GitHub Release workflow.
- Tightens `npm-release.yml` around tag/source-ref resolution, ref mismatch blocking, npm duplicate-version preflight, concurrency, package verification, and post-publish version checks.
- Adds `scripts/verify-npm-packages.mjs` to validate generated package metadata, executable bits, `npm pack --dry-run` contents, optional dependency alignment, and a host-platform wrapper smoke.
- Documents required npm trusted publisher setup and historical backfill behavior in `docs/release-playbook.md`.

Human setup still required:

- Keep npm trusted publishing configured for `newsjack`, `newsjack-linux-arm64`, `newsjack-linux-x64`, `newsjack-darwin-arm64`, and `newsjack-darwin-x64` with owner `elvisun`, repository `newsjack`, workflow filename `npm-release.yml`, allowed action `npm publish`, and no environment restriction.
- Do not add `NPM_TOKEN` for normal releases.
- GitHub Actions must allow the workflow `GITHUB_TOKEN` to dispatch workflows.
- Current npm `latest` is `0.1.5` while Git tags reach `v0.1.8`; if catch-up publishing is desired after merge, use the documented historical backfill path deliberately.

How to test/release:

- Local package verification: `NEWSJACK_VERSION=v0.1.0-ci NEWSJACK_NPM_DIST=.tmp/newsjack-npm-verify node scripts/build-npm-packages.mjs && node scripts/verify-npm-packages.mjs .tmp/newsjack-npm-verify v0.1.0-ci`
- Normal release: push a `vX.Y.Z` tag; `release.yml` creates the GitHub Release and queues `npm-release.yml` for the same tag.
- Watch both workflows: `gh run list --workflow release.yml --limit 5`, `gh run watch`, `gh run list --workflow npm-release.yml --limit 5`, `gh run watch`.

Validation run:

- `go test ./...` from `apps/cli`
- `pnpm lint` from `apps/site`
- `pnpm test` from `apps/site`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/npm-release.yml .github/workflows/release.yml`
- `NEWSJACK_VERSION=v0.1.0-ci NEWSJACK_NPM_DIST=.tmp/newsjack-npm-verify node scripts/build-npm-packages.mjs`
- `node scripts/verify-npm-packages.mjs .tmp/newsjack-npm-verify v0.1.0-ci`

## Checklist

- [x] Commit messages follow conventional commits (`feat:`, `fix:`, `docs:`, etc.)
- [x] No secrets or credentials committed (gitleaks runs in CI; please also review the diff)
- [x] New skills follow the structure established by `skills/meanest-editor/` (not applicable)
- [x] Positioning copy is consistent with **agentic PR** as the product category (not applicable)