### PR TITLE
Windows friction fixes from the first real-machine install test

### DIFF
--- a/.github/workflows/agent-harness-integration.yml
+++ b/.github/workflows/agent-harness-integration.yml
@@ -148,6 +148,7 @@ jobs:
             $env:NEWSJACK_RUNTIMES = 'claude'
             $env:NEWSJACK_INSTALL_MCP = '1'
             $env:NEWSJACK_NO_AUTO_UPDATE = '1'
+            $env:NEWSJACK_NO_PATH_UPDATE = '1'
 
             & $exe setup --json | Out-Null
             if ($LASTEXITCODE -ne 0) { throw "newsjack setup failed: $LASTEXITCODE" }

--- a/.github/workflows/post-release-smoke.yml
+++ b/.github/workflows/post-release-smoke.yml
@@ -127,6 +127,7 @@ jobs:
           $env:NEWSJACK_RUNTIMES = 'claude'
           $env:NEWSJACK_INSTALL_MCP = '0'
           $env:NEWSJACK_NO_AUTO_UPDATE = '1'
+          $env:NEWSJACK_NO_PATH_UPDATE = '1'
 
           & $exe setup --json | Out-Null
           if ($LASTEXITCODE -ne 0) { throw "newsjack setup failed: $LASTEXITCODE" }

--- a/README.md
+++ b/README.md
@@ -106,8 +106,11 @@ No script, no git, no Node. One PowerShell line downloads the CLI and runs
 setup (requires v0.1.10 or later):
 
 ```powershell
-iwr https://github.com/elvisun/newsjack/releases/latest/download/newsjack_windows_amd64.exe -OutFile newsjack.exe; Unblock-File newsjack.exe; .\newsjack.exe setup
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; iwr https://github.com/elvisun/newsjack/releases/latest/download/newsjack_windows_amd64.exe -OutFile newsjack.exe; Unblock-File newsjack.exe; .\newsjack.exe setup
 ```
+
+The TLS line makes the download work on stock Windows PowerShell 5.1 (it's a
+no-op on PowerShell 7).
 
 `newsjack setup` downloads the skills bundle, verifies its checksum, installs
 the CLI to `%USERPROFILE%\.newsjack\bin`, and walks you through the same

