### PR TITLE
Enforce a changelog entry on every release cut

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,15 @@ jobs:
           test "${GITHUB_REF_TYPE}" = "tag"
           [[ "${GITHUB_REF_NAME}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z.-]*)?$ ]]
 
+      - name: Require changelog entry
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p .tmp
+          node scripts/extract-changelog.mjs "${GITHUB_REF_NAME}" > .tmp/release-notes.md
+          echo "Release notes for ${GITHUB_REF_NAME}:"
+          cat .tmp/release-notes.md
+
       - name: Run CLI tests
         working-directory: apps/cli
         run: go test ./...
@@ -55,7 +64,8 @@ jobs:
           gh release create "${GITHUB_REF_NAME}" .tmp/newsjack-release/* \
             --verify-tag \
             --title "Newsjack ${GITHUB_REF_NAME}" \
-            --notes "Newsjack ${GITHUB_REF_NAME}" \
+            --notes-file .tmp/release-notes.md \
+            --generate-notes \
             "${prerelease_args[@]}"
 
       - name: Queue npm release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,64 @@
+# Changelog
+
+All notable Newsjack changes are documented here. **The release workflow
+refuses to publish a tag that has no entry in this file** — add your notes
+before pushing the tag.
+
+How it works:
+
+- Land user-visible changes with a bullet under `## Unreleased`.
+- **Stable tag (`vX.Y.Z`)**: rename `Unreleased` to `## vX.Y.Z — YYYY-MM-DD`
+  (and start a fresh empty `Unreleased` above it) before tagging. The
+  workflow fails the release if the tag has no section.
+- **Prerelease tag (`vX.Y.Z-rc.N`)**: no extra ceremony — the workflow uses
+  the non-empty `Unreleased` section (or an exact tag section if you write
+  one).
+
+The published GitHub Release appends the auto-generated list of merged PRs
+below these notes.
+
+## Unreleased
+
+## v0.1.10 — 2026-06-12
+
+### Added
+
+- **Windows support (GA).** One PowerShell line installs Newsjack on a stock
+  Windows 11 machine with no prerequisites — no install script, no git, no
+  Node. The bare `newsjack.exe` bootstraps its own release bundle (checksum
+  verified), installs skills, registers MCP, adds itself to the user PATH,
+  and self-updates natively from then on.
+- **Go-native Medialyst MCP bridge.** `newsjack mcp-bridge` speaks
+  streamable HTTP to Medialyst directly, replacing `npx mcp-remote` — the
+  Node dependency is gone on every platform. API keys still load at runtime
+  and never land in harness config files.
+- `headline-generator` skill: headline and subject-line candidates from a
+  story's raw facts.
+- Windows CI: unit tests, cross-compile gates, a full bootstrap battery,
+  and a Windows job in the post-release smoke.
+
+### Fixed
+
+- All 13 findings from the first real-machine Windows install test,
+  including: bootstrap now pins the bundle to the binary's own version;
+  Claude Code is detected on Windows even when not on PATH;
+  `install --source` adopts prebuilt bundles into the managed install;
+  `mcp setup` repairs stale Medialyst registrations instead of skipping
+  them; the documented install one-liner works on stock PowerShell 5.1.
+- npm release verification no longer reports false failures from registry
+  propagation lag.
+
+### Changed
+
+- New site logo (the `N_` mark).
+
+## v0.1.10-rc.1 — 2026-06-12
+
+Prerelease of v0.1.10 for Windows verification; superseded by the stable
+release above.
+
+## v0.1.9 and earlier
+
+Released before this changelog existed — see the
+[release list](https://github.com/elvisun/newsjack/releases) and git
+history.

--- a/docs/release-playbook.md
+++ b/docs/release-playbook.md
@@ -168,7 +168,20 @@ newsjack version
 
 Use stable releases for public default installs.
 
-1. Update or confirm release notes.
+1. Write the changelog entry — **the release workflow refuses to publish a
+   tag without one.** Rename `## Unreleased` in `CHANGELOG.md` to
+   `## vX.Y.Z — YYYY-MM-DD`, start a fresh empty `Unreleased` above it, and
+   land that on `main` before tagging. Prerelease tags (`-rc.N`) skip this:
+   they fall back to a non-empty `Unreleased` section automatically. Check
+   locally with:
+
+```bash
+node scripts/extract-changelog.mjs vX.Y.Z
+```
+
+   The section becomes the GitHub Release body, with the auto-generated
+   merged-PR list appended.
+
 2. Tag the exact commit on `main`:
 
 ```bash

--- a/scripts/extract-changelog.mjs
+++ b/scripts/extract-changelog.mjs
@@ -1,0 +1,89 @@
+// Extract the CHANGELOG.md section for a release tag, for use as the
+// GitHub Release body. The release workflow fails if no usable section
+// exists, which is what enforces "no release without release notes".
+//
+// Rules:
+// - An exact `## <tag>` section always wins.
+// - Prerelease tags (containing "-") may fall back to a non-empty
+//   `## Unreleased` section.
+// - Stable tags require their own section: rename Unreleased before tagging.
+//
+// Usage: node scripts/extract-changelog.mjs v0.1.11 [path/to/CHANGELOG.md]
+
+import { readFileSync } from "node:fs";
+
+const tag = (process.argv[2] || "").trim();
+const changelogPath = process.argv[3] || "CHANGELOG.md";
+
+if (!tag) {
+  console.error("usage: node scripts/extract-changelog.mjs <tag> [changelog]");
+  process.exit(2);
+}
+
+let body;
+try {
+  body = readFileSync(changelogPath, "utf8");
+} catch {
+  console.error(`${changelogPath} not found; every release needs a changelog entry.`);
+  process.exit(1);
+}
+
+function extractSection(name) {
+  const lines = body.split("\n");
+  const matchesHeading = (line) => {
+    if (!line.startsWith("## ")) {
+      return false;
+    }
+    const heading = line.slice(3).trim();
+    if (heading.toLowerCase() === name.toLowerCase()) {
+      return true;
+    }
+    // Allow a date or annotation suffix: "## v0.1.10 — 2026-06-12".
+    // The boundary check keeps "## v0.1.10" from matching "v0.1.10-rc.1".
+    if (!heading.toLowerCase().startsWith(name.toLowerCase())) {
+      return false;
+    }
+    const next = heading[name.length];
+    return next === " " || next === "\t";
+  };
+
+  const start = lines.findIndex(matchesHeading);
+  if (start === -1) {
+    return null;
+  }
+  let end = lines.length;
+  for (let i = start + 1; i < lines.length; i++) {
+    if (lines[i].startsWith("## ")) {
+      end = i;
+      break;
+    }
+  }
+  const content = lines.slice(start + 1, end).join("\n").trim();
+  return content === "" ? null : content;
+}
+
+let notes = extractSection(tag);
+let source = `the \`## ${tag}\` section`;
+
+if (!notes && tag.includes("-")) {
+  notes = extractSection("Unreleased");
+  source = "the `## Unreleased` section (prerelease fallback)";
+}
+
+if (!notes) {
+  console.error(
+    [
+      `No release notes for ${tag} in ${changelogPath}.`,
+      "",
+      tag.includes("-")
+        ? `Add bullets under \`## Unreleased\` (prereleases use it automatically), or add a \`## ${tag}\` section.`
+        : `Stable releases need their own section: rename \`## Unreleased\` to \`## ${tag} — YYYY-MM-DD\` and start a fresh Unreleased.`,
+      "",
+      "Then push the tag again.",
+    ].join("\n"),
+  );
+  process.exit(1);
+}
+
+console.error(`release notes: using ${source}`);
+process.stdout.write(notes + "\n");


### PR DESCRIPTION
Releases currently publish with `--notes "Newsjack vX.Y.Z"` — no actual notes. This makes release notes impossible to skip:

- **`CHANGELOG.md`** (new): Keep-a-Changelog style with an `Unreleased` section at top; seeded with the full v0.1.10 entry. The header documents the workflow so any agent or human editing the repo learns the rules in place.
- **`scripts/extract-changelog.mjs`** (new): pulls the section for a tag. Exact `## vX.Y.Z` section wins; prerelease tags fall back to a **non-empty** `Unreleased` (so `-rc.N` tags don't force double ceremony); anything else exits 1 with instructions. Boundary-safe (`v0.1.10` never matches `v0.1.10-rc.1`).
- **`release.yml`**: a "Require changelog entry" step right after tag validation — **the release hard-fails before building anything if there are no notes**. The extracted section becomes the release body via `--notes-file`, with GitHub's auto-generated merged-PR list appended via `--generate-notes`.
- **Playbook**: stable-release step 1 is now "write the changelog entry", with the local pre-check command.

Verified locally across all five extractor cases: stable-with-section ✓, prerelease-with-own-section ✓, prerelease falling back to Unreleased ✓, stable-without-section fails with instructions ✓, prerelease-with-empty-Unreleased fails ✓.

Also backfilled the published v0.1.10 release notes with the seeded changelog content (they previously read just "Newsjack v0.1.10").

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented automated changelog extraction for release notes generation.
  * Added release workflow validation to ensure changelog entries exist for tags.

* **Documentation**
  * Created comprehensive CHANGELOG.md documenting release history.
  * Updated release playbook with detailed changelog workflow instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->