### PR TITLE
ci: fix Windows post-release smoke checksum read against real GitHub releases

### DIFF
--- a/.github/workflows/post-release-smoke.yml
+++ b/.github/workflows/post-release-smoke.yml
@@ -110,8 +110,11 @@ jobs:
           Invoke-WebRequest -Uri "$base/newsjack_windows_amd64.exe" -OutFile $exe
 
           # Verify the download against the published checksums, exactly as a
-          # careful user would.
-          $checksums = (Invoke-WebRequest -Uri "$base/checksums.txt").Content
+          # careful user would. Download to a file: GitHub serves the asset as
+          # octet-stream, so .Content would be a byte array, not a string.
+          $checksumsFile = Join-Path $scratch 'checksums.txt'
+          Invoke-WebRequest -Uri "$base/checksums.txt" -OutFile $checksumsFile
+          $checksums = Get-Content -Raw $checksumsFile
           $line = ($checksums -split "`n") | Where-Object { $_ -match 'newsjack_windows_amd64\.exe' } | Select-Object -First 1
           if (-not $line) { throw 'checksums.txt has no entry for newsjack_windows_amd64.exe' }
           $expected = ($line -split '\s+')[0].ToLower()


### PR DESCRIPTION
GitHub serves release assets as `application/octet-stream`, so `Invoke-WebRequest`'s `.Content` is a byte array in pwsh and the checksum line-match silently failed. Download to a file and `Get-Content -Raw` instead.

Verified: post-release smoke dispatched from this branch against the real `v0.1.10-rc.1` release is fully green — all three jobs including the Windows bare-exe bootstrap (download → checksum verify → bootstrap → mock detector): https://github.com/elvisun/newsjack/actions/runs/27394442932

(The PR-battery never hit this because its local python server serves text/plain.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal release workflow to improve checksum verification reliability on Windows systems.

---

**Note:** This release contains no user-facing changes. The update addresses internal infrastructure processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->