--- a/apps/cli/cmd/newsjack/bundle.go
+++ b/apps/cli/cmd/newsjack/bundle.go
@@ -12,8 +12,10 @@ import (
 	"io/fs"
 	"net/http"
 	"os"
+	"os/exec"
 	"path"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 	"time"
@@ -45,7 +47,7 @@ func releaseArtifactName() string {
 // git is required on the machine. runtimeSelection comes from setup's
 // --runtime flag; NEWSJACK_RUNTIMES still wins when set.
 func bootstrapInstall(runtimeSelection string, stdout, stderr io.Writer) error {
-	base := releaseBaseForUpdate()
+	base := releaseBaseForBootstrap()
 	logf(stderr, "newsjack is not installed yet; fetching the release bundle from %s", base)
 	version, err := applyReleaseBundle(base, stderr)
 	if err != nil {
@@ -67,6 +69,7 @@ func finalizeBootstrap(version, runtimeSelection string, stdout, stderr io.Write
 	if err := writeInstallStateFile(bootstrapInstallState(version, runtimeSelection)); err != nil {
 		return err
 	}
+	maybeAddWindowsUserPath(stderr)
 	if os.Getenv("NEWSJACK_INSTALL_SKILLS") == "0" {
 		successf(stdout, "installed newsjack %s (runtime skill install skipped: NEWSJACK_INSTALL_SKILLS=0)", version)
 		return nil
@@ -126,6 +129,36 @@ func ensureInstalledRoot(runtimeSelection string, stdout, stderr io.Writer) erro
 		return finalizeBootstrap(readTrimmedFile(filepath.Join(root, "VERSION")), runtimeSelection, stdout, stderr)
 	}
 	return bootstrapInstall(runtimeSelection, stdout, stderr)
+}
+
+// releaseBaseForBootstrap picks where a bare binary fetches its bundle.
+// Unlike update (which wants latest), first install must use the bundle
+// matching the running binary: a prerelease exe pointed at `latest` would
+// fail whenever latest does not carry this platform yet, and a stale exe
+// must not install a mismatched newer bundle. Overrides:
+// NEWSJACK_RELEASE_BASE (full URL) and NEWSJACK_VERSION (tag).
+func releaseBaseForBootstrap() string {
+	if base := strings.TrimSpace(os.Getenv("NEWSJACK_RELEASE_BASE")); base != "" {
+		return strings.TrimRight(base, "/")
+	}
+	state := readInstallStateOrDefault()
+	repo := strings.TrimSpace(getenv("NEWSJACK_REPO", state.Repo))
+	if repo == "" {
+		repo = defaultRepo
+	}
+	tag := strings.TrimSpace(getenv("NEWSJACK_VERSION", version))
+	if isReleaseTag(tag) {
+		return "https://github.com/" + repo + "/releases/download/" + tag
+	}
+	return "https://github.com/" + repo + "/releases/latest/download"
+}
+
+var releaseTagPattern = regexp.MustCompile(`^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z.-]*)?$`)
+
+// isReleaseTag reports whether a version string names a published release
+// tag. Dev builds (v0.1.0-dev, v0.1.0-dev+commit) fall back to latest.
+func isReleaseTag(tag string) bool {
+	return releaseTagPattern.MatchString(tag) && !strings.Contains(tag, "dev")
 }
 
 // applyReleaseBundle downloads, verifies, unpacks, and atomically swaps in
@@ -285,6 +318,170 @@ func untarGz(data []byte, dest string) error {
 			continue
 		}
 	}
+}
+
+// adoptBundle copies a prebuilt source bundle into the managed install
+// root and finishes the managed layout (binary + install state), so a
+// manually downloaded bundle given to `install --source` behaves exactly
+// like a bootstrap install: doctor is clean, update works, and the MCP
+// bridge command points at a binary that exists.
+func adoptBundle(source, runtimeSelection string, stderr io.Writer) error {
+	if err := os.MkdirAll(newsjackHome(), 0o755); err != nil {
+		return err
+	}
+	staging := managedInstallDir() + ".new"
+	if err := os.RemoveAll(staging); err != nil {
+		return err
+	}
+	if err := copyDirTree(source, staging); err != nil {
+		_ = os.RemoveAll(staging)
+		return err
+	}
+	if err := validateBundleLayout(staging); err != nil {
+		_ = os.RemoveAll(staging)
+		return err
+	}
+	if err := swapInstallDir(staging); err != nil {
+		return err
+	}
+	if err := updateInstalledBinaryFromBundle(); err != nil {
+		return err
+	}
+	bundleVersion := readTrimmedFile(filepath.Join(managedInstallDir(), "VERSION"))
+	if err := writeInstallStateFile(bootstrapInstallState(bundleVersion, runtimeSelection)); err != nil {
+		return err
+	}
+	maybeAddWindowsUserPath(stderr)
+	return nil
+}
+
+// shouldAdoptBundle reports whether an `install --source` target is a
+// prebuilt bundle that should be promoted into the managed root. The
+// installer scripts pass the managed root itself (no-op), and source
+// checkouts have no prebuilt marker.
+func shouldAdoptBundle(source string) bool {
+	if npmDistribution() {
+		return false
+	}
+	if !fileExists(filepath.Join(source, ".newsjack-prebuilt")) {
+		return false
+	}
+	if samePath(source, managedInstallDir()) {
+		return false
+	}
+	return !dirExists(managedInstallDir()) || !fileExists(installedBinaryPath()) || !fileExists(installStatePath())
+}
+
+// copyDirTree mirrors a bundle directory, preserving file modes and
+// stripping env files exactly like untarGz.
+func copyDirTree(src, dest string) error {
+	return filepath.WalkDir(src, func(walkPath string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(src, walkPath)
+		if err != nil {
+			return err
+		}
+		if rel == "." {
+			return os.MkdirAll(dest, 0o755)
+		}
+		base := filepath.Base(rel)
+		if !d.IsDir() && (base == ".env" || strings.HasPrefix(base, ".env.")) && base != ".env.example" {
+			return nil
+		}
+		target := filepath.Join(dest, rel)
+		if d.IsDir() {
+			return os.MkdirAll(target, 0o755)
+		}
+		data, err := os.ReadFile(walkPath)
+		if err != nil {
+			return err
+		}
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		mode := info.Mode() & 0o777
+		if mode == 0 {
+			mode = 0o644
+		}
+		return os.WriteFile(target, data, mode)
+	})
+}
+
+// maybeAddWindowsUserPath appends the managed bin dir to the per-user
+// Path registry value so new shells can run `newsjack` directly. The
+// shell installers handle PATH on Unix; the bare-exe flow must do it
+// itself. Best-effort: a failure only prints the manual step. Opt out
+// with NEWSJACK_NO_PATH_UPDATE=1.
+func maybeAddWindowsUserPath(stderr io.Writer) {
+	if goos() != "windows" || os.Getenv("NEWSJACK_NO_PATH_UPDATE") == "1" {
+		return
+	}
+	binDir := filepath.Dir(installedBinaryPath())
+	current := readWindowsUserPath()
+	if pathListContains(current, binDir) {
+		return
+	}
+	updated := binDir
+	if strings.TrimSpace(current) != "" {
+		updated = strings.TrimRight(current, ";") + ";" + binDir
+	}
+	// reg.exe instead of setx: setx truncates Path values at 1024 chars.
+	cmd := exec.Command("reg", "add", `HKCU\Environment`, "/v", "Path", "/t", "REG_EXPAND_SZ", "/d", updated, "/f")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		warn(stderr, "could not add %s to your user PATH (%s); add it manually for new shells", binDir, strings.TrimSpace(string(out)))
+		return
+	}
+	logf(stderr, "added %s to your user PATH; open a new terminal to run `newsjack` directly", binDir)
+}
+
+func readWindowsUserPath() string {
+	out, err := exec.Command("reg", "query", `HKCU\Environment`, "/v", "Path").Output()
+	if err != nil {
+		return ""
+	}
+	return parseRegQueryValue(string(out))
+}
+
+// parseRegQueryValue extracts the data column from `reg query /v Path`:
+//
+//	HKEY_CURRENT_USER\Environment
+//	    Path    REG_EXPAND_SZ    C:\foo;C:\bar
+//
+// Internal spacing in the value is preserved.
+func parseRegQueryValue(out string) string {
+	for _, line := range strings.Split(out, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(strings.ToLower(trimmed), "path") {
+			continue
+		}
+		typeIdx := strings.Index(trimmed, "REG_")
+		if typeIdx < 0 {
+			continue
+		}
+		rest := trimmed[typeIdx:]
+		valueIdx := strings.IndexAny(rest, " \t")
+		if valueIdx < 0 {
+			continue
+		}
+		return strings.TrimSpace(rest[valueIdx:])
+	}
+	return ""
+}
+
+func pathListContains(list, dir string) bool {
+	normalize := func(entry string) string {
+		return strings.ToLower(strings.TrimRight(strings.TrimSpace(entry), `\`))
+	}
+	want := normalize(dir)
+	for _, entry := range strings.Split(list, ";") {
+		if entry != "" && normalize(entry) == want {
+			return true
+		}
+	}
+	return false
 }
 
 // updateInstalledBinaryFromBundle replaces the managed CLI binary with the

--- a/apps/cli/cmd/newsjack/install.go
+++ b/apps/cli/cmd/newsjack/install.go
@@ -83,12 +83,67 @@ func runtimeDetected(rt runtimeTarget) bool {
 	return runtimeCLIInstalled(rt)
 }
 
-func runtimeCLIInstalled(rt runtimeTarget) bool {
-	if rt.Binary == "" {
-		return false
+func runtimeByKey(key string) (runtimeTarget, bool) {
+	for _, rt := range runtimeTargets {
+		if rt.Key == key {
+			return rt, true
+		}
 	}
-	_, err := exec.LookPath(rt.Binary)
-	return err == nil
+	return runtimeTarget{}, false
+}
+
+func runtimeCLIInstalled(rt runtimeTarget) bool {
+	_, ok := resolveRuntimeBinary(rt)
+	return ok
+}
+
+// resolveRuntimeBinary finds the runtime CLI. PATH wins; on Windows,
+// Claude Code's installers do not put `claude` on PATH, so its known
+// install locations are probed as a fallback.
+func resolveRuntimeBinary(rt runtimeTarget) (string, bool) {
+	if rt.Binary == "" {
+		return "", false
+	}
+	if path, err := exec.LookPath(rt.Binary); err == nil {
+		return path, true
+	}
+	if goos() == "windows" && rt.Key == "claude" {
+		if path := findWindowsClaudeBinary(os.Getenv("APPDATA"), homeDir()); path != "" {
+			return path, true
+		}
+	}
+	return "", false
+}
+
+// findWindowsClaudeBinary probes Claude Code's Windows install locations:
+// the native installer's %USERPROFILE%\.local\bin and the per-version
+// directories under %APPDATA%\Claude\claude-code.
+func findWindowsClaudeBinary(appData, home string) string {
+	if home != "" {
+		candidate := filepath.Join(home, ".local", "bin", "claude.exe")
+		if fileExists(candidate) {
+			return candidate
+		}
+	}
+	if appData == "" {
+		return ""
+	}
+	root := filepath.Join(appData, "Claude", "claude-code")
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return ""
+	}
+	// Version-named subdirectories; prefer the lexically newest.
+	for i := len(entries) - 1; i >= 0; i-- {
+		if !entries[i].IsDir() {
+			continue
+		}
+		candidate := filepath.Join(root, entries[i].Name(), "claude.exe")
+		if fileExists(candidate) {
+			return candidate
+		}
+	}
+	return ""
 }
 
 func selectedRuntimes(raw string) []runtimeTarget {
@@ -178,6 +233,14 @@ func cmdInstall(args []string, stdout, stderr io.Writer) int {
 		Repo:       getenv("NEWSJACK_REPO", defaultRepo),
 		Ref:        getenv("NEWSJACK_REF", defaultRef),
 	}
+	if shouldAdoptBundle(opts.Source) {
+		logf(stdout, "adopting bundle %s into %s", opts.Source, managedInstallDir())
+		if err := adoptBundle(opts.Source, opts.Runtimes, stderr); err != nil {
+			return fail(stderr, err)
+		}
+		opts.Source = managedInstallDir()
+		opts.CLI = newsjackCLIInvocation()
+	}
 	if err := installRuntimeSkills(opts, stdout, stderr); err != nil {
 		return fail(stderr, err)
 	}
@@ -198,7 +261,7 @@ func installRuntimeSkills(opts installOptions, stdout, stderr io.Writer) error {
 	}
 	targets := selectedRuntimes(opts.Runtimes)
 	if len(targets) == 0 && !strings.Contains(","+strings.Join(normalizeRuntimeList(opts.Runtimes), ",")+",", ",none,") {
-		warn(stderr, "no supported runtime detected; installing portable skills into %s", filepath.Join(homeDir(), ".agents", "skills"))
+		warn(stderr, "no supported runtime detected; installing portable skills into %s — note Claude Code reads %s, so run `newsjack install --runtimes claude` to target it explicitly", filepath.Join(homeDir(), ".agents", "skills"), filepath.Join(homeDir(), ".claude", "skills"))
 		targets = []runtimeTarget{{Key: "portable", Label: "portable Agent Skills"}}
 	}
 	for _, rt := range targets {

--- a/apps/cli/cmd/newsjack/mcp.go
+++ b/apps/cli/cmd/newsjack/mcp.go
@@ -44,8 +44,26 @@ func configureCodexMCP(cli commandInvocation, stdout, stderr io.Writer) error {
 	args := append([]string{"mcp", "add", "medialyst", "--", cli.Command}, cli.With("mcp-bridge")...)
 	cmd := exec.Command("codex", args...)
 	cmd.Stdin = nil
-	if out, err := cmd.CombinedOutput(); err != nil {
-		warn(stderr, "Codex MCP server 'medialyst' may already exist; leaving existing config in place: %s", strings.TrimSpace(string(out)))
+	out, err := cmd.CombinedOutput()
+	if err != nil && strings.Contains(string(out), "already exists") {
+		// Same repair semantics as Claude Code: the entry is
+		// newsjack-managed, so a stale registration is rewritten.
+		remove := exec.Command("codex", "mcp", "remove", "medialyst")
+		remove.Stdin = nil
+		if removeOut, removeErr := remove.CombinedOutput(); removeErr != nil {
+			warn(stderr, "could not refresh existing Codex MCP server 'medialyst': %s", strings.TrimSpace(string(removeOut)))
+			return nil
+		}
+		cmd = exec.Command("codex", args...)
+		cmd.Stdin = nil
+		out, err = cmd.CombinedOutput()
+		if err == nil {
+			logf(stdout, "refreshed Codex MCP server: medialyst")
+			return nil
+		}
+	}
+	if err != nil {
+		warn(stderr, "could not configure Codex MCP server 'medialyst': %s", strings.TrimSpace(string(out)))
 		return nil
 	}
 	logf(stdout, "configured Codex MCP server: medialyst")
@@ -53,15 +71,38 @@ func configureCodexMCP(cli commandInvocation, stdout, stderr io.Writer) error {
 }
 
 func configureClaudeMCP(cli commandInvocation, stdout, stderr io.Writer) error {
-	if _, err := exec.LookPath("claude"); err != nil {
+	claudeRT, _ := runtimeByKey("claude")
+	claude, ok := resolveRuntimeBinary(claudeRT)
+	if !ok {
 		return nil
 	}
 	payload := map[string]any{"type": "stdio", "command": cli.Command, "args": cli.With("mcp-bridge")}
 	data, _ := json.Marshal(payload)
-	cmd := exec.Command("claude", "mcp", "add-json", "--scope", "user", "medialyst", string(data))
+	addArgs := []string{"mcp", "add-json", "--scope", "user", "medialyst", string(data)}
+	cmd := exec.Command(claude, addArgs...)
 	cmd.Stdin = nil
-	if out, err := cmd.CombinedOutput(); err != nil {
-		warn(stderr, "Claude Code MCP server 'medialyst' may already exist; leaving existing config in place: %s", strings.TrimSpace(string(out)))
+	out, err := cmd.CombinedOutput()
+	if err != nil && strings.Contains(string(out), "already exists") {
+		// Repair, don't preserve: a stale entry (for example pointing at a
+		// binary path that no longer exists) leaves the MCP server
+		// permanently broken. The entry is newsjack-managed, so rewriting
+		// it with the current bridge command is always safe.
+		remove := exec.Command(claude, "mcp", "remove", "--scope", "user", "medialyst")
+		remove.Stdin = nil
+		if removeOut, removeErr := remove.CombinedOutput(); removeErr != nil {
+			warn(stderr, "could not refresh existing Claude Code MCP server 'medialyst': %s", strings.TrimSpace(string(removeOut)))
+			return nil
+		}
+		cmd = exec.Command(claude, addArgs...)
+		cmd.Stdin = nil
+		out, err = cmd.CombinedOutput()
+		if err == nil {
+			logf(stdout, "refreshed Claude Code MCP server: medialyst")
+			return nil
+		}
+	}
+	if err != nil {
+		warn(stderr, "could not configure Claude Code MCP server 'medialyst': %s", strings.TrimSpace(string(out)))
 		return nil
 	}
 	logf(stdout, "configured Claude Code MCP server: medialyst")

--- a/apps/cli/cmd/newsjack/monitor.go
+++ b/apps/cli/cmd/newsjack/monitor.go
@@ -459,11 +459,24 @@ func launchSetupAgent(runtime string, plan setupLaunchPlan, prompt string, stdin
 	if len(plan.args) == 0 {
 		return nil
 	}
-	if _, err := exec.LookPath(plan.args[0]); err != nil {
-		fmt.Fprintf(stdout, "%s is not on PATH. Run this command when it is available:\n%s\n", plan.args[0], setupAgentCommand(runtime, prompt))
-		printSetupContinuationPrompt(stdout, runtime, prompt)
-		return nil
+	// Resolve through the runtime prober so Windows Claude Code installs
+	// (which are not on PATH) still launch.
+	resolved := ""
+	if rt, ok := runtimeByKey(runtime); ok {
+		if path, found := resolveRuntimeBinary(rt); found && rt.Binary == plan.args[0] {
+			resolved = path
+		}
 	}
+	if resolved == "" {
+		path, err := exec.LookPath(plan.args[0])
+		if err != nil {
+			fmt.Fprintf(stdout, "%s is not on PATH. Run this command when it is available:\n%s\n", plan.args[0], setupAgentCommand(runtime, prompt))
+			printSetupContinuationPrompt(stdout, runtime, prompt)
+			return nil
+		}
+		resolved = path
+	}
+	plan.args = append([]string{resolved}, plan.args[1:]...)
 	if !plan.seeded {
 		// The runtime opens an interactive session but can't seed a prompt, so
 		// show it for the user to send as their first message once the agent is up.

--- a/apps/cli/cmd/newsjack/usage.go
+++ b/apps/cli/cmd/newsjack/usage.go
@@ -53,6 +53,28 @@ func printCommandHelp(w io.Writer, command string) bool {
 	case "auth":
 		printAuthHelp(w)
 		return true
+	case "install":
+		uiProduct(w, "install", "install skills and MCP config into agent runtimes.")
+		fmt.Fprintln(w)
+		uiSection(w, "usage")
+		fmt.Fprintln(w, "  newsjack install [--source <bundle-dir>] [--runtimes auto|all|none|codex,claude,openclaw,hermes] [--mcp] [--force]")
+		fmt.Fprintln(w)
+		uiSection(w, "options")
+		uiCommand(w, "--source", "install from a local bundle dir; prebuilt bundles are adopted as the managed install", "<dir>")
+		uiCommand(w, "--runtimes", "target runtimes; auto detects installed agent CLIs", "claude")
+		uiCommand(w, "--force", "overwrite user-owned skill directories too", "")
+		uiNote(w, "release overrides: NEWSJACK_VERSION pins the bundle tag; NEWSJACK_RELEASE_BASE points at any URL serving release assets.")
+		return true
+	case "skills":
+		uiProduct(w, "skills", "inspect and manage installed runtime skills.")
+		fmt.Fprintln(w)
+		uiSection(w, "usage")
+		fmt.Fprintln(w, "  newsjack skills list|install|status")
+		fmt.Fprintln(w)
+		uiCommand(w, "skills list", "list skills in the installed bundle", "")
+		uiCommand(w, "skills install", "same as newsjack install", "")
+		uiCommand(w, "skills status", "skills install health as JSON", "")
+		return true
 	case "doctor":
 		uiProduct(w, "doctor", "checks install health and prints concrete recovery commands.")
 		fmt.Fprintln(w)

--- a/apps/cli/cmd/newsjack/windows_friction_test.go
+++ b/apps/cli/cmd/newsjack/windows_friction_test.go
@@ -1,0 +1,272 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Regression tests for the Windows install friction report (2026-06-12).
+
+func TestIsReleaseTag(t *testing.T) {
+	cases := map[string]bool{
+		"v0.1.10":         true,
+		"v0.1.10-rc.1":    true,
+		"v1.2.3-beta.2":   true,
+		"v0.1.0-dev":      false,
+		"v0.1.0-dev+abc1": false,
+		"dev":             false,
+		"":                false,
+		"0.1.10":          false,
+	}
+	for tag, want := range cases {
+		if got := isReleaseTag(tag); got != want {
+			t.Errorf("isReleaseTag(%q) = %v, want %v", tag, got, want)
+		}
+	}
+}
+
+func TestReleaseBaseForBootstrapPinsOwnVersion(t *testing.T) {
+	saved := version
+	t.Cleanup(func() { version = saved })
+
+	withTempEnv(t, map[string]string{
+		"HOME":                  t.TempDir(),
+		"NEWSJACK_HOME":         "",
+		"NEWSJACK_RELEASE_BASE": "",
+		"NEWSJACK_VERSION":      "",
+		"NEWSJACK_REPO":         "",
+	}, func() {
+		// A release-tagged binary must fetch its own bundle: `latest` may
+		// not carry this platform yet (friction report #5).
+		version = "v0.1.10-rc.1"
+		if got := releaseBaseForBootstrap(); !strings.HasSuffix(got, "/releases/download/v0.1.10-rc.1") {
+			t.Fatalf("release binary should pin its own tag, got %s", got)
+		}
+		// Dev builds have no published release; fall back to latest.
+		version = "v0.1.0-dev"
+		if got := releaseBaseForBootstrap(); !strings.HasSuffix(got, "/releases/latest/download") {
+			t.Fatalf("dev build should use latest, got %s", got)
+		}
+	})
+
+	withTempEnv(t, map[string]string{
+		"HOME":             t.TempDir(),
+		"NEWSJACK_HOME":    "",
+		"NEWSJACK_VERSION": "v9.9.9",
+		"NEWSJACK_REPO":    "",
+	}, func() {
+		if got := releaseBaseForBootstrap(); !strings.HasSuffix(got, "/releases/download/v9.9.9") {
+			t.Fatalf("NEWSJACK_VERSION should override the pinned tag, got %s", got)
+		}
+	})
+}
+
+func TestFindWindowsClaudeBinary(t *testing.T) {
+	appData := t.TempDir()
+	home := t.TempDir()
+
+	if got := findWindowsClaudeBinary(appData, home); got != "" {
+		t.Fatalf("nothing installed should find nothing, got %q", got)
+	}
+
+	versioned := filepath.Join(appData, "Claude", "claude-code", "2.1.170")
+	if err := os.MkdirAll(versioned, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(versioned, "claude.exe"), []byte("x"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if got := findWindowsClaudeBinary(appData, home); got != filepath.Join(versioned, "claude.exe") {
+		t.Fatalf("AppData install not found, got %q", got)
+	}
+
+	// The native installer location wins when both exist.
+	local := filepath.Join(home, ".local", "bin")
+	if err := os.MkdirAll(local, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(local, "claude.exe"), []byte("x"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if got := findWindowsClaudeBinary(appData, home); got != filepath.Join(local, "claude.exe") {
+		t.Fatalf(".local/bin install should win, got %q", got)
+	}
+}
+
+func TestInstallSourceAdoptsPrebuiltBundle(t *testing.T) {
+	home := t.TempDir()
+	bundleDir := t.TempDir()
+	for name, content := range testBundleFiles("v9.9.9-test") {
+		path := filepath.Join(bundleDir, filepath.FromSlash(name))
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	withTempEnv(t, map[string]string{
+		"HOME":                    home,
+		"NEWSJACK_HOME":           "",
+		"NEWSJACK_ROOT":           "",
+		"NEWSJACK_RUNTIMES":       "claude",
+		"NEWSJACK_INSTALL_MCP":    "0",
+		"NEWSJACK_NO_AUTO_UPDATE": "1",
+		"NEWSJACK_IGNORE_DOTENV":  "1",
+		"PATH":                    os.TempDir(),
+	}, func() {
+		var out, errBuf bytes.Buffer
+		code := runCLI([]string{"install", "--source", bundleDir, "--runtimes", "claude", "--mcp=false"}, &out, &errBuf)
+		if code != 0 {
+			t.Fatalf("install --source code=%d stderr=%s", code, errBuf.String())
+		}
+
+		// Friction report #9 and #13: the managed root, managed binary,
+		// and install state must all exist after a --source install so
+		// doctor is clean and the registered MCP bridge path is real.
+		if got := readTrimmedFile(filepath.Join(managedInstallDir(), "VERSION")); got != "v9.9.9-test" {
+			t.Fatalf("managed root not adopted, VERSION=%q", got)
+		}
+		if !fileExists(installedBinaryPath()) {
+			t.Fatal("managed binary missing after adoption — MCP bridge command would point at nothing")
+		}
+		var state installState
+		data, err := os.ReadFile(installStatePath())
+		if err != nil {
+			t.Fatalf("install state missing after adoption: %v", err)
+		}
+		if err := json.Unmarshal(data, &state); err != nil {
+			t.Fatal(err)
+		}
+		if state.Version != "v9.9.9-test" || state.RuntimesRaw != "claude" {
+			t.Fatalf("adopted state = %+v", state)
+		}
+		if !fileExists(filepath.Join(home, ".claude", "skills", "newsjack-detector", "SKILL.md")) {
+			t.Fatal("skills not installed from adopted bundle")
+		}
+		root, err := newsjackRoot()
+		if err != nil || root != managedInstallDir() {
+			t.Fatalf("doctor's install root should be clean after adoption: %q, %v", root, err)
+		}
+
+		// Re-running against the managed root itself must not re-adopt.
+		if shouldAdoptBundle(managedInstallDir()) {
+			t.Fatal("the managed root must never be adopted into itself")
+		}
+	})
+}
+
+func TestConfigureClaudeMCPRepairsStaleEntry(t *testing.T) {
+	requirePOSIXShell(t)
+	home := t.TempDir()
+	fakeBin := t.TempDir()
+	capture := filepath.Join(t.TempDir(), "claude-args.txt")
+	marker := filepath.Join(t.TempDir(), "existing-entry")
+	if err := os.WriteFile(marker, []byte("1"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Fake claude: add-json fails with "already exists" while the marker
+	// is present; remove deletes the marker; every call is recorded.
+	script := "#!/bin/sh\n" +
+		"printf '%s\\n' \"$*\" >> " + shellQuote(capture) + "\n" +
+		"case \"$2\" in\n" +
+		"add-json) if [ -f " + shellQuote(marker) + " ]; then echo 'MCP server medialyst already exists in user config'; exit 1; fi ;;\n" +
+		"remove) rm -f " + shellQuote(marker) + " ;;\n" +
+		"esac\n" +
+		"exit 0\n"
+	if err := os.WriteFile(filepath.Join(fakeBin, "claude"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	withTempEnv(t, map[string]string{
+		"HOME":          home,
+		"NEWSJACK_HOME": "",
+		"PATH":          testPATH(fakeBin),
+	}, func() {
+		var out, errBuf bytes.Buffer
+		if err := configureClaudeMCP(newsjackCLIInvocation(), &out, &errBuf); err != nil {
+			t.Fatal(err)
+		}
+		calls, err := os.ReadFile(capture)
+		if err != nil {
+			t.Fatal(err)
+		}
+		text := string(calls)
+		if !strings.Contains(text, "mcp remove --scope user medialyst") {
+			t.Fatalf("stale entry should be removed, calls:\n%s", text)
+		}
+		if strings.Count(text, "add-json") != 2 {
+			t.Fatalf("expected add-json retry after remove, calls:\n%s", text)
+		}
+		if !strings.Contains(out.String(), "refreshed Claude Code MCP server") {
+			t.Fatalf("repair should be reported:\n%s", out.String())
+		}
+		if fileExists(marker) {
+			t.Fatal("stale entry marker should be gone")
+		}
+	})
+}
+
+func TestDoctorExitsZeroWhenOnlyOptionalKeysMissing(t *testing.T) {
+	repo := repoRootForTest(t)
+	withTempEnv(t, map[string]string{
+		"HOME":                     t.TempDir(),
+		"NEWSJACK_HOME":            "",
+		"NEWSJACK_ROOT":            repo,
+		"NEWSJACK_NO_AUTO_UPDATE":  "1",
+		"NEWSJACK_IGNORE_DOTENV":   "1",
+		"MEDIALYST_API_KEY":        "",
+		"X_BEARER_TOKEN":           "",
+		"TWITTER_BEARER_TOKEN":     "",
+		"X_API_BEARER_TOKEN":       "",
+		"TWITTER_API_BEARER_TOKEN": "",
+		"PATH":                     t.TempDir(),
+	}, func() {
+		var out, errBuf bytes.Buffer
+		if code := runCLI([]string{"doctor"}, &out, &errBuf); code != 0 {
+			t.Fatalf("doctor with only optional keys missing must exit 0, got %d", code)
+		}
+		if code := runCLI([]string{"doctor", "--json"}, &out, &errBuf); code != 0 {
+			t.Fatalf("doctor --json with only optional keys missing must exit 0, got %d", code)
+		}
+	})
+}
+
+func TestHelpCoversAllListedCommands(t *testing.T) {
+	for _, topic := range []string{"install", "skills", "doctor", "setup", "auth"} {
+		var out, errBuf bytes.Buffer
+		code := runCLI([]string{"help", topic}, &out, &errBuf)
+		if code != 0 {
+			t.Fatalf("help %s exited %d: %s", topic, code, errBuf.String())
+		}
+		if strings.Contains(errBuf.String(), "unknown help topic") {
+			t.Fatalf("help %s should exist", topic)
+		}
+	}
+}
+
+func TestParseRegQueryValue(t *testing.T) {
+	out := "\r\nHKEY_CURRENT_USER\\Environment\r\n    Path    REG_EXPAND_SZ    C:\\Program Files\\Foo;C:\\Users\\jane smith\\bin\r\n\r\n"
+	got := parseRegQueryValue(out)
+	if got != `C:\Program Files\Foo;C:\Users\jane smith\bin` {
+		t.Fatalf("parseRegQueryValue = %q", got)
+	}
+	if parseRegQueryValue("garbage") != "" {
+		t.Fatal("garbage input should parse to empty")
+	}
+}
+
+func TestPathListContains(t *testing.T) {
+	list := `C:\Program Files\Foo;C:\Users\jane\.newsjack\bin\;D:\tools`
+	if !pathListContains(list, `c:\users\jane\.newsjack\bin`) {
+		t.Fatal("case- and trailing-slash-insensitive match expected")
+	}
+	if pathListContains(list, `C:\Users\other\.newsjack\bin`) {
+		t.Fatal("must not match a different dir")
+	}
+}

--- a/docs/release-playbook.md
+++ b/docs/release-playbook.md
@@ -400,7 +400,7 @@ and `Unblock-File` strips the Mark-of-the-Web so later launches stay clean —
 the binary is unsigned, so this is the supported path until code signing:
 
 ```powershell
-iwr https://github.com/elvisun/newsjack/releases/latest/download/newsjack_windows_amd64.exe -OutFile newsjack.exe; Unblock-File newsjack.exe; .\newsjack.exe setup
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; iwr https://github.com/elvisun/newsjack/releases/latest/download/newsjack_windows_amd64.exe -OutFile newsjack.exe; Unblock-File newsjack.exe; .\newsjack.exe setup
 ```
 
 Automated coverage:

--- a/harness/scripts/run-ci-installer.ps1
+++ b/harness/scripts/run-ci-installer.ps1
@@ -219,6 +219,7 @@ function Invoke-BootstrapLeg {
     NEWSJACK_RUNTIMES       = $env:NEWSJACK_RUNTIMES
     NEWSJACK_INSTALL_MCP    = $env:NEWSJACK_INSTALL_MCP
     NEWSJACK_NO_AUTO_UPDATE = $env:NEWSJACK_NO_AUTO_UPDATE
+    NEWSJACK_NO_PATH_UPDATE = $env:NEWSJACK_NO_PATH_UPDATE
     USERPROFILE             = $env:USERPROFILE
     HOME                    = $env:HOME
   }
@@ -233,6 +234,8 @@ function Invoke-BootstrapLeg {
     $env:NEWSJACK_RUNTIMES = 'claude'
     $env:NEWSJACK_INSTALL_MCP = '0'
     $env:NEWSJACK_NO_AUTO_UPDATE = '1'
+    # Keep the runner's HKCU PATH untouched.
+    $env:NEWSJACK_NO_PATH_UPDATE = '1'
     # The Go CLI's homeDir() prefers HOME over USERPROFILE; set both so the
     # leg stays isolated even on runners that define HOME.
     $env:USERPROFILE = $scratch


### PR DESCRIPTION
Fixes every actionable finding from the 2026-06-12 Windows friction report. The report's causal chain — bootstrap fetched from `latest` which lacks Windows assets (#5), Claude Code undetected off PATH (#6), the `--source` workaround leaving no managed bin so the MCP registration pointed at a nonexistent binary (#13, CRITICAL) — is broken at every link:

| Finding | Fix |
|---|---|
| #5 bootstrap ignores binary version | Bootstrap pins the bundle to the running binary's own release tag; dev builds fall back to `latest`; `NEWSJACK_VERSION`/`NEWSJACK_RELEASE_BASE` override |
| #6 detection only via PATH | Windows probes Claude Code's real install dirs (`%USERPROFILE%\.local\bin`, `%APPDATA%\Claude\claude-code\<ver>`); MCP config and setup's agent launch resolve through the same prober |
| #9 `--source` leaves doctor broken | A prebuilt bundle passed to `install --source` is **adopted**: managed root populated, managed binary installed, install.json written — doctor clean, update works |
| #13 MCP registered to nonexistent path | Falls out of #5/#9 (managed bin now always exists), **plus** `mcp setup` now repairs an existing-but-stale `medialyst` entry (remove + re-add) for Claude Code and Codex instead of "leaving existing config in place" |
| #7 silent portable fallback | Warning now says Claude Code reads `~/.claude/skills` and names the explicit `--runtimes claude` fix |
| #10 PATH not updated | `setup`/adoption appends the managed bin dir to the user PATH via `reg.exe` (setx truncates at 1024 chars), opt-out `NEWSJACK_NO_PATH_UPDATE=1`; CI keeps runner registries clean |
| #2 TLS 1.2 on PS 5.1 | Documented one-liner (README + playbook) now prefixes the TLS line — no-op on pwsh 7 |
| #8/#11 missing help | `help install` / `help skills` added; install help documents `--source` adoption and the release override envs |
| #12 doctor exits 255 | Not reproducible on the current build (doctor exits 0 with only optional keys missing, verified empirically); contract now pinned by a regression test |
| #1/#4 no stable Windows release | Process, not code: tag `v0.1.10` after this merges and the documented `latest` URL resolves; #3 (HTML error dump) becomes moot then |

**Tests:** 9 new regression tests, one per finding (version pinning, Windows Claude discovery, `--source` adoption end-to-end, MCP repair sequence with a fake `claude`, doctor exit code, help coverage, reg.exe output parsing, PATH-list matching). Full suite + `GOOS=windows go vet` green.

**After merge:** tag `v0.1.10` — that closes #1/#3/#4 and makes the README's Windows section live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Support for installing from prebuilt bundles via new `--source` option
  * Added Windows PATH update control via environment variable
  * Improved Claude runtime detection on Windows systems

* **Bug Fixes**
  * Enhanced Windows PowerShell 5.1 compatibility with explicit TLS 1.2 configuration
  * Automatic repair of stale MCP configuration entries

* **Documentation**
  * Updated CLI help for install and skills commands
  * Improved installation instructions with better security settings

* **Tests**
  * Added comprehensive Windows-focused regression tests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->