### PR TITLE
Windows install docs in README + npm verify retry

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -184,7 +184,19 @@ jobs:
             newsjack
           )
 
+          # The registry can lag publish by ~15-30s; retry instead of
+          # reporting a false-red release.
           for package in "${packages[@]}"; do
-            published="$(npm view "${package}@${NPM_VERSION}" version --registry https://registry.npmjs.org)"
-            test "$published" = "$NPM_VERSION"
+            for attempt in 1 2 3 4 5 6; do
+              published="$(npm view "${package}@${NPM_VERSION}" version --registry https://registry.npmjs.org 2>/dev/null || true)"
+              if [ "$published" = "$NPM_VERSION" ]; then
+                break
+              fi
+              if [ "$attempt" = "6" ]; then
+                echo "::error title=Not visible on npm::${package}@${NPM_VERSION} not visible after $attempt attempts"
+                exit 1
+              fi
+              sleep 10
+            done
+            echo "verified ${package}@${NPM_VERSION}"
           done

--- a/README.md
+++ b/README.md
@@ -100,6 +100,21 @@ newsjack install
 
 After install, agents and skills should call the CLI as `newsjack`.
 
+### Windows
+
+No script, no git, no Node. One PowerShell line downloads the CLI and runs
+setup (requires v0.1.10 or later):
+
+```powershell
+iwr https://github.com/elvisun/newsjack/releases/latest/download/newsjack_windows_amd64.exe -OutFile newsjack.exe; Unblock-File newsjack.exe; .\newsjack.exe setup
+```
+
+`newsjack setup` downloads the skills bundle, verifies its checksum, installs
+the CLI to `%USERPROFILE%\.newsjack\bin`, and walks you through the same
+guided setup as macOS/Linux — including installing Claude Code through its
+own native Windows installer if you don't have it yet. Updates are automatic,
+same as the curl install.
+
 ### Limited mode: Running on Claude.ai, ChatGPT, Claude Cowork
 
 Newsjack needs a local agent for Full Mode. On Claude.ai, ChatGPT, or Claude


### PR DESCRIPTION
Two follow-ups from the v0.1.10-rc.1 prerelease:

- **README**: adds the Windows install section with the PowerShell one-liner (`iwr … ; Unblock-File … ; .\newsjack.exe setup`) — until now the Windows path was only documented in the release playbook, invisible to customers and their agents. Noted as requiring v0.1.10+, so it becomes accurate the moment the stable tag ships.
- **npm-release.yml**: the verify step now retries for up to a minute instead of failing on npm's ~15-30s registry propagation lag, which produced a false-red run on the rc despite all 5 packages publishing fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added Windows installation instructions with PowerShell-based one-line setup and automatic CLI installation
  
* **Chores**
  * Improved npm release workflow with automatic retry logic for package version verification, enhancing publication reliability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->