### PR TITLE
Windows support: native bootstrap, Go MCP bridge, self-update, and CI battery

### DIFF
--- a/.github/workflows/agent-harness-ci.yml
+++ b/.github/workflows/agent-harness-ci.yml
@@ -8,9 +8,13 @@ on:
 
 jobs:
   cli-unit:
-    name: CLI unit tests
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
+    name: CLI unit tests (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
     steps:
       - uses: actions/checkout@v6
 
@@ -22,6 +26,18 @@ jobs:
       - name: Run Go tests
         working-directory: apps/cli
         run: go test ./...
+
+      - name: Cross-compile gates
+        if: matrix.os == 'ubuntu-latest'
+        working-directory: apps/cli
+        shell: bash
+        run: |
+          set -euo pipefail
+          CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build ./...
+          CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go vet ./...
+          CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build ./...
+          CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build ./...
+          CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build ./...
 
   release-installer-smoke:
     name: Release installer smoke
@@ -42,6 +58,13 @@ jobs:
 
       - name: Build release assets
         run: NEWSJACK_VERSION=v0.1.0-ci NEWSJACK_RELEASE_DIST=.tmp/newsjack-release node scripts/build-release-dist.mjs
+
+      - name: Upload release dist for the Windows battery
+        uses: actions/upload-artifact@v6
+        with:
+          name: newsjack-release-dist
+          path: .tmp/newsjack-release
+          retention-days: 1
 
       - name: Smoke full branded install from release assets
         shell: bash
@@ -111,6 +134,29 @@ jobs:
 
           newsjack version | grep -F 'v0.1.0-ci'
           jq -e '.skills_mode == "external" and .install_mcp == false' "$HOME/.newsjack/install.json"
+
+  windows-installer:
+    name: Windows bootstrap battery
+    needs: release-installer-smoke
+    runs-on: windows-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: '1.26.x'
+          cache-dependency-path: apps/cli/go.sum
+
+      - name: Download release dist
+        uses: actions/download-artifact@v6
+        with:
+          name: newsjack-release-dist
+          path: .tmp/newsjack-release
+
+      - name: Run Windows bootstrap battery
+        shell: pwsh
+        run: harness/scripts/run-ci-installer.ps1 -DistDir .tmp/newsjack-release
 
   no-token-installer:
     name: No-token installer harness

--- a/.github/workflows/agent-harness-integration.yml
+++ b/.github/workflows/agent-harness-integration.yml
@@ -3,8 +3,16 @@ name: Agent Harness Manual
 on:
   workflow_dispatch:
     inputs:
+      os:
+        description: Target environment
+        required: true
+        default: linux
+        type: choice
+        options:
+          - linux
+          - windows
       runtime:
-        description: Runtime install target
+        description: Runtime install target (linux Docker harness only)
         required: true
         default: all
         type: choice
@@ -28,6 +36,7 @@ on:
 jobs:
   installer:
     name: Manual installer harness
+    if: inputs.os == 'linux'
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
@@ -57,3 +66,87 @@ jobs:
           harness/scripts/run-ci-installer.sh \
             --runtime "${{ inputs.runtime }}" \
             "$source_flag"
+
+  windows-claude:
+    name: Manual Windows Claude Code harness
+    if: inputs.os == 'windows'
+    runs-on: windows-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: '1.26.x'
+          cache-dependency-path: apps/cli/go.sum
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
+      - name: Build release dist
+        shell: bash
+        run: NEWSJACK_VERSION=v0.1.0-manual NEWSJACK_RELEASE_DIST=.tmp/newsjack-release node scripts/build-release-dist.mjs
+
+      - name: Install Claude Code via the native Windows installer
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          irm https://claude.ai/install.ps1 | iex
+          $claudeBin = Join-Path $env:USERPROFILE '.local\bin'
+          "$claudeBin" | Out-File -FilePath $env:GITHUB_PATH -Append -Encoding utf8
+          & (Join-Path $claudeBin 'claude.exe') --version
+
+      - name: Bootstrap newsjack and verify Claude Code MCP registration
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $dist = Resolve-Path .tmp/newsjack-release
+          $server = Start-Process -FilePath 'python' -ArgumentList @('-m', 'http.server', '8765', '--directory', "$dist") -PassThru -NoNewWindow
+          try {
+            for ($i = 0; $i -lt 50; $i++) {
+              try { Invoke-WebRequest -Uri 'http://127.0.0.1:8765/checksums.txt' -TimeoutSec 2 | Out-Null; break } catch { Start-Sleep -Milliseconds 300 }
+            }
+
+            $scratch = Join-Path $env:RUNNER_TEMP 'newsjack-windows-manual'
+            New-Item -ItemType Directory -Path $scratch -Force | Out-Null
+            $exe = Join-Path $scratch 'newsjack.exe'
+            Copy-Item (Join-Path $dist 'newsjack_windows_amd64.exe') $exe
+
+            $env:NEWSJACK_HOME = Join-Path $scratch '.newsjack'
+            $env:NEWSJACK_RELEASE_BASE = 'http://127.0.0.1:8765'
+            $env:NEWSJACK_RUNTIMES = 'claude'
+            $env:NEWSJACK_INSTALL_MCP = '1'
+            $env:NEWSJACK_NO_AUTO_UPDATE = '1'
+
+            & $exe setup --json | Out-Null
+            if ($LASTEXITCODE -ne 0) { throw "newsjack setup failed: $LASTEXITCODE" }
+
+            $cli = Join-Path $env:NEWSJACK_HOME 'bin\newsjack.exe'
+            & $cli doctor --json | Out-String | Write-Host
+
+            $mcpList = claude mcp list 2>&1 | Out-String
+            Write-Host $mcpList
+            if ($mcpList -notmatch 'medialyst') { throw 'Claude Code MCP registry has no medialyst entry' }
+            if ($mcpList -notmatch 'mcp-bridge') { throw 'medialyst MCP entry does not point at the newsjack bridge' }
+          } finally {
+            if (-not $server.HasExited) { Stop-Process -Id $server.Id -Force }
+          }
+
+      - name: Live Medialyst query through the bridge (only with secret)
+        if: ${{ secrets.MEDIALYST_API_KEY != '' }}
+        shell: pwsh
+        env:
+          MEDIALYST_API_KEY: ${{ secrets.MEDIALYST_API_KEY }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $cli = Join-Path $env:RUNNER_TEMP 'newsjack-windows-manual\.newsjack\bin\newsjack.exe'
+          $env:NEWSJACK_HOME = Join-Path $env:RUNNER_TEMP 'newsjack-windows-manual\.newsjack'
+          $messages = @(
+            '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"windows-manual","version":"0"}}}'
+            '{"jsonrpc":"2.0","method":"notifications/initialized"}'
+            '{"jsonrpc":"2.0","id":2,"method":"tools/list"}'
+          )
+          $out = $messages | & $cli mcp-bridge
+          if ($LASTEXITCODE -ne 0) { throw "live bridge handshake failed: $LASTEXITCODE" }
+          if (($out -join "`n") -notmatch 'tools') { throw 'live tools/list returned no tools' }

--- a/.github/workflows/agent-harness-integration.yml
+++ b/.github/workflows/agent-harness-integration.yml
@@ -67,15 +67,13 @@ jobs:
             --runtime "${{ inputs.runtime }}" \
             "$source_flag"
 
-  windows-claude:
-    name: Manual Windows Claude Code harness
+  windows-build-dist:
+    name: Build release dist for the Windows harness
     if: inputs.os == 'windows'
-    runs-on: windows-latest
-    timeout-minutes: 45
-    env:
-      # secrets is not available in step-level `if` expressions; surface the
-      # presence check through job env instead.
-      HAS_MEDIALYST_KEY: ${{ secrets.MEDIALYST_API_KEY != '' }}
+    # The dist build script is Linux/macOS-only (it resolves Go via sh);
+    # cross-compile here and hand the artifacts to the Windows job.
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
 
@@ -89,8 +87,32 @@ jobs:
           node-version: '22'
 
       - name: Build release dist
-        shell: bash
         run: NEWSJACK_VERSION=v0.1.0-manual NEWSJACK_RELEASE_DIST=.tmp/newsjack-release node scripts/build-release-dist.mjs
+
+      - uses: actions/upload-artifact@v6
+        with:
+          name: newsjack-release-dist-manual
+          path: .tmp/newsjack-release
+          retention-days: 1
+
+  windows-claude:
+    name: Manual Windows Claude Code harness
+    if: inputs.os == 'windows'
+    needs: windows-build-dist
+    runs-on: windows-latest
+    timeout-minutes: 45
+    env:
+      # secrets is not available in step-level `if` expressions; surface the
+      # presence check through job env instead.
+      HAS_MEDIALYST_KEY: ${{ secrets.MEDIALYST_API_KEY != '' }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Download release dist
+        uses: actions/download-artifact@v6
+        with:
+          name: newsjack-release-dist-manual
+          path: .tmp/newsjack-release
 
       - name: Install Claude Code via the native Windows installer
         shell: pwsh

--- a/.github/workflows/agent-harness-integration.yml
+++ b/.github/workflows/agent-harness-integration.yml
@@ -139,6 +139,10 @@ jobs:
             $exe = Join-Path $scratch 'newsjack.exe'
             Copy-Item (Join-Path $dist 'newsjack_windows_amd64.exe') $exe
 
+            # Run from the scratch dir: inside the checkout, newsjackRoot()
+            # resolves to the source tree and setup never bootstraps.
+            Set-Location $scratch
+
             $env:NEWSJACK_HOME = Join-Path $scratch '.newsjack'
             $env:NEWSJACK_RELEASE_BASE = 'http://127.0.0.1:8765'
             $env:NEWSJACK_RUNTIMES = 'claude'

--- a/.github/workflows/agent-harness-integration.yml
+++ b/.github/workflows/agent-harness-integration.yml
@@ -72,6 +72,10 @@ jobs:
     if: inputs.os == 'windows'
     runs-on: windows-latest
     timeout-minutes: 45
+    env:
+      # secrets is not available in step-level `if` expressions; surface the
+      # presence check through job env instead.
+      HAS_MEDIALYST_KEY: ${{ secrets.MEDIALYST_API_KEY != '' }}
     steps:
       - uses: actions/checkout@v6
 
@@ -134,7 +138,7 @@ jobs:
           }
 
       - name: Live Medialyst query through the bridge (only with secret)
-        if: ${{ secrets.MEDIALYST_API_KEY != '' }}
+        if: env.HAS_MEDIALYST_KEY == 'true'
         shell: pwsh
         env:
           MEDIALYST_API_KEY: ${{ secrets.MEDIALYST_API_KEY }}

--- a/.github/workflows/post-release-smoke.yml
+++ b/.github/workflows/post-release-smoke.yml
@@ -87,3 +87,59 @@ jobs:
           newsjack doctor --json | jq -e \
             '.root_ok == true and .install.skills_mode == "managed" and .install.cli_installed == true'
           CONTAINER_SCRIPT
+
+  windows-install:
+    name: Windows bare-exe bootstrap
+    runs-on: windows-latest
+    timeout-minutes: 15
+    steps:
+      - name: Bootstrap from GitHub Release and smoke the CLI
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $version = '${{ inputs.version }}'
+          $base = if ($version) {
+            "https://github.com/${{ github.repository }}/releases/download/$version"
+          } else {
+            "https://github.com/${{ github.repository }}/releases/latest/download"
+          }
+
+          $scratch = Join-Path $env:RUNNER_TEMP 'newsjack-release-smoke'
+          New-Item -ItemType Directory -Path $scratch -Force | Out-Null
+          $exe = Join-Path $scratch 'newsjack.exe'
+          Invoke-WebRequest -Uri "$base/newsjack_windows_amd64.exe" -OutFile $exe
+
+          # Verify the download against the published checksums, exactly as a
+          # careful user would.
+          $checksums = (Invoke-WebRequest -Uri "$base/checksums.txt").Content
+          $line = ($checksums -split "`n") | Where-Object { $_ -match 'newsjack_windows_amd64\.exe' } | Select-Object -First 1
+          if (-not $line) { throw 'checksums.txt has no entry for newsjack_windows_amd64.exe' }
+          $expected = ($line -split '\s+')[0].ToLower()
+          $actual = (Get-FileHash -Algorithm SHA256 $exe).Hash.ToLower()
+          if ($expected -ne $actual) { throw "checksum mismatch: $expected vs $actual" }
+
+          $env:NEWSJACK_HOME = Join-Path $scratch '.newsjack'
+          $env:NEWSJACK_REPO = '${{ github.repository }}'
+          if ($version) { $env:NEWSJACK_RELEASE_BASE = $base }
+          $env:NEWSJACK_RUNTIMES = 'claude'
+          $env:NEWSJACK_INSTALL_MCP = '0'
+          $env:NEWSJACK_NO_AUTO_UPDATE = '1'
+
+          & $exe setup --json | Out-Null
+          if ($LASTEXITCODE -ne 0) { throw "newsjack setup failed: $LASTEXITCODE" }
+
+          $cli = Join-Path $env:NEWSJACK_HOME 'bin\newsjack.exe'
+          $installed = (& $cli version | Out-String).Trim()
+          Write-Host "installed version: $installed"
+          if ($version -and ($installed -ne $version)) { throw "version mismatch: $installed vs $version" }
+
+          $doctor = & $cli doctor --json | Out-String | ConvertFrom-Json
+          if (-not $doctor.root_ok) { throw 'doctor root_ok is false' }
+          if ($doctor.mcp_bridge.transport -ne 'native') { throw 'doctor mcp_bridge.transport is not native' }
+          if (-not $doctor.install.cli_installed) { throw 'doctor cli_installed is false' }
+
+          $skill = Join-Path $env:USERPROFILE '.claude\skills\newsjack-detector\SKILL.md'
+          if (-not (Test-Path $skill)) { throw "skill not installed: $skill" }
+
+          $detector = & $cli detector run 'AI search visibility' --mock --limit 1 | Out-String | ConvertFrom-Json
+          if (-not $detector.monitor.mock) { throw 'mock detector run failed' }

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ out/
 build/
 coverage/
 apps/cli/newsjack
+apps/cli/newsjack.exe
 
 # ─── editor / os ──────────────────────────────────────
 .DS_Store

--- a/apps/cli/cmd/newsjack/auth_test.go
+++ b/apps/cli/cmd/newsjack/auth_test.go
@@ -44,13 +44,10 @@ func TestAuthStatusMissingAndLoginHeaders(t *testing.T) {
 		if code != 0 {
 			t.Fatalf("login code=%d stderr=%s", code, err.String())
 		}
-		info, statErr := os.Stat(credentialsPath())
-		if statErr != nil {
+		if _, statErr := os.Stat(credentialsPath()); statErr != nil {
 			t.Fatalf("credentials not written: %v", statErr)
 		}
-		if got := info.Mode().Perm(); got != 0o600 {
-			t.Fatalf("credentials mode=%o, want 600", got)
-		}
+		assertOwnerOnlyFile(t, credentialsPath())
 
 		out.Reset()
 		err.Reset()
@@ -112,13 +109,7 @@ func TestAuthSetStoresOptionalAPIs(t *testing.T) {
 		if !strings.Contains(string(envBody), `X_BEARER_TOKEN="x-token"`) {
 			t.Fatalf("X token was not saved to newsjack env:\n%s", envBody)
 		}
-		mode, err := os.Stat(newsjackEnvPath())
-		if err != nil {
-			t.Fatal(err)
-		}
-		if mode.Mode().Perm() != 0o600 {
-			t.Fatalf("env permissions=%o, want 600", mode.Mode().Perm())
-		}
+		assertOwnerOnlyFile(t, newsjackEnvPath())
 
 		out.Reset()
 		errBuf.Reset()

--- a/apps/cli/cmd/newsjack/bundle.go
+++ b/apps/cli/cmd/newsjack/bundle.go
@@ -42,18 +42,27 @@ func releaseArtifactName() string {
 // fetch the release bundle for this platform, verify its checksum, unpack
 // it, install this binary as the managed CLI, write install state, then
 // run the regular skills and MCP install. No shell, tar, curl, Node, or
-// git is required on the machine.
-func bootstrapInstall(stdout, stderr io.Writer) error {
+// git is required on the machine. runtimeSelection comes from setup's
+// --runtime flag; NEWSJACK_RUNTIMES still wins when set.
+func bootstrapInstall(runtimeSelection string, stdout, stderr io.Writer) error {
 	base := releaseBaseForUpdate()
 	logf(stderr, "newsjack is not installed yet; fetching the release bundle from %s", base)
 	version, err := applyReleaseBundle(base, stderr)
 	if err != nil {
 		return err
 	}
+	return finalizeBootstrap(version, runtimeSelection, stdout, stderr)
+}
+
+// finalizeBootstrap is the post-bundle half of first install: managed
+// binary, install state, skills, MCP. Split out so an interrupted
+// bootstrap (bundle applied, rest missing) can be resumed without
+// re-downloading the release.
+func finalizeBootstrap(version, runtimeSelection string, stdout, stderr io.Writer) error {
 	if err := installSelfBinary(); err != nil {
 		return err
 	}
-	if err := writeInstallStateFile(bootstrapInstallState(version)); err != nil {
+	if err := writeInstallStateFile(bootstrapInstallState(version, runtimeSelection)); err != nil {
 		return err
 	}
 	if os.Getenv("NEWSJACK_INSTALL_SKILLS") == "0" {
@@ -62,7 +71,7 @@ func bootstrapInstall(stdout, stderr io.Writer) error {
 	}
 	opts := installOptions{
 		Source:     managedInstallDir(),
-		Runtimes:   getenv("NEWSJACK_RUNTIMES", "auto"),
+		Runtimes:   bootstrapRuntimes(runtimeSelection),
 		InstallMCP: os.Getenv("NEWSJACK_INSTALL_MCP") != "0",
 		Force:      os.Getenv("NEWSJACK_FORCE") == "1",
 		CLI:        newsjackCLIInvocation(),
@@ -81,10 +90,22 @@ func bootstrapInstall(stdout, stderr io.Writer) error {
 	return nil
 }
 
+func bootstrapRuntimes(runtimeSelection string) string {
+	if v := strings.TrimSpace(os.Getenv("NEWSJACK_RUNTIMES")); v != "" {
+		return v
+	}
+	if v := strings.TrimSpace(runtimeSelection); v != "" && v != "other" && v != "manual" {
+		return v
+	}
+	return "auto"
+}
+
 // ensureInstalledRoot bootstraps a bare binary on first run. Explicit
 // NEWSJACK_ROOT overrides, source checkouts, and npm installs never
-// trigger a release download.
-func ensureInstalledRoot(stdout, stderr io.Writer) error {
+// trigger a release download. A managed root left behind by an
+// interrupted bootstrap (bundle present, binary or state missing) is
+// finished here without re-downloading.
+func ensureInstalledRoot(runtimeSelection string, stdout, stderr io.Writer) error {
 	if npmDistribution() {
 		return nil
 	}
@@ -92,10 +113,17 @@ func ensureInstalledRoot(stdout, stderr io.Writer) error {
 		_, err := newsjackRoot()
 		return err
 	}
-	if _, err := newsjackRoot(); err == nil {
-		return nil
+	if root, err := newsjackRoot(); err == nil {
+		if root != managedInstallDir() {
+			return nil
+		}
+		if fileExists(installedBinaryPath()) && fileExists(installStatePath()) {
+			return nil
+		}
+		logf(stderr, "finishing an interrupted newsjack install at %s", root)
+		return finalizeBootstrap(readTrimmedFile(filepath.Join(root, "VERSION")), runtimeSelection, stdout, stderr)
 	}
-	return bootstrapInstall(stdout, stderr)
+	return bootstrapInstall(runtimeSelection, stdout, stderr)
 }
 
 // applyReleaseBundle downloads, verifies, unpacks, and atomically swaps in
@@ -352,12 +380,12 @@ func samePath(a, b string) bool {
 	return filepath.Clean(a) == filepath.Clean(b)
 }
 
-func bootstrapInstallState(version string) installState {
+func bootstrapInstallState(version, runtimeSelection string) installState {
 	skillsMode := skillsModeManaged
 	if os.Getenv("NEWSJACK_INSTALL_SKILLS") == "0" {
 		skillsMode = skillsModeExternal
 	}
-	runtimesRaw := getenv("NEWSJACK_RUNTIMES", "auto")
+	runtimesRaw := bootstrapRuntimes(runtimeSelection)
 	return normalizeInstallState(installState{
 		Version:     version,
 		Commit:      readTrimmedFile(filepath.Join(managedInstallDir(), "COMMIT")),

--- a/apps/cli/cmd/newsjack/bundle.go
+++ b/apps/cli/cmd/newsjack/bundle.go
@@ -1,0 +1,405 @@
+package main
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/fs"
+	"net/http"
+	"os"
+	"path"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func installedBinaryName() string {
+	if runtime.GOOS == "windows" {
+		return "newsjack.exe"
+	}
+	return "newsjack"
+}
+
+func installedBinaryPath() string {
+	return filepath.Join(newsjackHome(), "bin", installedBinaryName())
+}
+
+func managedInstallDir() string {
+	return filepath.Join(newsjackHome(), "newsjack")
+}
+
+func releaseArtifactName() string {
+	return fmt.Sprintf("newsjack_%s_%s.tar.gz", runtime.GOOS, runtime.GOARCH)
+}
+
+// bootstrapInstall turns a bare downloaded binary into a full install:
+// fetch the release bundle for this platform, verify its checksum, unpack
+// it, install this binary as the managed CLI, write install state, then
+// run the regular skills and MCP install. No shell, tar, curl, Node, or
+// git is required on the machine.
+func bootstrapInstall(stdout, stderr io.Writer) error {
+	base := releaseBaseForUpdate()
+	logf(stderr, "newsjack is not installed yet; fetching the release bundle from %s", base)
+	version, err := applyReleaseBundle(base, stderr)
+	if err != nil {
+		return err
+	}
+	if err := installSelfBinary(); err != nil {
+		return err
+	}
+	if err := writeInstallStateFile(bootstrapInstallState(version)); err != nil {
+		return err
+	}
+	if os.Getenv("NEWSJACK_INSTALL_SKILLS") == "0" {
+		successf(stdout, "installed newsjack %s (runtime skill install skipped: NEWSJACK_INSTALL_SKILLS=0)", version)
+		return nil
+	}
+	opts := installOptions{
+		Source:     managedInstallDir(),
+		Runtimes:   getenv("NEWSJACK_RUNTIMES", "auto"),
+		InstallMCP: os.Getenv("NEWSJACK_INSTALL_MCP") != "0",
+		Force:      os.Getenv("NEWSJACK_FORCE") == "1",
+		CLI:        newsjackCLIInvocation(),
+		Repo:       getenv("NEWSJACK_REPO", defaultRepo),
+		Ref:        getenv("NEWSJACK_REF", defaultRef),
+	}
+	if err := installRuntimeSkills(opts, stdout, stderr); err != nil {
+		return err
+	}
+	if opts.InstallMCP {
+		if err := configureMCP(opts, stdout, stderr); err != nil {
+			warn(stderr, "%v", err)
+		}
+	}
+	successf(stdout, "installed newsjack %s to %s", version, managedInstallDir())
+	return nil
+}
+
+// ensureInstalledRoot bootstraps a bare binary on first run. Explicit
+// NEWSJACK_ROOT overrides, source checkouts, and npm installs never
+// trigger a release download.
+func ensureInstalledRoot(stdout, stderr io.Writer) error {
+	if npmDistribution() {
+		return nil
+	}
+	if os.Getenv("NEWSJACK_ROOT") != "" {
+		_, err := newsjackRoot()
+		return err
+	}
+	if _, err := newsjackRoot(); err == nil {
+		return nil
+	}
+	return bootstrapInstall(stdout, stderr)
+}
+
+// applyReleaseBundle downloads, verifies, unpacks, and atomically swaps in
+// the platform release bundle, returning the installed version. The
+// previous install is kept at <dir>.previous for rollback.
+func applyReleaseBundle(base string, logw io.Writer) (string, error) {
+	artifact := releaseArtifactName()
+	checksums, err := fetchReleaseBytes(base + "/checksums.txt")
+	if err != nil {
+		return "", fmt.Errorf("fetching checksums.txt: %w", err)
+	}
+	expected := checksumFor(string(checksums), artifact)
+	if expected == "" {
+		return "", fmt.Errorf("release has no checksum for %s; this platform may not be supported by %s", artifact, base)
+	}
+	payload, err := fetchReleaseBytes(base + "/" + artifact)
+	if err != nil {
+		return "", fmt.Errorf("fetching %s: %w", artifact, err)
+	}
+	sum := sha256.Sum256(payload)
+	if hex.EncodeToString(sum[:]) != expected {
+		return "", fmt.Errorf("checksum mismatch for %s", artifact)
+	}
+	logf(logw, "verified checksum for %s", artifact)
+
+	if err := os.MkdirAll(newsjackHome(), 0o755); err != nil {
+		return "", err
+	}
+	staging := managedInstallDir() + ".new"
+	if err := os.RemoveAll(staging); err != nil {
+		return "", err
+	}
+	if err := untarGz(payload, staging); err != nil {
+		_ = os.RemoveAll(staging)
+		return "", fmt.Errorf("unpacking %s: %w", artifact, err)
+	}
+	if err := validateBundleLayout(staging); err != nil {
+		_ = os.RemoveAll(staging)
+		return "", err
+	}
+	version := readTrimmedFile(filepath.Join(staging, "VERSION"))
+	if err := swapInstallDir(staging); err != nil {
+		return "", err
+	}
+	return version, nil
+}
+
+func checksumFor(checksums, artifact string) string {
+	for _, line := range strings.Split(checksums, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) == 2 && fields[1] == artifact {
+			return fields[0]
+		}
+	}
+	return ""
+}
+
+func validateBundleLayout(dir string) error {
+	checks := []struct {
+		path string
+		dir  bool
+	}{
+		{"skills", true},
+		{".newsjack-prebuilt", false},
+		{filepath.Join("bin", installedBinaryName()), false},
+		{"VERSION", false},
+		{"COMMIT", false},
+		{"skills-manifest.json", false},
+	}
+	for _, check := range checks {
+		target := filepath.Join(dir, check.path)
+		if check.dir && !dirExists(target) {
+			return fmt.Errorf("release bundle is missing directory %s", check.path)
+		}
+		if !check.dir && !fileExists(target) {
+			return fmt.Errorf("release bundle is missing %s", check.path)
+		}
+	}
+	return nil
+}
+
+func swapInstallDir(staging string) error {
+	installDir := managedInstallDir()
+	previous := installDir + ".previous"
+	if err := os.RemoveAll(previous); err != nil {
+		return err
+	}
+	if dirExists(installDir) {
+		if err := os.Rename(installDir, previous); err != nil {
+			return err
+		}
+	}
+	if err := os.Rename(staging, installDir); err != nil {
+		if dirExists(previous) && !dirExists(installDir) {
+			_ = os.Rename(previous, installDir)
+		}
+		return err
+	}
+	return nil
+}
+
+func untarGz(data []byte, dest string) error {
+	gz, err := gzip.NewReader(bytes.NewReader(data))
+	if err != nil {
+		return err
+	}
+	defer gz.Close()
+	reader := tar.NewReader(gz)
+	for {
+		header, err := reader.Next()
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		name := strings.TrimPrefix(filepath.ToSlash(header.Name), "./")
+		if name == "" {
+			continue
+		}
+		clean := path.Clean(name)
+		if path.IsAbs(clean) || clean == ".." || strings.HasPrefix(clean, "../") {
+			return fmt.Errorf("unsafe path in archive: %s", header.Name)
+		}
+		// Strip env files exactly like the shell installer's copy_tree.
+		base := path.Base(clean)
+		if (base == ".env" || strings.HasPrefix(base, ".env.")) && base != ".env.example" {
+			continue
+		}
+		target := filepath.Join(dest, filepath.FromSlash(clean))
+		switch header.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(target, 0o755); err != nil {
+				return err
+			}
+		case tar.TypeReg:
+			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+				return err
+			}
+			mode := fs.FileMode(header.Mode) & 0o777
+			if mode == 0 {
+				mode = 0o644
+			}
+			out, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode)
+			if err != nil {
+				return err
+			}
+			if _, err := io.Copy(out, reader); err != nil {
+				out.Close()
+				return err
+			}
+			if err := out.Close(); err != nil {
+				return err
+			}
+		default:
+			// Release bundles contain only files and directories.
+			continue
+		}
+	}
+}
+
+// installSelfBinary copies the currently running executable into the
+// managed bin directory so future runs and MCP configs use a stable path.
+func installSelfBinary() error {
+	exe, err := os.Executable()
+	if err != nil {
+		return err
+	}
+	if resolved, err := filepath.EvalSymlinks(exe); err == nil {
+		exe = resolved
+	}
+	dest := installedBinaryPath()
+	if samePath(exe, dest) {
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+		return err
+	}
+	data, err := os.ReadFile(exe)
+	if err != nil {
+		return err
+	}
+	staging := dest + ".new"
+	if err := os.WriteFile(staging, data, 0o755); err != nil {
+		return err
+	}
+	// Windows cannot rename over an existing file; the destination is not
+	// the running executable here, so removing it first is safe.
+	if fileExists(dest) {
+		if err := os.Remove(dest); err != nil {
+			_ = os.Remove(staging)
+			return err
+		}
+	}
+	return os.Rename(staging, dest)
+}
+
+// updateInstalledBinaryFromBundle replaces the managed CLI binary with the
+// one shipped in the freshly applied bundle. The destination may be the
+// currently running executable: Windows allows renaming a running exe but
+// not deleting or overwriting it, so the old binary is parked at .old and
+// removed by cleanupStaleBinary on a later run.
+func updateInstalledBinaryFromBundle() error {
+	src := filepath.Join(managedInstallDir(), "bin", installedBinaryName())
+	data, err := os.ReadFile(src)
+	if err != nil {
+		return err
+	}
+	dest := installedBinaryPath()
+	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+		return err
+	}
+	staging := dest + ".new"
+	if err := os.WriteFile(staging, data, 0o755); err != nil {
+		return err
+	}
+	parked := dest + ".old"
+	_ = os.Remove(parked)
+	if fileExists(dest) {
+		if err := os.Rename(dest, parked); err != nil {
+			_ = os.Remove(staging)
+			return err
+		}
+	}
+	if err := os.Rename(staging, dest); err != nil {
+		if fileExists(parked) && !fileExists(dest) {
+			_ = os.Rename(parked, dest)
+		}
+		return err
+	}
+	if goos() != "windows" {
+		_ = os.Remove(parked)
+	}
+	return nil
+}
+
+// cleanupStaleBinary removes the parked previous binary left behind by a
+// Windows in-place update once it is no longer running. Removal fails
+// silently while the old process still holds the file; a later run wins.
+func cleanupStaleBinary() {
+	_ = os.Remove(installedBinaryPath() + ".old")
+}
+
+func samePath(a, b string) bool {
+	if resolvedA, err := filepath.EvalSymlinks(a); err == nil {
+		a = resolvedA
+	}
+	if resolvedB, err := filepath.EvalSymlinks(b); err == nil {
+		b = resolvedB
+	}
+	if runtime.GOOS == "windows" {
+		return strings.EqualFold(filepath.Clean(a), filepath.Clean(b))
+	}
+	return filepath.Clean(a) == filepath.Clean(b)
+}
+
+func bootstrapInstallState(version string) installState {
+	skillsMode := skillsModeManaged
+	if os.Getenv("NEWSJACK_INSTALL_SKILLS") == "0" {
+		skillsMode = skillsModeExternal
+	}
+	runtimesRaw := getenv("NEWSJACK_RUNTIMES", "auto")
+	return normalizeInstallState(installState{
+		Version:     version,
+		Commit:      readTrimmedFile(filepath.Join(managedInstallDir(), "COMMIT")),
+		Channel:     "stable",
+		Repo:        getenv("NEWSJACK_REPO", defaultRepo),
+		InstallURL:  getenv("NEWSJACK_INSTALL_URL", defaultInstallURL),
+		SkillsMode:  skillsMode,
+		Runtimes:    normalizeRuntimeList(runtimesRaw),
+		RuntimesRaw: runtimesRaw,
+		InstallMCP:  os.Getenv("NEWSJACK_INSTALL_MCP") != "0",
+		InstalledAt: time.Now().UTC().Format(time.RFC3339),
+	})
+}
+
+func writeInstallStateFile(state installState) error {
+	if err := os.MkdirAll(newsjackHome(), 0o755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(installStatePath(), append(data, '\n'), 0o644)
+}
+
+func readTrimmedFile(path string) string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
+}
+
+func fetchReleaseBytes(rawURL string) ([]byte, error) {
+	client := &http.Client{Timeout: 120 * time.Second}
+	resp, err := client.Get(rawURL)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("HTTP %d for %s", resp.StatusCode, rawURL)
+	}
+	return io.ReadAll(resp.Body)
+}

--- a/apps/cli/cmd/newsjack/bundle.go
+++ b/apps/cli/cmd/newsjack/bundle.go
@@ -57,9 +57,11 @@ func bootstrapInstall(runtimeSelection string, stdout, stderr io.Writer) error {
 // finalizeBootstrap is the post-bundle half of first install: managed
 // binary, install state, skills, MCP. Split out so an interrupted
 // bootstrap (bundle applied, rest missing) can be resumed without
-// re-downloading the release.
+// re-downloading the release. The managed binary comes from the verified
+// bundle, not the running exe: a stale downloaded binary must not become
+// the installed CLI while install.json records the bundle's version.
 func finalizeBootstrap(version, runtimeSelection string, stdout, stderr io.Writer) error {
-	if err := installSelfBinary(); err != nil {
+	if err := updateInstalledBinaryFromBundle(); err != nil {
 		return err
 	}
 	if err := writeInstallStateFile(bootstrapInstallState(version, runtimeSelection)); err != nil {
@@ -283,42 +285,6 @@ func untarGz(data []byte, dest string) error {
 			continue
 		}
 	}
-}
-
-// installSelfBinary copies the currently running executable into the
-// managed bin directory so future runs and MCP configs use a stable path.
-func installSelfBinary() error {
-	exe, err := os.Executable()
-	if err != nil {
-		return err
-	}
-	if resolved, err := filepath.EvalSymlinks(exe); err == nil {
-		exe = resolved
-	}
-	dest := installedBinaryPath()
-	if samePath(exe, dest) {
-		return nil
-	}
-	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
-		return err
-	}
-	data, err := os.ReadFile(exe)
-	if err != nil {
-		return err
-	}
-	staging := dest + ".new"
-	if err := os.WriteFile(staging, data, 0o755); err != nil {
-		return err
-	}
-	// Windows cannot rename over an existing file; the destination is not
-	// the running executable here, so removing it first is safe.
-	if fileExists(dest) {
-		if err := os.Remove(dest); err != nil {
-			_ = os.Remove(staging)
-			return err
-		}
-	}
-	return os.Rename(staging, dest)
 }
 
 // updateInstalledBinaryFromBundle replaces the managed CLI binary with the

--- a/apps/cli/cmd/newsjack/bundle_test.go
+++ b/apps/cli/cmd/newsjack/bundle_test.go
@@ -108,8 +108,14 @@ func TestBootstrapInstallFromBareBinary(t *testing.T) {
 		if got := readTrimmedFile(filepath.Join(install, "VERSION")); got != "v9.9.9-test" {
 			t.Fatalf("installed VERSION=%q, want v9.9.9-test", got)
 		}
-		if !fileExists(filepath.Join(home, ".newsjack", "bin", installedBinaryName())) {
-			t.Fatal("self binary was not installed into the managed bin dir")
+		managedBin, err := os.ReadFile(filepath.Join(home, ".newsjack", "bin", installedBinaryName()))
+		if err != nil {
+			t.Fatalf("managed binary was not installed: %v", err)
+		}
+		// The managed CLI must come from the verified bundle, not the
+		// (possibly stale) running exe, so it always matches install.json.
+		if string(managedBin) != "fake binary payload\n" {
+			t.Fatalf("managed binary content = %q, want the bundle binary", managedBin)
 		}
 		if fileExists(filepath.Join(install, ".env")) {
 			t.Fatal("bundle .env file should be stripped during unpack")

--- a/apps/cli/cmd/newsjack/bundle_test.go
+++ b/apps/cli/cmd/newsjack/bundle_test.go
@@ -1,0 +1,287 @@
+package main
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+func buildBundleTarGz(t *testing.T, files map[string]string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	names := make([]string, 0, len(files))
+	for name := range files {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		content := files[name]
+		header := &tar.Header{Name: "./" + name, Mode: 0o755, Size: int64(len(content)), Typeflag: tar.TypeReg}
+		if err := tw.WriteHeader(header); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tw.Write([]byte(content)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+func testBundleFiles(version string) map[string]string {
+	return map[string]string{
+		"skills/newsjack-detector/SKILL.md":      "# detector\n",
+		"skills/newsjack-monitor-setup/SKILL.md": "# monitor setup\n",
+		".newsjack-prebuilt":                     "1\n",
+		"VERSION":                                version + "\n",
+		"COMMIT":                                 "deadbeef\n",
+		"skills-manifest.json":                   "{}\n",
+		"bin/" + installedBinaryName():           "fake binary payload\n",
+		".env":                                   "SECRET=1\n",
+	}
+}
+
+func serveRelease(t *testing.T, payload []byte, version string) *httptest.Server {
+	t.Helper()
+	artifact := releaseArtifactName()
+	sum := sha256.Sum256(payload)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/checksums.txt", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprintf(w, "%s  %s\n", hex.EncodeToString(sum[:]), artifact)
+	})
+	mux.HandleFunc("/"+artifact, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(payload)
+	})
+	mux.HandleFunc("/manifest.json", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprintf(w, `{"version":%q}`, version)
+	})
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	return server
+}
+
+func bootstrapEnv(home, releaseBase string) map[string]string {
+	return map[string]string{
+		"HOME":                    home,
+		"NEWSJACK_HOME":           "",
+		"NEWSJACK_ROOT":           "",
+		"NEWSJACK_RELEASE_BASE":   releaseBase,
+		"NEWSJACK_RUNTIMES":       "claude",
+		"NEWSJACK_INSTALL_MCP":    "0",
+		"NEWSJACK_NO_AUTO_UPDATE": "1",
+		"NEWSJACK_IGNORE_DOTENV":  "1",
+		"PATH":                    os.TempDir(),
+	}
+}
+
+func TestBootstrapInstallFromBareBinary(t *testing.T) {
+	payload := buildBundleTarGz(t, testBundleFiles("v9.9.9-test"))
+	server := serveRelease(t, payload, "v9.9.9-test")
+	home := t.TempDir()
+
+	withTempEnv(t, bootstrapEnv(home, server.URL), func() {
+		var out, errBuf bytes.Buffer
+		if err := bootstrapInstall(&out, &errBuf); err != nil {
+			t.Fatalf("bootstrapInstall: %v\nstderr=%s", err, errBuf.String())
+		}
+
+		install := filepath.Join(home, ".newsjack", "newsjack")
+		if got := readTrimmedFile(filepath.Join(install, "VERSION")); got != "v9.9.9-test" {
+			t.Fatalf("installed VERSION=%q, want v9.9.9-test", got)
+		}
+		if !fileExists(filepath.Join(home, ".newsjack", "bin", installedBinaryName())) {
+			t.Fatal("self binary was not installed into the managed bin dir")
+		}
+		if fileExists(filepath.Join(install, ".env")) {
+			t.Fatal("bundle .env file should be stripped during unpack")
+		}
+		if !fileExists(filepath.Join(home, ".claude", "skills", "newsjack-detector", "SKILL.md")) {
+			t.Fatal("skills were not installed for the selected runtime")
+		}
+
+		data, err := os.ReadFile(filepath.Join(home, ".newsjack", "install.json"))
+		if err != nil {
+			t.Fatalf("install.json missing: %v", err)
+		}
+		var state installState
+		if err := json.Unmarshal(data, &state); err != nil {
+			t.Fatalf("install.json invalid: %s", data)
+		}
+		if state.Version != "v9.9.9-test" || state.Commit != "deadbeef" {
+			t.Fatalf("install state version/commit = %q/%q", state.Version, state.Commit)
+		}
+		if state.SkillsMode != skillsModeManaged || state.RuntimesRaw != "claude" {
+			t.Fatalf("install state mode/runtimes = %q/%q", state.SkillsMode, state.RuntimesRaw)
+		}
+
+		root, err := newsjackRoot()
+		if err != nil || root != install {
+			t.Fatalf("newsjackRoot() = %q, %v; want %q", root, err, install)
+		}
+	})
+}
+
+func TestApplyReleaseBundleChecksumMismatchLeavesInstallUntouched(t *testing.T) {
+	payload := buildBundleTarGz(t, testBundleFiles("v9.9.9-test"))
+	artifact := releaseArtifactName()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/checksums.txt", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprintf(w, "%s  %s\n", strings.Repeat("0", 64), artifact)
+	})
+	mux.HandleFunc("/"+artifact, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(payload)
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	home := t.TempDir()
+	withTempEnv(t, bootstrapEnv(home, server.URL), func() {
+		install := managedInstallDir()
+		sentinel := filepath.Join(install, "sentinel.txt")
+		if err := os.MkdirAll(install, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(sentinel, []byte("keep me"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		if _, err := applyReleaseBundle(server.URL, io.Discard); err == nil || !strings.Contains(err.Error(), "checksum mismatch") {
+			t.Fatalf("expected checksum mismatch error, got %v", err)
+		}
+		if !fileExists(sentinel) {
+			t.Fatal("existing install was modified after a failed download")
+		}
+		if dirExists(install + ".new") {
+			t.Fatal("failed apply left a staging directory behind")
+		}
+	})
+}
+
+func TestApplyReleaseBundleTruncatedArtifactFails(t *testing.T) {
+	payload := buildBundleTarGz(t, testBundleFiles("v9.9.9-test"))
+	artifact := releaseArtifactName()
+	sum := sha256.Sum256(payload)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/checksums.txt", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprintf(w, "%s  %s\n", hex.EncodeToString(sum[:]), artifact)
+	})
+	mux.HandleFunc("/"+artifact, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(payload[:len(payload)/2])
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	home := t.TempDir()
+	withTempEnv(t, bootstrapEnv(home, server.URL), func() {
+		if _, err := applyReleaseBundle(server.URL, io.Discard); err == nil || !strings.Contains(err.Error(), "checksum mismatch") {
+			t.Fatalf("truncated artifact should fail checksum verification, got %v", err)
+		}
+	})
+}
+
+func TestApplyReleaseBundleMissingPlatformArtifact(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/checksums.txt", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, strings.Repeat("0", 64)+"  newsjack_plan9_mips.tar.gz\n")
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	home := t.TempDir()
+	withTempEnv(t, bootstrapEnv(home, server.URL), func() {
+		_, err := applyReleaseBundle(server.URL, io.Discard)
+		if err == nil || !strings.Contains(err.Error(), releaseArtifactName()) {
+			t.Fatalf("missing platform artifact should name the artifact, got %v", err)
+		}
+	})
+}
+
+func TestApplyReleaseBundleRerunKeepsPreviousInstall(t *testing.T) {
+	payload := buildBundleTarGz(t, testBundleFiles("v9.9.9-test"))
+	server := serveRelease(t, payload, "v9.9.9-test")
+	home := t.TempDir()
+
+	withTempEnv(t, bootstrapEnv(home, server.URL), func() {
+		if _, err := applyReleaseBundle(server.URL, io.Discard); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := applyReleaseBundle(server.URL, io.Discard); err != nil {
+			t.Fatal(err)
+		}
+		if !dirExists(managedInstallDir() + ".previous") {
+			t.Fatal("re-apply should keep the previous install for rollback")
+		}
+		if got := readTrimmedFile(filepath.Join(managedInstallDir(), "VERSION")); got != "v9.9.9-test" {
+			t.Fatalf("VERSION=%q after re-apply", got)
+		}
+	})
+}
+
+func TestSetupJSONBootstrapsWhenRootMissing(t *testing.T) {
+	payload := buildBundleTarGz(t, testBundleFiles("v9.9.9-test"))
+	server := serveRelease(t, payload, "v9.9.9-test")
+	home := t.TempDir()
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(cwd); err != nil {
+			t.Fatal(err)
+		}
+	})
+	// Leave the repo so newsjackRoot cannot fall back to the source checkout.
+	if err := os.Chdir(t.TempDir()); err != nil {
+		t.Fatal(err)
+	}
+
+	withTempEnv(t, bootstrapEnv(home, server.URL), func() {
+		var out, errBuf bytes.Buffer
+		code := runCLI([]string{"setup", "--json"}, &out, &errBuf)
+		if code != 0 {
+			t.Fatalf("setup --json code=%d stderr=%s", code, errBuf.String())
+		}
+		var payload map[string]any
+		if json.Unmarshal(out.Bytes(), &payload) != nil {
+			t.Fatalf("setup --json should still emit valid JSON after bootstrap:\n%s", out.String())
+		}
+		root, err := newsjackRoot()
+		if err != nil {
+			t.Fatalf("root missing after setup bootstrap: %v", err)
+		}
+		if root != filepath.Join(home, ".newsjack", "newsjack") {
+			t.Fatalf("root=%q after bootstrap", root)
+		}
+	})
+}
+
+func TestUntarGzRejectsPathTraversal(t *testing.T) {
+	payload := buildBundleTarGz(t, map[string]string{"../evil.txt": "nope"})
+	dest := filepath.Join(t.TempDir(), "out")
+	if err := untarGz(payload, dest); err == nil || !strings.Contains(err.Error(), "unsafe path") {
+		t.Fatalf("expected unsafe path error, got %v", err)
+	}
+	if fileExists(filepath.Join(filepath.Dir(dest), "evil.txt")) {
+		t.Fatal("traversal entry escaped the destination directory")
+	}
+}

--- a/apps/cli/cmd/newsjack/bundle_test.go
+++ b/apps/cli/cmd/newsjack/bundle_test.go
@@ -100,7 +100,7 @@ func TestBootstrapInstallFromBareBinary(t *testing.T) {
 
 	withTempEnv(t, bootstrapEnv(home, server.URL), func() {
 		var out, errBuf bytes.Buffer
-		if err := bootstrapInstall(&out, &errBuf); err != nil {
+		if err := bootstrapInstall("", &out, &errBuf); err != nil {
 			t.Fatalf("bootstrapInstall: %v\nstderr=%s", err, errBuf.String())
 		}
 
@@ -271,6 +271,54 @@ func TestSetupJSONBootstrapsWhenRootMissing(t *testing.T) {
 		}
 		if root != filepath.Join(home, ".newsjack", "newsjack") {
 			t.Fatalf("root=%q after bootstrap", root)
+		}
+	})
+}
+
+func TestEnsureInstalledRootFinishesInterruptedBootstrap(t *testing.T) {
+	payload := buildBundleTarGz(t, testBundleFiles("v9.9.9-test"))
+	server := serveRelease(t, payload, "v9.9.9-test")
+	home := t.TempDir()
+
+	withTempEnv(t, bootstrapEnv(home, server.URL), func() {
+		// Simulate a bootstrap that died after the bundle swap: the managed
+		// root exists, but the binary and install state were never written.
+		if _, err := applyReleaseBundle(server.URL, io.Discard); err != nil {
+			t.Fatal(err)
+		}
+		if fileExists(installedBinaryPath()) || fileExists(installStatePath()) {
+			t.Fatal("precondition: interrupted install should have no binary or state")
+		}
+
+		var out, errBuf bytes.Buffer
+		if err := ensureInstalledRoot("", &out, &errBuf); err != nil {
+			t.Fatalf("ensureInstalledRoot: %v\nstderr=%s", err, errBuf.String())
+		}
+		if !fileExists(installedBinaryPath()) {
+			t.Fatal("repair should install the managed binary")
+		}
+		var state installState
+		data, err := os.ReadFile(installStatePath())
+		if err != nil {
+			t.Fatalf("repair should write install state: %v", err)
+		}
+		if err := json.Unmarshal(data, &state); err != nil {
+			t.Fatal(err)
+		}
+		if state.Version != "v9.9.9-test" {
+			t.Fatalf("repaired state version = %q", state.Version)
+		}
+		if !fileExists(filepath.Join(home, ".claude", "skills", "newsjack-detector", "SKILL.md")) {
+			t.Fatal("repair should install runtime skills")
+		}
+
+		// A second call must be a no-op, not another repair.
+		errBuf.Reset()
+		if err := ensureInstalledRoot("", &out, &errBuf); err != nil {
+			t.Fatal(err)
+		}
+		if strings.Contains(errBuf.String(), "interrupted") {
+			t.Fatalf("completed install should not re-trigger repair:\n%s", errBuf.String())
 		}
 	})
 }

--- a/apps/cli/cmd/newsjack/distribution.go
+++ b/apps/cli/cmd/newsjack/distribution.go
@@ -27,7 +27,7 @@ func newsjackCLIInvocation() commandInvocation {
 	if npmDistribution() {
 		return commandInvocation{Command: "newsjack"}
 	}
-	return commandInvocation{Command: filepath.Join(newsjackHome(), "bin", "newsjack")}
+	return commandInvocation{Command: installedBinaryPath()}
 }
 
 func (inv commandInvocation) With(args ...string) []string {

--- a/apps/cli/cmd/newsjack/doctor.go
+++ b/apps/cli/cmd/newsjack/doctor.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"os/exec"
-	"path/filepath"
 )
 
 func commandAvailable(name string) bool {
@@ -38,7 +37,7 @@ func cmdDoctor(args []string, stdout, stderr io.Writer) int {
 		"install": map[string]any{
 			"distribution":   distributionName(),
 			"cli_command":    cli.CommandLine(),
-			"cli_installed":  npmDistribution() || fileExists(filepath.Join(newsjackHome(), "bin", "newsjack")),
+			"cli_installed":  npmDistribution() || fileExists(installedBinaryPath()),
 			"cli_version":    version,
 			"bundle_version": installedVersion(),
 			"skills_mode":    state.SkillsMode,
@@ -52,8 +51,9 @@ func cmdDoctor(args []string, stdout, stderr io.Writer) int {
 			"source":               nullableString(source),
 			"x_api_configured":     xConfigured,
 		},
-		"dependencies": map[string]any{
-			"npx": commandAvailable("npx"),
+		"mcp_bridge": map[string]any{
+			"transport": "native",
+			"endpoint":  medialystMCPEndpoint(),
 		},
 		"sources": map[string]any{
 			"news_search": contains(available, "news_search"),
@@ -196,6 +196,9 @@ func doctorActions(rootErr error, medialystConfigured, xConfigured bool) []map[s
 func reinstallCommand() string {
 	if npmDistribution() {
 		return "npm i -g newsjack"
+	}
+	if goos() == "windows" {
+		return "newsjack setup"
 	}
 	return "curl -fsSL https://newsjack.sh | bash"
 }

--- a/apps/cli/cmd/newsjack/main.go
+++ b/apps/cli/cmd/newsjack/main.go
@@ -21,6 +21,7 @@ func runCLIWithIO(args []string, stdin io.Reader, stdout, stderr io.Writer) int 
 	if len(args) > 0 {
 		cmd = args[0]
 	}
+	cleanupStaleBinary()
 	if code, handled := maybeAutoUpdate(args, stderr); handled {
 		return code
 	}

--- a/apps/cli/cmd/newsjack/mcp.go
+++ b/apps/cli/cmd/newsjack/mcp.go
@@ -158,7 +158,8 @@ func cmdMCPStatus(_ []string, stdout, _ io.Writer) int {
 	cli := newsjackCLIInvocation()
 	payload := map[string]any{
 		"bridge_command": cli.CommandLine("mcp-bridge"),
-		"npx_available":  commandAvailable("npx"),
+		"transport":      "native",
+		"endpoint":       medialystMCPEndpoint(),
 	}
 	writeJSON(stdout, payload)
 	return 0

--- a/apps/cli/cmd/newsjack/mcp_bridge.go
+++ b/apps/cli/cmd/newsjack/mcp_bridge.go
@@ -60,39 +60,28 @@ func newMCPBridge(endpoint, key string, stdout, stderr io.Writer) *mcpBridge {
 	}
 }
 
+// run processes messages strictly in order: a piped handshake must not let
+// tools/list reach the server before the initialize response has populated
+// the session and protocol headers, and a fatal condition (rejected key)
+// must end the process promptly instead of blocking on stdin.
 func (b *mcpBridge) run(stdin io.Reader) int {
 	scanner := bufio.NewScanner(stdin)
 	scanner.Buffer(make([]byte, 64*1024), mcpBridgeMaxMessageBytes)
-	fatal := make(chan int, 1)
-	var wg sync.WaitGroup
 	for scanner.Scan() {
 		line := bytes.TrimSpace(scanner.Bytes())
 		if len(line) == 0 {
 			continue
 		}
 		msg := append([]byte(nil), line...)
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			if code := b.forward(msg); code != 0 {
-				select {
-				case fatal <- code:
-				default:
-				}
-			}
-		}()
+		if code := b.forward(msg); code != 0 {
+			return code
+		}
 	}
-	wg.Wait()
 	if err := scanner.Err(); err != nil {
 		fmt.Fprintf(b.stderr, "newsjack mcp-bridge: stdin: %v\n", err)
 		return 1
 	}
-	select {
-	case code := <-fatal:
-		return code
-	default:
-		return 0
-	}
+	return 0
 }
 
 // forward sends one client JSON-RPC message upstream and relays every

--- a/apps/cli/cmd/newsjack/mcp_bridge.go
+++ b/apps/cli/cmd/newsjack/mcp_bridge.go
@@ -1,44 +1,267 @@
 package main
 
 import (
+	"bufio"
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
-	"os/exec"
 	"strings"
-	"syscall"
+	"sync"
+	"time"
 )
 
-func cmdMCPBridge(_ []string, _ io.Writer, stderr io.Writer) int {
+// mcpBridgeMaxMessageBytes bounds a single stdio JSON-RPC message.
+const mcpBridgeMaxMessageBytes = 16 << 20
+
+func medialystMCPEndpoint() string {
+	return getenv("NEWSJACK_MEDIALYST_MCP_URL", medialystMCPURL)
+}
+
+func cmdMCPBridge(_ []string, stdout io.Writer, stderr io.Writer) int {
 	key, source := loadAPIKey()
 	if key == "" {
 		fmt.Fprintf(stderr, "Medialyst API key not found. Run: %s\n", newsjackCLIInvocation().Display("login"))
 		return 1
 	}
-	npx, err := exec.LookPath("npx")
-	if err != nil {
-		fmt.Fprintln(stderr, "npx is required for the Medialyst MCP stdio bridge. Install Node.js, then retry.")
-		return 1
-	}
 	if os.Getenv("NEWSJACK_AUTH_DEBUG") != "" {
 		fmt.Fprintf(stderr, "Loaded Medialyst API key from %s\n", source)
 	}
-	env := os.Environ()
-	env = setEnv(env, envMedialystKey, key)
-	args := []string{npx, "-y", "mcp-remote", medialystMCPURL, "--header", "Authorization: Bearer ${" + envMedialystKey + "}"}
-	if err := syscall.Exec(npx, args, env); err != nil {
-		return fail(stderr, err)
-	}
-	return 127
+	bridge := newMCPBridge(medialystMCPEndpoint(), key, stdout, stderr)
+	return bridge.run(os.Stdin)
 }
 
-func setEnv(env []string, key, value string) []string {
-	prefix := key + "="
-	for i, item := range env {
-		if strings.HasPrefix(item, prefix) {
-			env[i] = prefix + value
-			return env
+// mcpBridge proxies MCP stdio (newline-delimited JSON-RPC) from a local
+// agent harness to the remote Medialyst streamable-HTTP MCP endpoint. The
+// bearer token is attached per request so the key never lands in harness
+// config files, and no external runtime (Node/npx) is required.
+type mcpBridge struct {
+	endpoint string
+	key      string
+	client   *http.Client
+	stdout   io.Writer
+	stderr   io.Writer
+
+	writeMu  sync.Mutex
+	stateMu  sync.Mutex
+	session  string
+	protocol string
+}
+
+func newMCPBridge(endpoint, key string, stdout, stderr io.Writer) *mcpBridge {
+	return &mcpBridge{
+		endpoint: endpoint,
+		key:      key,
+		client:   &http.Client{Timeout: 5 * time.Minute},
+		stdout:   stdout,
+		stderr:   stderr,
+	}
+}
+
+func (b *mcpBridge) run(stdin io.Reader) int {
+	scanner := bufio.NewScanner(stdin)
+	scanner.Buffer(make([]byte, 64*1024), mcpBridgeMaxMessageBytes)
+	fatal := make(chan int, 1)
+	var wg sync.WaitGroup
+	for scanner.Scan() {
+		line := bytes.TrimSpace(scanner.Bytes())
+		if len(line) == 0 {
+			continue
+		}
+		msg := append([]byte(nil), line...)
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if code := b.forward(msg); code != 0 {
+				select {
+				case fatal <- code:
+				default:
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	if err := scanner.Err(); err != nil {
+		fmt.Fprintf(b.stderr, "newsjack mcp-bridge: stdin: %v\n", err)
+		return 1
+	}
+	select {
+	case code := <-fatal:
+		return code
+	default:
+		return 0
+	}
+}
+
+// forward sends one client JSON-RPC message upstream and relays every
+// resulting server message to stdout. A nonzero return marks a fatal
+// bridge condition (for example rejected credentials), not a normal
+// JSON-RPC level error.
+func (b *mcpBridge) forward(msg []byte) int {
+	req, err := http.NewRequest(http.MethodPost, b.endpoint, bytes.NewReader(msg))
+	if err != nil {
+		fmt.Fprintf(b.stderr, "newsjack mcp-bridge: %v\n", err)
+		return 1
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	req.Header.Set("Authorization", "Bearer "+b.key)
+	if session := b.sessionID(); session != "" {
+		req.Header.Set("Mcp-Session-Id", session)
+	}
+	if protocol := b.protocolVersion(); protocol != "" {
+		req.Header.Set("MCP-Protocol-Version", protocol)
+	}
+
+	resp, err := b.client.Do(req)
+	if err != nil {
+		fmt.Fprintf(b.stderr, "newsjack mcp-bridge: Medialyst MCP request failed: %v\n", err)
+		b.writeErrorResponse(msg, "Medialyst MCP request failed; check network connectivity")
+		return 0
+	}
+	defer resp.Body.Close()
+
+	if session := resp.Header.Get("Mcp-Session-Id"); session != "" {
+		b.setSessionID(session)
+	}
+
+	switch {
+	case resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden:
+		fmt.Fprintf(b.stderr, "Medialyst rejected the API key (HTTP %d). Run: %s\n", resp.StatusCode, newsjackCLIInvocation().Display("login"))
+		b.writeErrorResponse(msg, "Medialyst authentication failed; run: newsjack login")
+		return 1
+	case resp.StatusCode == http.StatusAccepted || resp.StatusCode == http.StatusNoContent:
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return 0
+	case resp.StatusCode < 200 || resp.StatusCode > 299:
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		fmt.Fprintf(b.stderr, "newsjack mcp-bridge: HTTP %d from Medialyst MCP: %s\n", resp.StatusCode, strings.TrimSpace(string(body)))
+		b.writeErrorResponse(msg, fmt.Sprintf("Medialyst MCP returned HTTP %d", resp.StatusCode))
+		return 0
+	}
+
+	if strings.HasPrefix(resp.Header.Get("Content-Type"), "text/event-stream") {
+		b.relaySSE(resp.Body)
+		return 0
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, mcpBridgeMaxMessageBytes))
+	if err != nil {
+		fmt.Fprintf(b.stderr, "newsjack mcp-bridge: reading Medialyst response: %v\n", err)
+		b.writeErrorResponse(msg, "Medialyst MCP response could not be read")
+		return 0
+	}
+	b.relayMessage(body)
+	return 0
+}
+
+// relaySSE forwards each data event of a text/event-stream response.
+func (b *mcpBridge) relaySSE(body io.Reader) {
+	reader := bufio.NewReaderSize(body, 64*1024)
+	var data []string
+	flush := func() {
+		if len(data) == 0 {
+			return
+		}
+		b.relayMessage([]byte(strings.Join(data, "\n")))
+		data = data[:0]
+	}
+	for {
+		line, err := reader.ReadString('\n')
+		line = strings.TrimRight(line, "\r\n")
+		switch {
+		case line == "":
+			flush()
+		case strings.HasPrefix(line, "data:"):
+			data = append(data, strings.TrimPrefix(strings.TrimPrefix(line, "data:"), " "))
+		}
+		if err != nil {
+			flush()
+			return
 		}
 	}
-	return append(env, prefix+value)
+}
+
+// relayMessage writes one upstream JSON-RPC payload to stdout in
+// newline-delimited form, compacting so embedded newlines cannot break
+// the stdio framing.
+func (b *mcpBridge) relayMessage(raw []byte) {
+	raw = bytes.TrimSpace(raw)
+	if len(raw) == 0 {
+		return
+	}
+	var compact bytes.Buffer
+	if err := json.Compact(&compact, raw); err != nil {
+		fmt.Fprintf(b.stderr, "newsjack mcp-bridge: dropping non-JSON upstream payload: %v\n", err)
+		return
+	}
+	b.captureProtocolVersion(compact.Bytes())
+	b.writeMu.Lock()
+	defer b.writeMu.Unlock()
+	_, _ = b.stdout.Write(append(compact.Bytes(), '\n'))
+}
+
+// writeErrorResponse answers a client request locally so the harness does
+// not hang waiting on an upstream reply that will never come.
+// Notifications (no id) get no response per JSON-RPC.
+func (b *mcpBridge) writeErrorResponse(request []byte, message string) {
+	var envelope struct {
+		ID json.RawMessage `json:"id"`
+	}
+	if json.Unmarshal(request, &envelope) != nil || len(envelope.ID) == 0 || string(envelope.ID) == "null" {
+		return
+	}
+	payload := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      json.RawMessage(envelope.ID),
+		"error":   map[string]any{"code": -32603, "message": message},
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return
+	}
+	b.writeMu.Lock()
+	defer b.writeMu.Unlock()
+	_, _ = b.stdout.Write(append(data, '\n'))
+}
+
+// captureProtocolVersion remembers the negotiated MCP protocol version
+// from the initialize result so later HTTP requests can advertise it.
+func (b *mcpBridge) captureProtocolVersion(message []byte) {
+	if b.protocolVersion() != "" || !bytes.Contains(message, []byte("protocolVersion")) {
+		return
+	}
+	var envelope struct {
+		Result struct {
+			ProtocolVersion string `json:"protocolVersion"`
+		} `json:"result"`
+	}
+	if json.Unmarshal(message, &envelope) == nil && envelope.Result.ProtocolVersion != "" {
+		b.setProtocolVersion(envelope.Result.ProtocolVersion)
+	}
+}
+
+func (b *mcpBridge) sessionID() string {
+	b.stateMu.Lock()
+	defer b.stateMu.Unlock()
+	return b.session
+}
+
+func (b *mcpBridge) setSessionID(session string) {
+	b.stateMu.Lock()
+	defer b.stateMu.Unlock()
+	b.session = session
+}
+
+func (b *mcpBridge) protocolVersion() string {
+	b.stateMu.Lock()
+	defer b.stateMu.Unlock()
+	return b.protocol
+}
+
+func (b *mcpBridge) setProtocolVersion(protocol string) {
+	b.stateMu.Lock()
+	defer b.stateMu.Unlock()
+	b.protocol = protocol
 }

--- a/apps/cli/cmd/newsjack/mcp_bridge_test.go
+++ b/apps/cli/cmd/newsjack/mcp_bridge_test.go
@@ -1,0 +1,270 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+type bridgeRequestLog struct {
+	mu       sync.Mutex
+	auth     []string
+	sessions []string
+}
+
+func (l *bridgeRequestLog) record(r *http.Request) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.auth = append(l.auth, r.Header.Get("Authorization"))
+	l.sessions = append(l.sessions, r.Header.Get("Mcp-Session-Id"))
+}
+
+func newMockMCPServer(t *testing.T, log *bridgeRequestLog) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		log.record(r)
+		if r.Header.Get("Authorization") != "Bearer mlst_test_key" {
+			w.WriteHeader(http.StatusUnauthorized)
+			fmt.Fprint(w, `{"error":"bad token"}`)
+			return
+		}
+		body, err := json.RawMessage(nil), error(nil)
+		raw := make([]byte, 0, 1024)
+		buf := bytes.NewBuffer(raw)
+		if _, err = buf.ReadFrom(r.Body); err != nil {
+			t.Errorf("mock server read: %v", err)
+		}
+		body = buf.Bytes()
+		var envelope struct {
+			ID     json.RawMessage `json:"id"`
+			Method string          `json:"method"`
+		}
+		if err := json.Unmarshal(body, &envelope); err != nil {
+			t.Errorf("mock server got non-JSON body: %s", body)
+		}
+		switch envelope.Method {
+		case "initialize":
+			w.Header().Set("Mcp-Session-Id", "session-123")
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintf(w, `{
+				"jsonrpc": "2.0",
+				"id": %s,
+				"result": {"protocolVersion": "2025-03-26", "capabilities": {}, "serverInfo": {"name": "mock-medialyst"}}
+			}`, envelope.ID)
+		case "notifications/initialized":
+			w.WriteHeader(http.StatusAccepted)
+		case "tools/list":
+			w.Header().Set("Content-Type", "text/event-stream")
+			fmt.Fprintf(w, "event: message\ndata: {\"jsonrpc\":\"2.0\",\"id\":%s,\"result\":{\"tools\":[{\"name\":\"mock_search\"}]}}\n\n", envelope.ID)
+		default:
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintf(w, `{"jsonrpc":"2.0","id":%s,"result":{}}`, envelope.ID)
+		}
+	}))
+}
+
+func runBridge(t *testing.T, endpoint, key, input string) (int, string, string) {
+	t.Helper()
+	var out, errBuf bytes.Buffer
+	bridge := newMCPBridge(endpoint, key, &out, &errBuf)
+	code := bridge.run(strings.NewReader(input))
+	return code, out.String(), errBuf.String()
+}
+
+func bridgeResponseByID(t *testing.T, stdout string, id int) map[string]any {
+	t.Helper()
+	for _, line := range strings.Split(strings.TrimSpace(stdout), "\n") {
+		if line == "" {
+			continue
+		}
+		var msg map[string]any
+		if err := json.Unmarshal([]byte(line), &msg); err != nil {
+			t.Fatalf("bridge stdout line is not JSON: %q", line)
+		}
+		if got, ok := msg["id"].(float64); ok && int(got) == id {
+			return msg
+		}
+	}
+	t.Fatalf("no response with id=%d in bridge stdout:\n%s", id, stdout)
+	return nil
+}
+
+func TestMCPBridgeInitializeAndToolListRoundTrip(t *testing.T) {
+	log := &bridgeRequestLog{}
+	server := newMockMCPServer(t, log)
+	defer server.Close()
+
+	// Sequential messages mirror the MCP handshake order; the harness waits
+	// for each response before sending the next message.
+	input := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26"}}` + "\n"
+	code, stdout, stderr := runBridge(t, server.URL, "mlst_test_key", input)
+	if code != 0 {
+		t.Fatalf("bridge exit=%d stderr=%s", code, stderr)
+	}
+	initResp := bridgeResponseByID(t, stdout, 1)
+	result, _ := initResp["result"].(map[string]any)
+	if result == nil || result["protocolVersion"] != "2025-03-26" {
+		t.Fatalf("initialize result missing protocol version: %s", stdout)
+	}
+
+	input = `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26"}}` + "\n" +
+		`{"jsonrpc":"2.0","method":"notifications/initialized"}` + "\n" +
+		`{"jsonrpc":"2.0","id":2,"method":"tools/list"}` + "\n"
+	code, stdout, stderr = runBridge(t, server.URL, "mlst_test_key", input)
+	if code != 0 {
+		t.Fatalf("bridge exit=%d stderr=%s", code, stderr)
+	}
+	toolsResp := bridgeResponseByID(t, stdout, 2)
+	if !strings.Contains(stdout, "mock_search") {
+		t.Fatalf("SSE tool response not relayed: %s", stdout)
+	}
+	if toolsResp["error"] != nil {
+		t.Fatalf("tools/list relayed an error: %s", stdout)
+	}
+
+	log.mu.Lock()
+	defer log.mu.Unlock()
+	if len(log.auth) == 0 {
+		t.Fatal("mock server saw no requests")
+	}
+	for i, auth := range log.auth {
+		if auth != "Bearer mlst_test_key" {
+			t.Fatalf("request %d missing bearer auth: %q", i, auth)
+		}
+	}
+}
+
+func TestMCPBridgeRejectedKeyFailsWithLoginHint(t *testing.T) {
+	log := &bridgeRequestLog{}
+	server := newMockMCPServer(t, log)
+	defer server.Close()
+
+	input := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}` + "\n"
+	code, stdout, stderr := runBridge(t, server.URL, "mlst_wrong_key", input)
+	if code == 0 {
+		t.Fatalf("bridge should exit nonzero on rejected key, stdout=%s", stdout)
+	}
+	if !strings.Contains(stderr, "login") {
+		t.Fatalf("stderr should include the re-auth hint:\n%s", stderr)
+	}
+	resp := bridgeResponseByID(t, stdout, 1)
+	if resp["error"] == nil {
+		t.Fatalf("client should receive a JSON-RPC error instead of hanging: %s", stdout)
+	}
+}
+
+func TestMCPBridgeServerErrorAnswersClientWithoutHanging(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	defer server.Close()
+
+	input := `{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{}}` + "\n"
+	code, stdout, stderr := runBridge(t, server.URL, "mlst_test_key", input)
+	if code != 0 {
+		t.Fatalf("HTTP 502 should not be fatal, exit=%d stderr=%s", code, stderr)
+	}
+	resp := bridgeResponseByID(t, stdout, 7)
+	errPayload, _ := resp["error"].(map[string]any)
+	if errPayload == nil || !strings.Contains(stringValue(errPayload["message"]), "502") {
+		t.Fatalf("client should see the upstream status: %s", stdout)
+	}
+}
+
+func TestMCPBridgeUnreachableServerAnswersClient(t *testing.T) {
+	input := `{"jsonrpc":"2.0","id":3,"method":"initialize","params":{}}` + "\n"
+	code, stdout, stderr := runBridge(t, "http://127.0.0.1:1", "mlst_test_key", input)
+	if code != 0 {
+		t.Fatalf("connection failure should not crash the bridge loop, exit=%d", code)
+	}
+	if !strings.Contains(stderr, "request failed") {
+		t.Fatalf("stderr should describe the connection failure:\n%s", stderr)
+	}
+	resp := bridgeResponseByID(t, stdout, 3)
+	if resp["error"] == nil {
+		t.Fatalf("client should receive a JSON-RPC error: %s", stdout)
+	}
+}
+
+func TestMCPBridgeSessionHeaderPropagates(t *testing.T) {
+	log := &bridgeRequestLog{}
+	server := newMockMCPServer(t, log)
+	defer server.Close()
+
+	input := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}` + "\n"
+	if code, _, stderr := runBridge(t, server.URL, "mlst_test_key", input); code != 0 {
+		t.Fatalf("bridge exit=%d stderr=%s", code, stderr)
+	}
+
+	var out, errBuf bytes.Buffer
+	bridge := newMCPBridge(server.URL, "mlst_test_key", &out, &errBuf)
+	if code := bridge.run(strings.NewReader(input)); code != 0 {
+		t.Fatalf("bridge exit=%d stderr=%s", code, errBuf.String())
+	}
+	if code := bridge.run(strings.NewReader(`{"jsonrpc":"2.0","id":2,"method":"tools/list"}` + "\n")); code != 0 {
+		t.Fatalf("bridge exit=%d stderr=%s", code, errBuf.String())
+	}
+
+	log.mu.Lock()
+	defer log.mu.Unlock()
+	last := log.sessions[len(log.sessions)-1]
+	if last != "session-123" {
+		t.Fatalf("follow-up request should carry the negotiated session id, got %q (all: %v)", last, log.sessions)
+	}
+}
+
+func TestCmdMCPBridgeLoadsKeyFromCredentialsFile(t *testing.T) {
+	log := &bridgeRequestLog{}
+	server := newMockMCPServer(t, log)
+	defer server.Close()
+
+	home := t.TempDir()
+	credentials := filepath.Join(home, ".newsjack", "credentials.json")
+	if err := os.MkdirAll(filepath.Dir(credentials), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(credentials, []byte(`{"medialyst":{"api_key":"mlst_test_key"}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	withTempEnv(t, map[string]string{
+		"HOME":                       home,
+		"NEWSJACK_HOME":              "",
+		"NEWSJACK_IGNORE_DOTENV":     "1",
+		"MEDIALYST_API_KEY":          "",
+		"NEWSJACK_MEDIALYST_MCP_URL": server.URL,
+	}, func() {
+		key, source := loadAPIKey()
+		if key != "mlst_test_key" || !strings.HasPrefix(source, "credentials:") {
+			t.Fatalf("key/source = %q/%q, want credentials file", key, source)
+		}
+		if medialystMCPEndpoint() != server.URL {
+			t.Fatalf("endpoint override not applied: %s", medialystMCPEndpoint())
+		}
+	})
+}
+
+func TestCmdMCPBridgeWithoutKeyPrintsLoginHint(t *testing.T) {
+	home := t.TempDir()
+	withTempEnv(t, map[string]string{
+		"HOME":                   home,
+		"NEWSJACK_HOME":          "",
+		"NEWSJACK_IGNORE_DOTENV": "1",
+		"MEDIALYST_API_KEY":      "",
+	}, func() {
+		var out, errBuf bytes.Buffer
+		if code := cmdMCPBridge(nil, &out, &errBuf); code != 1 {
+			t.Fatalf("missing key should exit 1, got %d", code)
+		}
+		if !strings.Contains(errBuf.String(), "login") {
+			t.Fatalf("stderr should point at login:\n%s", errBuf.String())
+		}
+	})
+}

--- a/apps/cli/cmd/newsjack/monitor.go
+++ b/apps/cli/cmd/newsjack/monitor.go
@@ -18,6 +18,7 @@ import (
 )
 
 const defaultClaudeInstallCommand = "curl -fsSL https://claude.ai/install.sh | bash"
+const defaultClaudeInstallCommandWindows = "irm https://claude.ai/install.ps1 | iex"
 const xAPIKeyURL = "https://docs.x.com/fundamentals/authentication/oauth-2-0/bearer-tokens"
 const medialystAPIKeyURL = "https://medialyst.ai/agents"
 
@@ -34,6 +35,15 @@ func cmdSetup(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	skipCredentials := fs.Bool("skip-credentials", false, "Do not prompt for optional API keys")
 	if err := fs.Parse(args); err != nil {
 		return 2
+	}
+	// In --json mode bootstrap progress goes to stderr so stdout stays
+	// valid JSON, mirroring the auto-update contract.
+	bootstrapOut := stdout
+	if *jsonOut {
+		bootstrapOut = stderr
+	}
+	if err := ensureInstalledRoot(bootstrapOut, stderr); err != nil {
+		return fail(stderr, err)
 	}
 	status := setupPayload(*runtimeRaw)
 	if *jsonOut {
@@ -862,7 +872,7 @@ func (w *setupWizard) ensureRuntimeInstalled(key, purpose string) (bool, error) 
 	}
 	fmt.Fprintln(w.stdout)
 	uiInfo(w.stdout, "Installing %s...", label)
-	cmd := exec.Command("bash", "-c", command)
+	cmd := shellCommand(command)
 	cmd.Stdin = w.stdin
 	cmd.Stdout = w.stdout
 	cmd.Stderr = w.stderr
@@ -895,6 +905,15 @@ func runtimeTargetForKey(key string) (runtimeTarget, bool) {
 	return runtimeTarget{}, false
 }
 
+// shellCommand wraps a runtime install command in the platform shell:
+// bash on Unix, PowerShell on Windows.
+func shellCommand(command string) *exec.Cmd {
+	if goos() == "windows" {
+		return exec.Command("powershell", "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", command)
+	}
+	return exec.Command("bash", "-c", command)
+}
+
 func runtimeInstallCommand(key string) string {
 	if cmd := strings.TrimSpace(os.Getenv(runtimeInstallCommandEnv(key))); cmd != "" {
 		return cmd
@@ -903,6 +922,9 @@ func runtimeInstallCommand(key string) string {
 	case "codex":
 		return "npm install -g @openai/codex"
 	case "claude":
+		if goos() == "windows" {
+			return defaultClaudeInstallCommandWindows
+		}
 		return defaultClaudeInstallCommand
 	case "openclaw":
 		return "npm install -g openclaw"

--- a/apps/cli/cmd/newsjack/monitor.go
+++ b/apps/cli/cmd/newsjack/monitor.go
@@ -42,7 +42,7 @@ func cmdSetup(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	if *jsonOut {
 		bootstrapOut = stderr
 	}
-	if err := ensureInstalledRoot(bootstrapOut, stderr); err != nil {
+	if err := ensureInstalledRoot(*runtimeRaw, bootstrapOut, stderr); err != nil {
 		return fail(stderr, err)
 	}
 	status := setupPayload(*runtimeRaw)

--- a/apps/cli/cmd/newsjack/monitor_test.go
+++ b/apps/cli/cmd/newsjack/monitor_test.go
@@ -306,10 +306,7 @@ func TestSetupRecommendsHighestPriorityDetectedHarness(t *testing.T) {
 	home := t.TempDir()
 	fakeBin := t.TempDir()
 	for _, name := range []string{"codex", "claude", "openclaw", "hermes"} {
-		path := filepath.Join(fakeBin, name)
-		if err := os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
-			t.Fatal(err)
-		}
+		writeFakeTool(t, fakeBin, name)
 	}
 	withTempEnv(t, map[string]string{
 		"HOME":                    home,
@@ -341,6 +338,7 @@ func TestSetupRecommendsHighestPriorityDetectedHarness(t *testing.T) {
 }
 
 func TestSetupInstallsClaudeCodeAfterConfirmation(t *testing.T) {
+	requirePOSIXShell(t)
 	repo := repoRootForTest(t)
 	home := t.TempDir()
 	fakeBin := t.TempDir()
@@ -433,17 +431,14 @@ func TestSetupPreservesSeparateRuntimeFlags(t *testing.T) {
 	repo := repoRootForTest(t)
 	home := t.TempDir()
 	fakeBin := t.TempDir()
-	hermesPath := filepath.Join(fakeBin, "hermes")
-	if err := os.WriteFile(hermesPath, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
-		t.Fatal(err)
-	}
+	writeFakeTool(t, fakeBin, "hermes")
 	withTempEnv(t, map[string]string{
 		"HOME":                    home,
 		"NEWSJACK_HOME":           "",
 		"NEWSJACK_ROOT":           repo,
 		"NEWSJACK_NO_AUTO_UPDATE": "1",
 		"NEWSJACK_IGNORE_DOTENV":  "1",
-		"PATH":                    fakeBin + ":/bin:/usr/bin",
+		"PATH":                    testPATH(fakeBin),
 	}, func() {
 		var out, errBuf bytes.Buffer
 		code := runCLIWithIO([]string{"setup", "--runtime", "codex", "--schedule-runtime", "hermes", "--skip-credentials", "--no-launch"}, strings.NewReader(""), &out, &errBuf)
@@ -520,13 +515,7 @@ func TestSetupStoresOptionalCredentials(t *testing.T) {
 		if !strings.Contains(string(envBody), `X_BEARER_TOKEN="value"`) {
 			t.Fatalf("X token was not saved to newsjack env:\n%s", envBody)
 		}
-		mode, err := os.Stat(envPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if mode.Mode().Perm() != 0o600 {
-			t.Fatalf("env permissions=%o, want 600", mode.Mode().Perm())
-		}
+		assertOwnerOnlyFile(t, envPath)
 		key, source := loadAPIKey()
 		if key != "mlst_test_key_12345" || !strings.HasPrefix(source, "credentials:") {
 			t.Fatalf("medialyst key/source=%q/%q", key, source)
@@ -535,6 +524,7 @@ func TestSetupStoresOptionalCredentials(t *testing.T) {
 }
 
 func TestSetupLaunchesSelectedHarnessWithSetupSkillPrompt(t *testing.T) {
+	requirePOSIXShell(t)
 	repo := repoRootForTest(t)
 	home := t.TempDir()
 	fakeBin := t.TempDir()
@@ -590,6 +580,7 @@ func TestSetupLaunchesSelectedHarnessWithSetupSkillPrompt(t *testing.T) {
 }
 
 func TestSetupOpenClawFallsBackToManualPrompt(t *testing.T) {
+	requirePOSIXShell(t)
 	repo := repoRootForTest(t)
 	home := t.TempDir()
 	fakeBin := t.TempDir()
@@ -647,6 +638,7 @@ func TestSetupOpenClawFallsBackToManualPrompt(t *testing.T) {
 }
 
 func TestSetupConfiguresMedialystMCPForSelectedRuntimes(t *testing.T) {
+	requirePOSIXShell(t)
 	repo := repoRootForTest(t)
 	home := t.TempDir()
 	fakeBin := t.TempDir()
@@ -704,10 +696,7 @@ func TestSetupConfiguresHermesMCP(t *testing.T) {
 	repo := repoRootForTest(t)
 	home := t.TempDir()
 	fakeBin := t.TempDir()
-	hermesPath := filepath.Join(fakeBin, "hermes")
-	if err := os.WriteFile(hermesPath, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
-		t.Fatal(err)
-	}
+	writeFakeTool(t, fakeBin, "hermes")
 	withTempEnv(t, map[string]string{
 		"HOME":                    home,
 		"NEWSJACK_HOME":           "",
@@ -717,7 +706,7 @@ func TestSetupConfiguresHermesMCP(t *testing.T) {
 		"MEDIALYST_API_KEY":       "",
 		"X_BEARER_TOKEN":          "",
 		"TWITTER_BEARER_TOKEN":    "",
-		"PATH":                    fakeBin + ":/bin:/usr/bin",
+		"PATH":                    testPATH(fakeBin),
 	}, func() {
 		var out, errBuf bytes.Buffer
 		code := runCLIWithIO(
@@ -745,6 +734,7 @@ func TestSetupConfiguresHermesMCP(t *testing.T) {
 }
 
 func TestSetupPrintsContinuationPromptWhenAgentLaunchFails(t *testing.T) {
+	requirePOSIXShell(t)
 	repo := repoRootForTest(t)
 	home := t.TempDir()
 	fakeBin := t.TempDir()

--- a/apps/cli/cmd/newsjack/monitor_test.go
+++ b/apps/cli/cmd/newsjack/monitor_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -724,9 +725,12 @@ func TestSetupConfiguresHermesMCP(t *testing.T) {
 			t.Fatal(err)
 		}
 		text := string(body)
+		// Build the expectation exactly like the product does (%q), so the
+		// per-OS binary name and Windows backslash escaping both match.
+		expectedCommand := fmt.Sprintf("command: %q", filepath.Join(home, ".newsjack", "bin", installedBinaryName()))
 		if !strings.Contains(text, "mcp_servers:") ||
 			!strings.Contains(text, "medialyst:") ||
-			!strings.Contains(text, `command: "`+filepath.Join(home, ".newsjack", "bin", "newsjack")+`"`) ||
+			!strings.Contains(text, expectedCommand) ||
 			!strings.Contains(text, `- "mcp-bridge"`) {
 			t.Fatalf("Hermes MCP config missing:\n%s", text)
 		}

--- a/apps/cli/cmd/newsjack/paths.go
+++ b/apps/cli/cmd/newsjack/paths.go
@@ -41,7 +41,7 @@ func newsjackRoot() (string, error) {
 			return repo, nil
 		}
 	}
-	return "", fmt.Errorf("newsjack is not installed at %s; run: newsjack setup (downloads the bundle), curl -fsSL newsjack.sh | bash, or npm i -g newsjack", root)
+	return "", fmt.Errorf("newsjack is not installed at %s; run: newsjack setup (downloads the bundle), curl -fsSL https://newsjack.sh | bash, or npm i -g newsjack", root)
 }
 
 func findRepoRoot(start string) (string, bool) {

--- a/apps/cli/cmd/newsjack/paths.go
+++ b/apps/cli/cmd/newsjack/paths.go
@@ -41,7 +41,7 @@ func newsjackRoot() (string, error) {
 			return repo, nil
 		}
 	}
-	return "", fmt.Errorf("newsjack is not installed at %s; run: curl -fsSL newsjack.sh | bash or npm i -g newsjack", root)
+	return "", fmt.Errorf("newsjack is not installed at %s; run: newsjack setup (downloads the bundle), curl -fsSL newsjack.sh | bash, or npm i -g newsjack", root)
 }
 
 func findRepoRoot(start string) (string, bool) {

--- a/apps/cli/cmd/newsjack/test_helpers_test.go
+++ b/apps/cli/cmd/newsjack/test_helpers_test.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -20,6 +23,17 @@ func repoRootForTest(t *testing.T) string {
 
 func withTempEnv(t *testing.T, env map[string]string, fn func()) {
 	t.Helper()
+	if home, ok := env["HOME"]; ok && runtime.GOOS == "windows" {
+		if _, explicit := env["USERPROFILE"]; !explicit {
+			// os.UserHomeDir resolves USERPROFILE on Windows; keep both in sync
+			// so HOME-faking tests isolate the same way on every platform.
+			mirrored := map[string]string{"USERPROFILE": home}
+			for key, value := range env {
+				mirrored[key] = value
+			}
+			env = mirrored
+		}
+	}
 	old := map[string]string{}
 	present := map[string]bool{}
 	for key, value := range env {
@@ -40,4 +54,56 @@ func withTempEnv(t *testing.T, env map[string]string, fn func()) {
 		}
 	}()
 	fn()
+}
+
+// requirePOSIXShell skips tests whose fake agent CLIs are POSIX shell
+// scripts. The logic they cover is OS-independent and stays covered on the
+// Linux CI leg; Windows runtime-exec coverage comes from the Windows harness
+// battery (docs/2026-06-11-windows-support-test-plan.md).
+func requirePOSIXShell(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("fake CLIs are POSIX shell scripts; covered on the Linux CI leg")
+	}
+}
+
+// writeFakeTool creates an executable no-op command for LookPath-based
+// runtime detection tests on every platform.
+func writeFakeTool(t *testing.T, dir, name string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		if err := os.WriteFile(filepath.Join(dir, name+".cmd"), []byte("@exit /b 0\r\n"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		return
+	}
+	if err := os.WriteFile(filepath.Join(dir, name), []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// testPATH builds a PATH value from the given directories, keeping the
+// system shell directories available on Unix so product code can spawn sh.
+func testPATH(dirs ...string) string {
+	entries := append([]string{}, dirs...)
+	if runtime.GOOS != "windows" {
+		entries = append(entries, "/bin", "/usr/bin")
+	}
+	return strings.Join(entries, string(os.PathListSeparator))
+}
+
+// assertOwnerOnlyFile checks 0600 permissions where the OS supports POSIX
+// permission bits; Windows reduces modes to the read-only attribute.
+func assertOwnerOnlyFile(t *testing.T, path string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		return
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("%s permissions=%o, want 600", path, info.Mode().Perm())
+	}
 }

--- a/apps/cli/cmd/newsjack/update.go
+++ b/apps/cli/cmd/newsjack/update.go
@@ -170,16 +170,7 @@ func runningInstalledBinary() bool {
 	if err != nil {
 		return false
 	}
-	want := installedBinaryPath()
-	exeReal, err := filepath.EvalSymlinks(exe)
-	if err != nil {
-		exeReal = exe
-	}
-	wantReal, err := filepath.EvalSymlinks(want)
-	if err != nil {
-		wantReal = want
-	}
-	return exeReal == wantReal
+	return samePath(exe, installedBinaryPath())
 }
 
 func readInstalledVersion() string {
@@ -268,7 +259,7 @@ func setenv(env []string, key, value string) []string {
 }
 
 func runInstalledBinary(args []string) int {
-	bin := filepath.Join(newsjackHome(), "bin", "newsjack")
+	bin := installedBinaryPath()
 	cmd := exec.Command(bin, args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/apps/cli/cmd/newsjack/update.go
+++ b/apps/cli/cmd/newsjack/update.go
@@ -19,10 +19,76 @@ func cmdUpdate(_ []string, stdout, stderr io.Writer) int {
 		printNPMUpdate(stdout)
 		return 0
 	}
+	if useNativeUpdate() {
+		if err := runNativeUpdate(stdout, stderr); err != nil {
+			return fail(stderr, err)
+		}
+		return 0
+	}
 	if err := runHostedInstaller(stdout, stderr); err != nil {
 		return fail(stderr, err)
 	}
 	return 0
+}
+
+// useNativeUpdate selects the in-process update path. Windows always uses
+// it (there is no sh to re-run the hosted installer); other platforms can
+// opt in with NEWSJACK_NATIVE_UPDATE=1 while the hosted path stays default.
+func useNativeUpdate() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("NEWSJACK_NATIVE_UPDATE"))) {
+	case "1", "true", "on", "yes":
+		return true
+	case "0", "false", "off", "no":
+		return false
+	}
+	return goos() == "windows"
+}
+
+// runNativeUpdate mirrors what the hosted installer does, without a shell:
+// apply the release bundle, swap the managed binary, refresh install state,
+// then reinstall runtime skills and MCP config per the recorded modes.
+func runNativeUpdate(stdout, stderr io.Writer) error {
+	base := releaseBaseForUpdate()
+	newVersion, err := applyReleaseBundle(base, stderr)
+	if err != nil {
+		return err
+	}
+	if err := updateInstalledBinaryFromBundle(); err != nil {
+		return err
+	}
+	state := readInstallStateOrDefault()
+	state.Version = newVersion
+	state.Commit = readTrimmedFile(filepath.Join(managedInstallDir(), "COMMIT"))
+	state.InstalledAt = time.Now().UTC().Format(time.RFC3339)
+	if err := writeInstallStateFile(state); err != nil {
+		return err
+	}
+	if state.SkillsMode == skillsModeExternal {
+		successf(stdout, "updated newsjack to %s (external skills mode: runtime skills untouched)", newVersion)
+		return nil
+	}
+	runtimes := getenv("NEWSJACK_RUNTIMES", state.RuntimesRaw)
+	if strings.TrimSpace(runtimes) == "" {
+		runtimes = "auto"
+	}
+	opts := installOptions{
+		Source:     managedInstallDir(),
+		Runtimes:   runtimes,
+		InstallMCP: state.InstallMCP,
+		CLI:        newsjackCLIInvocation(),
+		Repo:       getenv("NEWSJACK_REPO", state.Repo),
+		Ref:        getenv("NEWSJACK_REF", defaultRef),
+	}
+	if err := installRuntimeSkills(opts, stdout, stderr); err != nil {
+		return err
+	}
+	if opts.InstallMCP {
+		if err := configureMCP(opts, stdout, stderr); err != nil {
+			warn(stderr, "%v", err)
+		}
+	}
+	successf(stdout, "updated newsjack to %s", newVersion)
+	return nil
 }
 
 func maybeAutoUpdate(args []string, stderr io.Writer) (int, bool) {
@@ -44,7 +110,12 @@ func maybeAutoUpdate(args []string, stderr io.Writer) (int, bool) {
 		logf(stderr, "auto-updating from %s to %s", current, latest)
 	}
 
-	if err := runHostedInstaller(os.Stderr, os.Stderr); err != nil {
+	if useNativeUpdate() {
+		if err := runNativeUpdate(os.Stderr, os.Stderr); err != nil {
+			warn(stderr, "auto-update failed: %v", err)
+			return 0, false
+		}
+	} else if err := runHostedInstaller(os.Stderr, os.Stderr); err != nil {
 		warn(stderr, "auto-update failed: %v", err)
 		return 0, false
 	}
@@ -99,7 +170,7 @@ func runningInstalledBinary() bool {
 	if err != nil {
 		return false
 	}
-	want := filepath.Join(newsjackHome(), "bin", "newsjack")
+	want := installedBinaryPath()
 	exeReal, err := filepath.EvalSymlinks(exe)
 	if err != nil {
 		exeReal = exe

--- a/apps/cli/cmd/newsjack/update.go
+++ b/apps/cli/cmd/newsjack/update.go
@@ -75,6 +75,7 @@ func runNativeUpdate(stdout, stderr io.Writer) error {
 		Source:     managedInstallDir(),
 		Runtimes:   runtimes,
 		InstallMCP: state.InstallMCP,
+		Force:      os.Getenv("NEWSJACK_FORCE") == "1",
 		CLI:        newsjackCLIInvocation(),
 		Repo:       getenv("NEWSJACK_REPO", state.Repo),
 		Ref:        getenv("NEWSJACK_REF", defaultRef),

--- a/apps/cli/cmd/newsjack/update_native_test.go
+++ b/apps/cli/cmd/newsjack/update_native_test.go
@@ -1,0 +1,184 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestUpdateInstalledBinaryFromBundleSwap(t *testing.T) {
+	home := t.TempDir()
+	withTempEnv(t, map[string]string{
+		"HOME":          home,
+		"NEWSJACK_HOME": "",
+	}, func() {
+		bundleBin := filepath.Join(managedInstallDir(), "bin", installedBinaryName())
+		if err := os.MkdirAll(filepath.Dir(bundleBin), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(bundleBin, []byte("new binary"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		dest := installedBinaryPath()
+		if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(dest, []byte("old binary"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := updateInstalledBinaryFromBundle(); err != nil {
+			t.Fatal(err)
+		}
+		got, err := os.ReadFile(dest)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(got) != "new binary" {
+			t.Fatalf("installed binary content = %q", got)
+		}
+		parked := dest + ".old"
+		if runtime.GOOS == "windows" {
+			// The swap never overwrites in place; the previous binary is
+			// parked so a running exe survives its own update.
+			old, err := os.ReadFile(parked)
+			if err != nil {
+				t.Fatalf("parked binary missing on windows: %v", err)
+			}
+			if string(old) != "old binary" {
+				t.Fatalf("parked binary content = %q", old)
+			}
+		} else if fileExists(parked) {
+			t.Fatal("parked binary should be removed immediately on unix")
+		}
+
+		cleanupStaleBinary()
+		if fileExists(parked) {
+			t.Fatal("cleanupStaleBinary should remove the parked binary")
+		}
+	})
+}
+
+func TestRunNativeUpdateAppliesBundleAndPreservesState(t *testing.T) {
+	payload := buildBundleTarGz(t, testBundleFiles("v2.0.0-test"))
+	server := serveRelease(t, payload, "v2.0.0-test")
+	home := t.TempDir()
+
+	env := bootstrapEnv(home, server.URL)
+	env["NEWSJACK_NATIVE_UPDATE"] = "1"
+	delete(env, "NEWSJACK_RUNTIMES")
+	withTempEnv(t, env, func() {
+		// Simulate an existing v1 install with recorded state.
+		if err := os.MkdirAll(filepath.Join(managedInstallDir(), "bin"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(managedInstallDir(), "VERSION"), []byte("v1.0.0\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := writeInstallStateFile(normalizeInstallState(installState{
+			Version:     "v1.0.0",
+			Commit:      "oldcommit",
+			RuntimesRaw: "claude",
+			Runtimes:    []string{"claude"},
+			SkillsMode:  skillsModeManaged,
+			InstallMCP:  false,
+		})); err != nil {
+			t.Fatal(err)
+		}
+		dest := installedBinaryPath()
+		if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(dest, []byte("v1 binary"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+
+		var out, errBuf bytes.Buffer
+		if err := runNativeUpdate(&out, &errBuf); err != nil {
+			t.Fatalf("runNativeUpdate: %v\nstderr=%s", err, errBuf.String())
+		}
+
+		if got := readTrimmedFile(filepath.Join(managedInstallDir(), "VERSION")); got != "v2.0.0-test" {
+			t.Fatalf("bundle VERSION=%q after update", got)
+		}
+		binary, err := os.ReadFile(dest)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(binary) != "fake binary payload\n" {
+			t.Fatalf("installed binary not refreshed from bundle: %q", binary)
+		}
+
+		data, err := os.ReadFile(installStatePath())
+		if err != nil {
+			t.Fatal(err)
+		}
+		var state installState
+		if err := json.Unmarshal(data, &state); err != nil {
+			t.Fatal(err)
+		}
+		if state.Version != "v2.0.0-test" || state.Commit != "deadbeef" {
+			t.Fatalf("state version/commit = %q/%q", state.Version, state.Commit)
+		}
+		if state.RuntimesRaw != "claude" || state.InstallMCP != false {
+			t.Fatalf("update must preserve recorded runtimes/mcp: %+v", state)
+		}
+		if !fileExists(filepath.Join(home, ".claude", "skills", "newsjack-detector", "SKILL.md")) {
+			t.Fatal("update should refresh runtime skills for the recorded runtimes")
+		}
+	})
+}
+
+func TestRunNativeUpdateExternalSkillsModeLeavesRuntimesAlone(t *testing.T) {
+	payload := buildBundleTarGz(t, testBundleFiles("v2.0.0-test"))
+	server := serveRelease(t, payload, "v2.0.0-test")
+	home := t.TempDir()
+
+	env := bootstrapEnv(home, server.URL)
+	env["NEWSJACK_NATIVE_UPDATE"] = "1"
+	withTempEnv(t, env, func() {
+		if err := writeInstallStateFile(normalizeInstallState(installState{
+			Version:    "v1.0.0",
+			SkillsMode: skillsModeExternal,
+		})); err != nil {
+			t.Fatal(err)
+		}
+
+		var out, errBuf bytes.Buffer
+		if err := runNativeUpdate(&out, &errBuf); err != nil {
+			t.Fatalf("runNativeUpdate: %v\nstderr=%s", err, errBuf.String())
+		}
+		if fileExists(filepath.Join(home, ".claude", "skills", "newsjack-detector", "SKILL.md")) {
+			t.Fatal("external skills mode must not write runtime skill dirs")
+		}
+		var state installState
+		data, _ := os.ReadFile(installStatePath())
+		if err := json.Unmarshal(data, &state); err != nil {
+			t.Fatal(err)
+		}
+		if state.SkillsMode != skillsModeExternal || state.Version != "v2.0.0-test" {
+			t.Fatalf("state after external update: %+v", state)
+		}
+	})
+}
+
+func TestUseNativeUpdateRespectsOverride(t *testing.T) {
+	withTempEnv(t, map[string]string{"NEWSJACK_NATIVE_UPDATE": "1"}, func() {
+		if !useNativeUpdate() {
+			t.Fatal("NEWSJACK_NATIVE_UPDATE=1 should force the native path")
+		}
+	})
+	withTempEnv(t, map[string]string{"NEWSJACK_NATIVE_UPDATE": "0"}, func() {
+		if useNativeUpdate() {
+			t.Fatal("NEWSJACK_NATIVE_UPDATE=0 should force the hosted path")
+		}
+	})
+	withTempEnv(t, map[string]string{"NEWSJACK_NATIVE_UPDATE": ""}, func() {
+		if got, want := useNativeUpdate(), runtime.GOOS == "windows"; got != want {
+			t.Fatalf("default native update = %v on %s", got, runtime.GOOS)
+		}
+	})
+}

--- a/apps/cli/cmd/newsjack/util.go
+++ b/apps/cli/cmd/newsjack/util.go
@@ -8,11 +8,16 @@ import (
 	"net/http"
 	"os"
 	"regexp"
+	"runtime"
 	"sort"
 	"strconv"
 	"strings"
 	"time"
 )
+
+func goos() string {
+	return runtime.GOOS
+}
 
 func getenv(key, fallback string) string {
 	if v := os.Getenv(key); v != "" {

--- a/docs/2026-06-11-windows-support-test-plan.md
+++ b/docs/2026-06-11-windows-support-test-plan.md
@@ -1,0 +1,249 @@
+# Windows Support: Harness and Test Plan
+
+Date: 2026-06-11
+Status: proposed
+
+## Scope
+
+This plan covers verification for native Windows support built on the
+no-install-script path:
+
+1. Windows release artifacts (`newsjack.exe`, `newsjack_windows_amd64.tar.gz`).
+2. Native bundle-apply in Go: fetch release, verify checksum, unpack, swap.
+3. Self-bootstrap: a bare downloaded exe plus `newsjack setup` produces a full
+   install with no shell script, Node, or git.
+4. Go-native Medialyst MCP bridge replacing `npx mcp-remote` (shared across
+   all platforms — the one change that can regress macOS/Linux).
+5. Windows-native self-update, including the running-exe swap.
+6. Per-OS setup wizard behavior (runtime install commands, doctor checks).
+
+Goals, in priority order: (a) do not break the existing macOS/Linux install
+path, (b) prove the Windows path end to end, (c) keep both protected in CI
+permanently.
+
+## Principles
+
+- Same doctrine as `harness/README.md`: the harness observes the real compiled
+  `newsjack` binary. No second implementation of install logic in test
+  scripts. The no-script design makes this easier on Windows: there is no
+  installer script to mirror, the binary owns everything and the harness only
+  asserts.
+- Windows CI does not use Docker. A fresh `windows-latest` runner VM is the
+  disposable clean environment; isolation comes from pointing `NEWSJACK_HOME`
+  (and `USERPROFILE` where needed) at a throwaway directory, exactly as the
+  Linux harness does with `HOME=/tmp/newsjack-home`.
+- Windows assertions are written in pwsh, not Git Bash. Running the battery
+  under bash on Windows would mask the PowerShell-environment bugs the tests
+  exist to catch.
+- Every assertion that exists in the Linux battery
+  (`harness/scripts/run-ci-installer.sh`) has a Windows twin unless it is
+  installer-script-specific. The JSON contracts (`setup --json`,
+  `doctor --json`, detector/monitor outputs) are identical across platforms
+  and are the shared source of truth.
+
+## Layer 0: cross-compile gates (land before any feature work)
+
+In `agent-harness-ci.yml` `cli-unit`:
+
+- `GOOS=windows GOARCH=amd64 go build ./...`
+- `GOOS=darwin GOARCH=arm64 go build ./...` (guards the reverse direction)
+
+Cost: seconds. Catches compile-level platform regressions in both directions
+from day one. The Windows build passes today; this keeps it that way.
+
+## Layer 1: unit tests on both OSes
+
+Add a `windows-latest` leg to `cli-unit` running `go test ./...`.
+
+Prerequisite test fixes (pure test-infra, no product change):
+
+- `withTempEnv` and tests that fake home via `HOME` must also set
+  `USERPROFILE` so `os.UserHomeDir()` resolves on Windows.
+- `monitor_test.go` writes `#!/bin/sh` scripts as fake runtime installers.
+  These need per-OS doubles (`.cmd` shims) or explicit platform skips with a
+  tracking comment.
+- Audit golden fixtures for hardcoded `/` path separators in compared output.
+
+New unit tests required with each feature:
+
+### Bundle-apply (with native update/bootstrap work)
+
+Serve a local release layout (`manifest.json`, `checksums.txt`, platform
+tar.gz) from `httptest`. Assert, on both OSes:
+
+- Happy path: download, checksum verify, unpack to `~/.newsjack/newsjack`,
+  layout matches what `install.sh` produces today (VERSION, COMMIT,
+  `skills-manifest.json`, `bin/` binary, prebuilt marker).
+- Checksum mismatch: fails, and a pre-existing install is left byte-identical
+  (no partial mutation).
+- Truncated/interrupted download: no mutation.
+- Missing platform artifact in manifest: clean, actionable error.
+
+### Bootstrap (with bootstrap work)
+
+- Empty `NEWSJACK_HOME` + `NEWSJACK_RELEASE_BASE` override: full layout
+  appears, `install.json` fields match the install.sh-written equivalent
+  (`skills_mode`, `runtimes_raw`, `channel`), binary copied to
+  `~/.newsjack/bin/newsjack` (`.exe` on Windows).
+- Re-run is idempotent and preserves the `.previous` rollback dir behavior.
+
+### Self-update swap (with update work)
+
+- Swap function uses rename-then-move (never in-place overwrite), leaves
+  `newsjack.exe.old` on Windows, and the next invocation cleans it up.
+- `runningInstalledBinary()` matches the per-OS binary name.
+
+### Go MCP bridge (with bridge work; runs on all platforms)
+
+Contract tests against an in-process fake Medialyst MCP endpoint
+(`httptest`, streamable HTTP):
+
+- `initialize` handshake round-trips over stdio JSON-RPC framing.
+- `Authorization: Bearer` header present on every upstream request; key
+  loaded from `credentials.json` and from `MEDIALYST_API_KEY`, with the
+  credentials-file path winning per current precedence.
+- Tool call request/response and SSE server-initiated messages pass through.
+- Upstream 401: bridge exits nonzero with the re-auth hint, not a hang.
+- Upstream connection close: bridge terminates cleanly.
+
+These replace the implicit trust we currently place in `mcp-remote`.
+
+## Layer 2: Linux/macOS regression protection (existing harness, surgical changes)
+
+The existing pipeline (`release-installer-smoke`, `no-token-installer` Docker
+battery, `post-release-smoke`) stays as-is and keeps gating every PR. Changes
+only where the shared bridge lands:
+
+- `run-ci-installer.sh` currently asserts `.dependencies.npx == true` in
+  `doctor --json`. When the Go bridge lands this assertion inverts: doctor
+  should no longer list npx as required, and the battery instead runs a
+  bridge smoke.
+- Bridge smoke (new step in the container battery): start a mock Medialyst
+  MCP server (small Go program under `harness/mock-mcp/`, run with `go run`;
+  the harness image already has Go), point the bridge at it via an
+  endpoint-override env var, drive one `initialize` + one tool call through
+  `newsjack mcp-bridge` stdin/stdout, assert the round trip. This runs
+  no-token and proves the npx-free bridge inside the same containers that
+  gate PRs today.
+- Live gate for the bridge swap: run
+  `harness/scripts/run-live-medialyst-mcp.sh` (all runtimes) once on the
+  branch before merge and once after release. This is the only place the
+  real Medialyst endpoint, real credentials, and real agent runtimes meet
+  the new bridge; it is manual and spends credits, same as today.
+- Self-update: macOS/Linux stay on the hosted `curl | sh` update path
+  initially (Windows-gated native apply), so the existing auto-update
+  observation flow in `harness/README.md` remains valid unchanged. If/when
+  unix switches to native apply, the same Docker auto-update smoke
+  (stale VERSION, run doctor, assert rewrite) covers it with no new
+  infrastructure.
+
+## Layer 3: Windows CI battery (the harness twin)
+
+New job(s) in `agent-harness-ci.yml` on `windows-latest`, plus
+`harness/scripts/run-ci-installer.ps1` (pwsh) mirroring the container battery.
+
+Build once, test native: the Linux job already builds the full release dist;
+upload `.tmp/newsjack-release` as an artifact and have the Windows job
+download it. This exercises the exact cross-compiled artifact a release
+would ship instead of rebuilding on Windows.
+
+Battery steps (each mirrors a named step in `run-ci-installer.sh`):
+
+1. **Serve dist locally** — `python -m http.server` (preinstalled on
+   runners) over the downloaded artifact dir.
+2. **Bootstrap smoke** — copy the bare `newsjack.exe` to a scratch dir,
+   set `NEWSJACK_HOME` to a fresh temp dir and
+   `NEWSJACK_RELEASE_BASE=http://127.0.0.1:<port>`, run
+   `newsjack setup --json`. Assert: bundle layout under
+   `$env:NEWSJACK_HOME\newsjack`, exe copied to `...\bin\newsjack.exe`,
+   `install.json` contents, `setup --json` schema (same jq assertions,
+   via `ConvertFrom-Json`).
+3. **Doctor** — `newsjack doctor --json`: `root_ok == true`, per-OS
+   dependency list (no npx requirement), PATH-presence check result.
+4. **Skills** — `newsjack-detector/SKILL.md` and
+   `newsjack-monitor-setup/SKILL.md` exist under
+   `$env:USERPROFILE\.claude\skills` (and `.agents\skills` for codex
+   selection), no `scripts/` leakage — same exclusion asserts as Linux.
+5. **Mock detector** — `newsjack detector run "AI search visibility" --mock
+   --limit 1`, identical JSON assertions.
+6. **Monitor lifecycle** — init/test/schedule/status with the same
+   harness-coffee profile and the same field-level assertions, including
+   the no-system-cron guarantees (`system_cron == false`, schedule markdown
+   free of crontab/launchd/systemd references).
+7. **Auto-update smoke** — write a stale `VERSION`, run `newsjack doctor`,
+   assert: stderr shows auto-update, the running exe was swapped via the
+   rename dance, `newsjack.exe.old` exists then is cleaned by the next
+   invocation, stdout stayed valid JSON. This is the only place the real
+   Windows file-locking behavior can be tested.
+8. **Bridge smoke, no Node** — for this step strip every Node directory
+   from `PATH` (runners preinstall Node; customers will not have it), run
+   the same mock-MCP round trip as the Linux battery. This leg is the
+   permanent contract that the Windows path needs no Node.
+9. **No-git leg** — strip git from `PATH`, re-run steps 2–6 in a second
+   fresh `NEWSJACK_HOME`. Proves install/setup never silently shells to
+   bash/git.
+10. **Spaces-in-profile leg** — repeat bootstrap with
+    `NEWSJACK_HOME=C:\t e m p\jane smith\.newsjack`-style path. Runner
+    usernames never contain spaces; real customers' do.
+
+Matrix note: steps run under pwsh 7. One spot-check leg invokes the
+user-facing commands from Windows PowerShell 5.1, since with no install
+script the user-typed surface is just `newsjack <cmd>` and the printed PATH
+instruction — small but cheap to keep honest.
+
+## Layer 4: manual / dispatch harness (agent-in-the-loop)
+
+Extend `agent-harness-integration.yml` with an `os: windows` input (or a
+sibling dispatch workflow):
+
+- Installs Claude Code on the runner via its native Windows installer
+  (`irm https://claude.ai/install.ps1 | iex`), pinned version arg like the
+  Docker image pins `CLAUDE_CODE_VERSION`.
+- Runs `newsjack install --runtimes claude`, asserts `claude mcp list`
+  shows `medialyst` pointing at the bridge command with the `.exe` path.
+- With `--with-local-env`-equivalent secrets: one live `news_search` through
+  Claude Code on Windows — the Windows twin of
+  `run-live-medialyst-mcp.sh`. Manual, credit-spending, run before the
+  Windows GA and after bridge changes.
+
+## Layer 5: post-release smoke
+
+Add a `windows-release-smoke` job to `post-release-smoke.yml`:
+
+- Download the released bare exe (and checksums) from the GitHub Release,
+  verify the checksum in pwsh, run bootstrap against the real release base
+  (no `NEWSJACK_RELEASE_BASE` override), then doctor + skills list + mock
+  detector. This is the closest CI gets to the real customer flow:
+  "download one file, run setup."
+
+## What stays manual (release checklist additions)
+
+CI cannot cover these; keep them as a short checklist in
+`docs/release-playbook.md` once Windows ships:
+
+- Interactive `newsjack setup` prompt flow in Windows Terminal (TTY
+  selection UX, colors under conhost vs Windows Terminal).
+- SmartScreen / Mark-of-the-Web behavior on a browser-downloaded exe
+  (known friction until code signing lands; verify the warning text and
+  click-through path once per release).
+- One fresh Windows 11 VM run per release: download exe from the site, full
+  setup with Claude Code, one real detector run. This is the
+  customer-shaped test no runner reproduces.
+
+Local dev note: there is no Docker equivalent for Windows on macOS hosts.
+The local loop is either a Windows 11 ARM VM or, preferably, driving the
+Layer 3/4 workflows with `gh workflow run` and reading artifacts.
+
+## Phasing (each lands with its feature, protection-first)
+
+| Phase | Feature | Tests that land with it |
+| --- | --- | --- |
+| 0 | none (now) | Layer 0 gates; Layer 1 windows `go test` leg + test-infra fixes |
+| 1 | Go MCP bridge | Bridge contract tests; harness mock-MCP smoke (Linux); doctor npx assertion flip; live Medialyst gate before merge |
+| 2 | Bundle-apply + bootstrap | Bundle/bootstrap unit tests (both OSes); Layer 3 battery steps 1–6, 8–10 |
+| 3 | Windows self-update | Swap unit tests; Layer 3 step 7 |
+| 4 | Release | Layer 5 post-release job; Layer 4 dispatch workflow; manual checklist in release playbook |
+
+Phase 0 is pure protection and has no dependency on any Windows feature
+work. Nothing in Phases 1–4 modifies `install.sh` or the existing Linux
+battery except the single doctor-npx assertion that the bridge makes stale.

--- a/docs/release-playbook.md
+++ b/docs/release-playbook.md
@@ -394,6 +394,15 @@ installs the binary to `%USERPROFILE%\.newsjack\bin`, and installs skills.
 Self-update is native Go (`NEWSJACK_NATIVE_UPDATE` controls it on other
 platforms; Windows always uses it).
 
+The documented install command (for users and agents) is a PowerShell
+one-liner. Launching from a terminal avoids the Explorer SmartScreen dialog,
+and `Unblock-File` strips the Mark-of-the-Web so later launches stay clean —
+the binary is unsigned, so this is the supported path until code signing:
+
+```powershell
+iwr https://github.com/elvisun/newsjack/releases/latest/download/newsjack_windows_amd64.exe -OutFile newsjack.exe; Unblock-File newsjack.exe; .\newsjack.exe setup
+```
+
 Automated coverage:
 
 - `agent-harness-ci.yml` runs Go tests on `windows-latest`, cross-compile

--- a/docs/release-playbook.md
+++ b/docs/release-playbook.md
@@ -349,3 +349,42 @@ If auto-update does not run:
 - Confirm `NEWSJACK_AUTO_UPDATE` is not `0`.
 - Confirm `NEWSJACK_NO_AUTO_UPDATE` is not `1`.
 - Run `newsjack doctor --json` and inspect `.install`.
+
+## Windows
+
+Windows ships as a bare `newsjack_windows_amd64.exe` release asset plus the
+`newsjack_windows_amd64.tar.gz` bundle. There is no install script: users
+download the exe and run `newsjack setup`, which bootstraps the bundle,
+installs the binary to `%USERPROFILE%\.newsjack\bin`, and installs skills.
+Self-update is native Go (`NEWSJACK_NATIVE_UPDATE` controls it on other
+platforms; Windows always uses it).
+
+Automated coverage:
+
+- `agent-harness-ci.yml` runs Go tests on `windows-latest`, cross-compile
+  gates on every PR, and the full bootstrap battery
+  (`harness/scripts/run-ci-installer.ps1`): bootstrap, doctor, skills, mock
+  detector, monitor lifecycle, no-Node bridge smoke, no-git leg,
+  spaces-in-profile leg, and the auto-update exe swap.
+- `post-release-smoke.yml` has a `windows-install` job: downloads the
+  released exe, verifies its checksum, bootstraps, and runs a mock detector.
+- `agent-harness-integration.yml` with `os: windows` installs real Claude
+  Code via its native installer and verifies the Medialyst MCP registration;
+  with the `MEDIALYST_API_KEY` secret it also runs a live bridge handshake.
+
+Manual checklist per release (CI cannot cover these):
+
+- Interactive `newsjack setup` prompt flow in Windows Terminal: selection
+  UX, colors, and the launch handoff into Claude Code.
+- SmartScreen / Mark-of-the-Web on a browser-downloaded exe: verify the
+  warning path and document the click-through until code signing lands.
+- One fresh Windows 11 VM run: download the exe from the release page, full
+  setup with Claude Code, one real detector run.
+
+Troubleshooting:
+
+- If bootstrap fails, check `checksums.txt` includes the windows artifacts
+  and that the release is not a prerelease.
+- If auto-update leaves a `newsjack.exe.old` behind, any later `newsjack`
+  command removes it once the old process has exited.
+- Reinstall command on Windows is `newsjack setup` (re-runs bootstrap).

--- a/docs/release-playbook.md
+++ b/docs/release-playbook.md
@@ -205,6 +205,8 @@ newsjack_darwin_amd64.tar.gz
 newsjack_darwin_arm64.tar.gz
 newsjack_linux_amd64.tar.gz
 newsjack_linux_arm64.tar.gz
+newsjack_windows_amd64.exe
+newsjack_windows_amd64.tar.gz
 ```
 
 The npm workflow publishes the five npm packages after checking that the exact

--- a/harness/README.md
+++ b/harness/README.md
@@ -222,6 +222,27 @@ harness/scripts/run-ci-installer.sh \
 `--env-file`. The script validates that repo-local env files are ignored by git
 and never prints secret values. CI should keep using the default no-token path.
 
+## Native MCP Bridge Smoke (no credentials)
+
+`newsjack mcp-bridge` is a native Go stdio-to-streamable-HTTP proxy; it needs
+no Node/npx on the machine. The CI battery proves this against
+`harness/mock-mcp`, a tiny mock Medialyst MCP server:
+
+```bash
+(cd harness/mock-mcp && go run . --addr 127.0.0.1:8970 --key mock-key) &
+printf '%s\n' \
+  '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"smoke","version":"0"}}}' \
+  '{"jsonrpc":"2.0","method":"notifications/initialized"}' \
+  '{"jsonrpc":"2.0","id":2,"method":"tools/list"}' | \
+  MEDIALYST_API_KEY=mock-key \
+  NEWSJACK_MEDIALYST_MCP_URL=http://127.0.0.1:8970/mcp \
+  newsjack mcp-bridge
+```
+
+Expected: the initialize result and a `mock_search` tool listing on stdout,
+exit 0. The same override env var points the bridge at any compatible
+endpoint for debugging.
+
 ## Live Medialyst MCP Check
 
 Use this only when you intentionally want to spend Medialyst credits. It runs one

--- a/harness/mock-mcp/go.mod
+++ b/harness/mock-mcp/go.mod
@@ -1,0 +1,3 @@
+module newsjack-harness-mock-mcp
+
+go 1.26

--- a/harness/mock-mcp/main.go
+++ b/harness/mock-mcp/main.go
@@ -1,0 +1,63 @@
+// Command mock-mcp is a minimal streamable-HTTP MCP server for harness
+// smoke tests of `newsjack mcp-bridge`. It is not product code: it exists so
+// CI can prove the native bridge handshake works with no live Medialyst
+// credentials and no Node runtime on the machine.
+//
+// Usage: go run . --addr 127.0.0.1:8970 --key mock-key
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+)
+
+func main() {
+	addr := flag.String("addr", "127.0.0.1:8970", "listen address")
+	key := flag.String("key", "mock-key", "bearer token the bridge must present")
+	flag.Parse()
+
+	http.HandleFunc("/mcp", func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer "+*key {
+			w.WriteHeader(http.StatusUnauthorized)
+			fmt.Fprint(w, `{"error":"missing or wrong bearer token"}`)
+			return
+		}
+		body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		var envelope struct {
+			ID     json.RawMessage `json:"id"`
+			Method string          `json:"method"`
+		}
+		if err := json.Unmarshal(body, &envelope); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		switch envelope.Method {
+		case "initialize":
+			w.Header().Set("Mcp-Session-Id", "mock-session")
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintf(w, `{"jsonrpc":"2.0","id":%s,"result":{"protocolVersion":"2025-03-26","capabilities":{"tools":{}},"serverInfo":{"name":"mock-medialyst","version":"0.0.1"}}}`, envelope.ID)
+		case "tools/list":
+			// Answer over SSE to exercise the bridge's event-stream path.
+			w.Header().Set("Content-Type", "text/event-stream")
+			fmt.Fprintf(w, "event: message\ndata: {\"jsonrpc\":\"2.0\",\"id\":%s,\"result\":{\"tools\":[{\"name\":\"mock_search\",\"description\":\"harness smoke tool\",\"inputSchema\":{\"type\":\"object\"}}]}}\n\n", envelope.ID)
+		default:
+			if len(envelope.ID) == 0 || string(envelope.ID) == "null" {
+				w.WriteHeader(http.StatusAccepted)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintf(w, `{"jsonrpc":"2.0","id":%s,"result":{}}`, envelope.ID)
+		}
+	})
+
+	log.Printf("mock-mcp listening on http://%s/mcp", *addr)
+	log.Fatal(http.ListenAndServe(*addr, nil))
+}

--- a/harness/scripts/run-ci-installer.ps1
+++ b/harness/scripts/run-ci-installer.ps1
@@ -1,0 +1,286 @@
+# Windows twin of run-ci-installer.sh: observes the real newsjack.exe doing
+# a bare-binary bootstrap install, then runs the same JSON assertion battery
+# as the Linux container script. No install script exists on Windows; the
+# binary owns the whole flow, so this harness only asserts.
+#
+# Usage (from repo root, pwsh):
+#   harness/scripts/run-ci-installer.ps1 -DistDir .tmp/newsjack-release
+#
+# Requires: the release dist (with the windows artifacts), python, go.
+
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory = $true)][string]$DistDir,
+  [int]$ServePort = 8765,
+  [int]$MockMCPPort = 8970
+)
+
+$ErrorActionPreference = 'Stop'
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..' '..')
+$DistDir = Resolve-Path $DistDir
+
+function Log([string]$message) {
+  Write-Host "ci-installer(windows): $message"
+}
+
+function Assert([bool]$condition, [string]$message) {
+  if (-not $condition) {
+    throw "ASSERTION FAILED: $message"
+  }
+}
+
+function Invoke-CLI {
+  # stderr streams through to the job log; only stdout is captured so JSON
+  # output stays parseable even when the CLI logs progress to stderr.
+  param([string]$Exe, [string[]]$CliArgs)
+  $output = & $Exe @CliArgs
+  if ($LASTEXITCODE -ne 0) {
+    throw "command failed ($LASTEXITCODE): $Exe $($CliArgs -join ' ')"
+  }
+  return $output
+}
+
+function New-ScratchHome([string]$name) {
+  $base = if ($env:RUNNER_TEMP) { $env:RUNNER_TEMP } else { [IO.Path]::GetTempPath() }
+  $path = Join-Path $base $name
+  if (Test-Path $path) { Remove-Item -Recurse -Force $path }
+  New-Item -ItemType Directory -Path $path | Out-Null
+  return $path
+}
+
+function Remove-PathEntries([string]$pattern) {
+  return (($env:PATH -split ';') | Where-Object { $_ -and ($_ -notmatch $pattern) }) -join ';'
+}
+
+# The battery asserts CLI JSON contracts; these mirror run-ci-installer.sh.
+function Test-SetupAndDoctor([string]$cli) {
+  $setup = Invoke-CLI $cli @('setup', '--json') | Out-String | ConvertFrom-Json
+  foreach ($field in 'monitors_dir', 'agent_prompt', 'recommended_runtime', 'recommended_scheduler', 'agent_command') {
+    Assert ($null -ne $setup.$field) "setup --json field $field"
+  }
+  $doctor = Invoke-CLI $cli @('doctor', '--json') | Out-String | ConvertFrom-Json
+  Assert ($doctor.root_ok -eq $true) 'doctor root_ok'
+  Assert ($doctor.mcp_bridge.transport -eq 'native') 'doctor mcp_bridge.transport native'
+  Assert ($doctor.install.skills_mode -eq 'managed') 'doctor skills_mode managed'
+}
+
+function Test-SkillsInstalled([string]$userProfileDir) {
+  foreach ($skill in 'newsjack-detector', 'newsjack-monitor-setup') {
+    $skillPath = Join-Path $userProfileDir ".claude\skills\$skill\SKILL.md"
+    Assert (Test-Path $skillPath) "skill installed: $skillPath"
+  }
+  $scripts = Join-Path $userProfileDir '.claude\skills\newsjack-detector\scripts'
+  Assert (-not (Test-Path $scripts)) 'skill scripts dir must not be installed'
+}
+
+function Test-MockDetector([string]$cli) {
+  $detector = Invoke-CLI $cli @('detector', 'run', 'AI search visibility', '--mock', '--limit', '1') | Out-String | ConvertFrom-Json
+  Assert ($detector.monitor.mock -eq $true) 'detector mock flag'
+  Assert ($detector.monitor.queries -contains 'AI search visibility') 'detector query echo'
+  Assert (@($detector.signals).Count -ge 1) 'detector returned signals'
+}
+
+function Test-MonitorLifecycle([string]$cli, [string]$scratch) {
+  $profilePath = Join-Path $scratch 'profile.json'
+  @'
+{
+  "company": "Harness Coffee",
+  "description": "Specialty coffee company used for installer verification.",
+  "topics": ["coffee supply chain"],
+  "search_terms": ["coffee supply chain"],
+  "feed_urls": ["https://example.com/feed.xml"],
+  "x_news": {"enabled": true},
+  "x_trends": {"mode": "none", "woeids": [], "locations": []},
+  "standing": ["coffee sourcing"],
+  "proof_assets": ["sourcing data"]
+}
+'@ | Set-Content -Path $profilePath -Encoding utf8
+
+  $init = Invoke-CLI $cli @('monitor', 'init', 'harness-coffee', '--profile', $profilePath) | Out-String | ConvertFrom-Json
+  Assert ($init.slug -eq 'harness-coffee') 'monitor init slug'
+  Assert ($null -ne $init.profile_path) 'monitor init profile_path'
+
+  $test = Invoke-CLI $cli @('monitor', 'test', 'harness-coffee', '--mock', '--limit', '2') | Out-String | ConvertFrom-Json
+  foreach ($field in 'candidates', 'summary', 'report_target') {
+    Assert ($null -ne $test.$field) "monitor test field $field"
+  }
+  Assert (Test-Path $test.candidates) 'monitor test candidates artifact'
+  Assert (Test-Path $test.summary) 'monitor test summary artifact'
+  Assert (-not (Test-Path $test.report_target)) 'monitor test must not write the report'
+
+  $schedule = Invoke-CLI $cli @('monitor', 'schedule', 'harness-coffee', '--runtime', 'claude', '--every', '1h') | Out-String | ConvertFrom-Json
+  Assert ($schedule.system_cron -eq $false) 'monitor schedule avoids system cron'
+  Assert ($schedule.runtime -eq 'claude') 'monitor schedule runtime'
+  Assert ($schedule.suggested_minute -ge 1 -and $schedule.suggested_minute -le 59) 'monitor schedule minute range'
+  $scheduleBody = Get-Content -Raw $schedule.schedule_path
+  Assert ($scheduleBody -notmatch 'crontab|launchd|systemd') 'schedule markdown free of system schedulers'
+  Assert ($scheduleBody -match 'never minute 0') 'schedule markdown keeps the never-minute-0 rule'
+
+  $status = Invoke-CLI $cli @('monitor', 'status', 'harness-coffee') | Out-String | ConvertFrom-Json
+  Assert ($status.exists -eq $true) 'monitor status exists'
+  Assert ($status.run_count -eq 1) 'monitor status run_count'
+}
+
+function Test-BridgeSmokeWithoutNode([string]$cli) {
+  $mock = Start-Process -FilePath 'go' -ArgumentList @('run', '.', '--addr', "127.0.0.1:$MockMCPPort", '--key', 'mock-key') `
+    -WorkingDirectory (Join-Path $repoRoot 'harness\mock-mcp') -PassThru -NoNewWindow
+  try {
+    $ready = $false
+    for ($i = 0; $i -lt 100; $i++) {
+      try {
+        $response = Invoke-WebRequest -Uri "http://127.0.0.1:$MockMCPPort/mcp" -Method Get -SkipHttpErrorCheck -TimeoutSec 2
+        if ($response.StatusCode -gt 0) { $ready = $true; break }
+      } catch {
+        Start-Sleep -Milliseconds 300
+      }
+    }
+    Assert $ready 'mock MCP server became ready'
+
+    $savedPath = $env:PATH
+    $savedKey = $env:MEDIALYST_API_KEY
+    $savedURL = $env:NEWSJACK_MEDIALYST_MCP_URL
+    try {
+      # Prove the bridge needs no Node: strip node/npm dirs from PATH.
+      $env:PATH = Remove-PathEntries 'node|npm'
+      $env:MEDIALYST_API_KEY = 'mock-key'
+      $env:NEWSJACK_MEDIALYST_MCP_URL = "http://127.0.0.1:$MockMCPPort/mcp"
+      $messages = @(
+        '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"harness-smoke","version":"0"}}}'
+        '{"jsonrpc":"2.0","method":"notifications/initialized"}'
+        '{"jsonrpc":"2.0","id":2,"method":"tools/list"}'
+      )
+      $bridgeOut = $messages | & $cli mcp-bridge
+      if ($LASTEXITCODE -ne 0) { throw "mcp-bridge exited $LASTEXITCODE" }
+      $joined = $bridgeOut -join "`n"
+      Assert ($joined -match 'protocolVersion') 'bridge relayed the initialize result'
+      Assert ($joined -match 'mock_search') 'bridge relayed the SSE tool list'
+    } finally {
+      $env:PATH = $savedPath
+      $env:MEDIALYST_API_KEY = $savedKey
+      $env:NEWSJACK_MEDIALYST_MCP_URL = $savedURL
+    }
+  } finally {
+    if (-not $mock.HasExited) { Stop-Process -Id $mock.Id -Force }
+  }
+}
+
+function Test-AutoUpdateSwapsRunningExe([string]$cli, [string]$newsjackHome) {
+  # Stale the recorded version, run a user-facing command, and assert the
+  # binary updated itself in place: the one scenario only a real Windows
+  # machine can prove (a running exe swapping itself via the rename dance).
+  $stateFile = Join-Path $newsjackHome 'install.json'
+  $state = Get-Content -Raw $stateFile | ConvertFrom-Json
+  $liveVersion = $state.version
+  $state.version = 'v0.0.0-stale'
+  $state | ConvertTo-Json -Depth 8 | Set-Content -Path $stateFile -Encoding utf8
+  Set-Content -Path (Join-Path $newsjackHome 'newsjack\VERSION') -Value 'v0.0.0-stale' -Encoding utf8
+
+  $savedNoUpdate = $env:NEWSJACK_NO_AUTO_UPDATE
+  try {
+    $env:NEWSJACK_NO_AUTO_UPDATE = ''
+    $doctor = Invoke-CLI $cli @('doctor', '--json') | Out-String | ConvertFrom-Json
+    Assert ($doctor.root_ok -eq $true) 'doctor stdout stayed valid JSON through auto-update'
+  } finally {
+    $env:NEWSJACK_NO_AUTO_UPDATE = $savedNoUpdate
+  }
+
+  $restored = (Get-Content -Raw (Join-Path $newsjackHome 'newsjack\VERSION')).Trim()
+  Assert ($restored -eq $liveVersion) "auto-update restored VERSION ($restored vs $liveVersion)"
+  $parked = "$cli.old"
+  Assert (Test-Path $parked) 'auto-update parked the previous exe at .old'
+
+  # The parked exe unlocks once the pre-update process exits; the next run
+  # cleans it up. Allow a few attempts for the file handle to release.
+  $cleaned = $false
+  for ($i = 0; $i -lt 10; $i++) {
+    Invoke-CLI $cli @('version') | Out-Null
+    if (-not (Test-Path $parked)) { $cleaned = $true; break }
+    Start-Sleep -Milliseconds 500
+  }
+  Assert $cleaned 'next run removed the parked .old binary'
+}
+
+function Invoke-BootstrapLeg {
+  param(
+    [string]$LegName,
+    [string]$NewsjackHome,
+    [switch]$StripGit,
+    [switch]$FullBattery
+  )
+  Log "leg: $LegName (NEWSJACK_HOME=$NewsjackHome)"
+  $scratch = New-ScratchHome "newsjack-$LegName-scratch"
+  $bareExe = Join-Path $scratch 'newsjack.exe'
+  Copy-Item (Join-Path $DistDir 'newsjack_windows_amd64.exe') $bareExe
+
+  $saved = @{
+    PATH                    = $env:PATH
+    NEWSJACK_HOME           = $env:NEWSJACK_HOME
+    NEWSJACK_RELEASE_BASE   = $env:NEWSJACK_RELEASE_BASE
+    NEWSJACK_RUNTIMES       = $env:NEWSJACK_RUNTIMES
+    NEWSJACK_INSTALL_MCP    = $env:NEWSJACK_INSTALL_MCP
+    NEWSJACK_NO_AUTO_UPDATE = $env:NEWSJACK_NO_AUTO_UPDATE
+    USERPROFILE             = $env:USERPROFILE
+  }
+  try {
+    if ($StripGit) { $env:PATH = Remove-PathEntries 'git' }
+    $env:NEWSJACK_HOME = $NewsjackHome
+    $env:NEWSJACK_RELEASE_BASE = "http://127.0.0.1:$ServePort"
+    $env:NEWSJACK_RUNTIMES = 'claude'
+    $env:NEWSJACK_INSTALL_MCP = '0'
+    $env:NEWSJACK_NO_AUTO_UPDATE = '1'
+    $env:USERPROFILE = $scratch
+
+    Invoke-CLI $bareExe @('setup', '--json') | Out-Null
+    $installedCli = Join-Path $NewsjackHome 'bin\newsjack.exe'
+    Assert (Test-Path $installedCli) 'bootstrap installed the managed CLI binary'
+    Assert (Test-Path (Join-Path $NewsjackHome 'newsjack\VERSION')) 'bootstrap installed the bundle'
+    Assert (Test-Path (Join-Path $NewsjackHome 'install.json')) 'bootstrap wrote install state'
+
+    $version = Invoke-CLI $installedCli @('version') | Out-String
+    Log "installed version: $($version.Trim())"
+
+    Test-SetupAndDoctor $installedCli
+    Test-SkillsInstalled $scratch
+    if ($FullBattery) {
+      Test-MockDetector $installedCli
+      Test-MonitorLifecycle $installedCli $scratch
+      Test-BridgeSmokeWithoutNode $installedCli
+      Test-AutoUpdateSwapsRunningExe $installedCli $NewsjackHome
+    }
+    Log "leg passed: $LegName"
+  } finally {
+    foreach ($key in $saved.Keys) {
+      Set-Item -Path "env:$key" -Value $saved[$key]
+    }
+  }
+}
+
+Log "serving release dist from $DistDir on port $ServePort"
+$server = Start-Process -FilePath 'python' -ArgumentList @('-m', 'http.server', "$ServePort", '--directory', "$DistDir") -PassThru -NoNewWindow
+try {
+  $ready = $false
+  for ($i = 0; $i -lt 50; $i++) {
+    try {
+      Invoke-WebRequest -Uri "http://127.0.0.1:$ServePort/checksums.txt" -TimeoutSec 2 | Out-Null
+      $ready = $true
+      break
+    } catch {
+      Start-Sleep -Milliseconds 300
+    }
+  }
+  Assert $ready 'release dist server became ready'
+
+  # Leg 1: full battery in a plain temp home.
+  Invoke-BootstrapLeg -LegName 'managed' -NewsjackHome (Join-Path (New-ScratchHome 'newsjack-managed-home') '.newsjack') -FullBattery
+
+  # Leg 2: no git on PATH — install/setup must not silently shell out.
+  Invoke-BootstrapLeg -LegName 'no-git' -NewsjackHome (Join-Path (New-ScratchHome 'newsjack-nogit-home') '.newsjack') -StripGit
+
+  # Leg 3: spaces in the profile path — the classic Windows installer bug.
+  $spacedBase = New-ScratchHome 'newsjack spaced home'
+  Invoke-BootstrapLeg -LegName 'spaced-profile' -NewsjackHome (Join-Path $spacedBase 'jane smith\.newsjack')
+
+  Log 'windows installer battery complete'
+} finally {
+  if (-not $server.HasExited) { Stop-Process -Id $server.Id -Force }
+}

--- a/harness/scripts/run-ci-installer.ps1
+++ b/harness/scripts/run-ci-installer.ps1
@@ -220,6 +220,7 @@ function Invoke-BootstrapLeg {
     NEWSJACK_INSTALL_MCP    = $env:NEWSJACK_INSTALL_MCP
     NEWSJACK_NO_AUTO_UPDATE = $env:NEWSJACK_NO_AUTO_UPDATE
     USERPROFILE             = $env:USERPROFILE
+    HOME                    = $env:HOME
   }
   # Run from the scratch dir, not the repo checkout: inside the repo,
   # newsjackRoot() resolves to the source tree and setup never bootstraps
@@ -232,7 +233,10 @@ function Invoke-BootstrapLeg {
     $env:NEWSJACK_RUNTIMES = 'claude'
     $env:NEWSJACK_INSTALL_MCP = '0'
     $env:NEWSJACK_NO_AUTO_UPDATE = '1'
+    # The Go CLI's homeDir() prefers HOME over USERPROFILE; set both so the
+    # leg stays isolated even on runners that define HOME.
     $env:USERPROFILE = $scratch
+    $env:HOME = $scratch
 
     Invoke-CLI $bareExe @('setup', '--json') | Out-Null
     $installedCli = Join-Path $NewsjackHome 'bin\newsjack.exe'

--- a/harness/scripts/run-ci-installer.ps1
+++ b/harness/scripts/run-ci-installer.ps1
@@ -221,6 +221,10 @@ function Invoke-BootstrapLeg {
     NEWSJACK_NO_AUTO_UPDATE = $env:NEWSJACK_NO_AUTO_UPDATE
     USERPROFILE             = $env:USERPROFILE
   }
+  # Run from the scratch dir, not the repo checkout: inside the repo,
+  # newsjackRoot() resolves to the source tree and setup never bootstraps
+  # (the same reason the Linux battery does `cd /tmp` before its checks).
+  Push-Location $scratch
   try {
     if ($StripGit) { $env:PATH = Remove-PathEntries 'git' }
     $env:NEWSJACK_HOME = $NewsjackHome
@@ -249,6 +253,7 @@ function Invoke-BootstrapLeg {
     }
     Log "leg passed: $LegName"
   } finally {
+    Pop-Location
     foreach ($key in $saved.Keys) {
       Set-Item -Path "env:$key" -Value $saved[$key]
     }

--- a/harness/scripts/run-ci-installer.sh
+++ b/harness/scripts/run-ci-installer.sh
@@ -224,7 +224,33 @@ newsjack version
 newsjack setup --json | tee /tmp/newsjack-setup.json
 jq -e '.monitors_dir and .agent_prompt and .recommended_runtime and .recommended_scheduler and .agent_command' /tmp/newsjack-setup.json >/dev/null
 newsjack doctor --json | tee /tmp/newsjack-doctor.json
-jq -e '.root_ok == true and .dependencies.npx == true' /tmp/newsjack-doctor.json >/dev/null
+jq -e '.root_ok == true and .mcp_bridge.transport == "native"' /tmp/newsjack-doctor.json >/dev/null
+
+log "running native MCP bridge smoke against mock server"
+(cd /repo/harness/mock-mcp && exec go run . --addr 127.0.0.1:8970 --key mock-key) &
+mock_mcp_pid=$!
+trap 'kill "$mock_mcp_pid" 2>/dev/null || true' EXIT
+for _ in $(seq 1 50); do
+  status="$(curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:8970/mcp || true)"
+  if [ -n "$status" ] && [ "$status" != "000" ]; then
+    break
+  fi
+  sleep 0.2
+done
+
+# Restrict PATH so the smoke proves the bridge needs no Node/npx on the
+# machine; only the installed CLI and core utilities stay visible.
+printf '%s\n' \
+  '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"harness-smoke","version":"0"}}}' \
+  '{"jsonrpc":"2.0","method":"notifications/initialized"}' \
+  '{"jsonrpc":"2.0","id":2,"method":"tools/list"}' | \
+  env PATH="$HOME/.newsjack/bin:/usr/bin:/bin" \
+    MEDIALYST_API_KEY=mock-key \
+    NEWSJACK_MEDIALYST_MCP_URL=http://127.0.0.1:8970/mcp \
+    "$HOME/.newsjack/bin/newsjack" mcp-bridge > /tmp/newsjack-bridge.out
+grep -q '"protocolVersion"' /tmp/newsjack-bridge.out
+grep -q 'mock_search' /tmp/newsjack-bridge.out
+kill "$mock_mcp_pid" 2>/dev/null || true
 
 log "checking installed runtime skills"
 mapfile -t skill_dirs < <(selected_skill_dirs)

--- a/scripts/build-release-dist.mjs
+++ b/scripts/build-release-dist.mjs
@@ -25,6 +25,7 @@ const targets = [
   ["darwin", "arm64"],
   ["linux", "amd64"],
   ["linux", "arm64"],
+  ["windows", "amd64"],
 ];
 
 function run(command, args, options = {}) {
@@ -175,7 +176,8 @@ function packageTarget({ os, arch }) {
   );
   const payloadRoot = join(workRoot, "payload");
   const binRoot = join(payloadRoot, "bin");
-  const binary = join(binRoot, "newsjack");
+  const binaryName = os === "windows" ? "newsjack.exe" : "newsjack";
+  const binary = join(binRoot, binaryName);
   const artifact = `newsjack_${os}_${arch}.tar.gz`;
   const artifactPath = join(outRoot, artifact);
 
@@ -218,15 +220,31 @@ function packageTarget({ os, arch }) {
   });
   const sha256 = sha256File(artifactPath);
   const size = statSync(artifactPath).size;
+
+  const artifacts = [{ name: artifact, os, arch, sha256, size }];
+  if (os === "windows") {
+    // Windows has no `curl | sh` channel: users download one bare exe and
+    // run `newsjack setup`, which bootstraps the bundle itself.
+    const bareName = `newsjack_${os}_${arch}.exe`;
+    const barePath = join(outRoot, bareName);
+    cpSync(binary, barePath);
+    artifacts.push({
+      name: bareName,
+      os,
+      arch,
+      sha256: sha256File(barePath),
+      size: statSync(barePath).size,
+    });
+  }
   rmSync(workRoot, { recursive: true, force: true });
 
-  return { name: artifact, os, arch, sha256, size };
+  return artifacts;
 }
 
 rmSync(outRoot, { recursive: true, force: true });
 mkdirSync(outRoot, { recursive: true });
 
-const artifacts = targets.map(([os, arch]) => packageTarget({ os, arch }));
+const artifacts = targets.flatMap(([os, arch]) => packageTarget({ os, arch }));
 const manifest = {
   version,
   commit,


### PR DESCRIPTION
## What this does

Adds first-class Windows support with **zero prerequisites** — no install script, no Node, no git. A Windows user downloads one `newsjack.exe`, runs `newsjack setup`, and gets the full install.

### Product changes

- **Go-native MCP bridge** (`mcp_bridge.go`): `newsjack mcp-bridge` now speaks streamable HTTP to Medialyst directly — stdio JSON-RPC proxy with bearer auth, session tracking, and SSE responses — replacing `npx -y mcp-remote`. This removes the Node dependency on **every** platform. The API key still loads at runtime from `credentials.json`/env, never landing in harness config. `NEWSJACK_MEDIALYST_MCP_URL` overrides the endpoint for testing.
- **Native bundle-apply + bootstrap** (`bundle.go`): `newsjack setup` on a bare binary downloads the platform release bundle, verifies its sha256 against `checksums.txt`, unpacks it (pure Go tar/gzip with traversal guards and `.env` stripping), installs the running exe to `~/.newsjack/bin`, writes `install.json`, and runs the regular skills/MCP install. Source checkouts, `NEWSJACK_ROOT` overrides, and npm installs never trigger a download.
- **Native self-update** (`update.go`): Windows always updates in-process — rename-dance exe swap (`.old` parking, next-run cleanup) since a running exe can't be overwritten. Other platforms keep the hosted `curl | sh` updater by default; `NEWSJACK_NATIVE_UPDATE=1` opts in.
- **Per-OS plumbing**: `newsjack.exe` binary naming throughout, PowerShell-wrapped runtime installs, Claude Code's native Windows installer (`irm https://claude.ai/install.ps1 | iex`) in the setup wizard, per-OS reinstall hints in doctor.

### Release pipeline

- `build-release-dist.mjs` adds the `windows/amd64` bundle plus a bare `newsjack_windows_amd64.exe` asset with checksums. `release.yml` uploads the dist wholesale, so the Windows assets publish automatically.
- Verified compatible with the just-merged npm auto-release pipeline (`build-npm-packages.mjs` + `verify-npm-packages.mjs` run clean on this branch).

### Test harness (per docs/2026-06-11-windows-support-test-plan.md)

- **CI**: `windows-latest` unit-test leg, cross-compile gates (windows/darwin/linux) on every PR, and a Windows bootstrap battery (`harness/scripts/run-ci-installer.ps1`) mirroring the Linux container battery: bootstrap → doctor → skills → mock detector → monitor lifecycle, plus a **no-Node bridge smoke** against `harness/mock-mcp`, a **no-git leg**, a **spaces-in-profile leg**, and the **auto-update exe swap** test.
- **Post-release**: new `windows-install` job downloads the released exe, verifies its checksum, bootstraps, and runs a mock detector — the literal customer flow.
- **Manual dispatch**: `agent-harness-integration.yml` gains `os: windows` — installs real Claude Code natively, asserts the Medialyst MCP registration, and (with the `MEDIALYST_API_KEY` secret) runs a live bridge handshake.
- **Linux protection**: the existing battery is unchanged except its `dependencies.npx` doctor assertion, which flips to a native-bridge smoke. The bridge rewrite is the only shared-behavior change.

### Verified locally (macOS)

- Full `go test ./...` green; bridge contract tests (7), bundle/bootstrap tests (7), native-update tests (4) all pass.
- End-to-end rehearsals of the exact Windows flow: bare binary + `setup --json` against a locally served dist (bundle fetch → checksum → skills → mock detector via the installed binary), and a native auto-update from a staled install (stderr shows `auto-updating`, stdout stays valid JSON, VERSION restored).
- Real binary driven through `harness/mock-mcp` over stdio: initialize (JSON) + tools/list (SSE) round trip, exit 0.

### Not verified here (needs the CI run on this PR)

- The `windows-latest` jobs themselves (no Windows machine locally; `run-ci-installer.ps1` could not be parse-checked without pwsh).
- The live Medialyst gate (`run-live-medialyst-mcp.sh`, all runtimes) should run once before merge — it spends credits, so it stays manual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Windows native standalone installer, native self-update, and an in-process MCP bridge for native JSON‑RPC relay.

* **Bug Fixes / UX**
  * CLI installer/setup and diagnostics now report native bridge details and use platform-appropriate installer/update commands; JSON output for setup/doctor improved for machine consumption.

* **Tests**
  * Expanded Windows CI battery and broad MCP bridge, installer/bootstrap, and native-update test suites.

* **Chores / CI**
  * Workflows updated to run Linux+Windows, cross-compile gates, produce Windows artifacts, and added Windows validation harnesses.

* **Documentation**
  * Added Windows support test plan, release playbook updates, and harness README guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Manual verification needed (only what CI and I can't do)

Everything scriptable has already been verified: local bare-binary bootstrap, native auto-update, and no-Node bridge rehearsals all ran clean on this branch, and CI covers them permanently (Windows unit tests, the Windows bootstrap battery, the Linux harness with the bridge smoke, and the post-release Windows job). What's left needs a human:

1. ~~Live Medialyst gate~~ ✅ **DONE (2026-06-12, with approval):** the Go bridge was driven against production Medialyst with real credentials — initialize handshake, tools/list (13 tools), `get_credit_balance`, a live `search_news` query returning real articles, and the JSON-RPC error relay (invalid-arg round trip). A live run on a real Windows runner with real Claude Code was also dispatched via `agent-harness-integration.yml os=windows`. Original instructions for re-running:
   ```bash
   harness/scripts/build-image.sh --harness all
   harness/scripts/run-live-medialyst-mcp.sh --image newsjack-agent-harness:all --with-local-env
   ```
   This is the only end-to-end test of the new Go bridge against the real Medialyst endpoint with real credentials, replacing what `npx mcp-remote` did in production.

2. **Publish a prerelease (after merge):** `git tag v0.1.X-rc.1 && git push origin v0.1.X-rc.1`. Confirm the release has **10 assets** including `newsjack_windows_amd64.exe` + `newsjack_windows_amd64.tar.gz` and that both appear in `checksums.txt`. Then `gh workflow run post-release-smoke.yml -f version=v0.1.X-rc.1` (its new Windows job does the rest automatically).

3. **One real Windows machine pass (per release, ~10 min):**
   - Download `newsjack_windows_amd64.exe` from the release page in a browser — note the SmartScreen warning ("More info → Run anyway"); expected until code signing, but verify the wording/path so we can document it for customers.
   - In PowerShell: `.\newsjack_windows_amd64.exe setup` — the interactive prompt flow in Windows Terminal (selection UX, colors, the Claude Code handoff) is the one thing no CI run can see.
   - Confirm no git/Node install prompts appear anywhere in the flow.

4. **Optional:** add the `MEDIALYST_API_KEY` repo secret so `gh workflow run agent-harness-integration.yml -f os=windows` also exercises a live bridge handshake on a Windows runner with real Claude Code installed.

