### PR TITLE
docs: replace runtime table with a skills × harness matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ curl -fsSL newsjack.sh | bash
 
 **Are you an agent?** Check out **[Getting started](docs/getting-started.md)**
 
+**Are you a human?** Jump to **[platform-specific setup](#install)** below.
+
 ---
 
 ## What your agent can do once newsjack is installed
@@ -56,6 +58,14 @@ reads — plus a small open-source CLI. Most skills run anywhere your agent runs
 A few reach for a live news index, a media database, real journalist contacts,
 or locally-saved monitoring state — those work best in a local agent.
 
+**Pick your setup:**
+
+- **[macOS / Linux](#macos--linux)** — one `curl` (or `npm`) command, for any local agent
+- **[Windows](#windows)** — one PowerShell line; no git or Node
+- **[Chat apps](#chat-apps-claudeai-chatgpt-cowork)** — Claude.ai, ChatGPT, Cowork; no install
+- **[Claude.ai plugin](#claudeai-plugin)** — install Newsjack from the marketplace
+- **[Connect Medialyst](#connect-medialyst-optional)** — optional; unlocks the 🔧 skills in any agent
+
 ### What runs where
 
 | Skill | [Claude.ai](https://claude.ai) | [ChatGPT](https://chatgpt.com) | [Cowork](https://claude.com/product/cowork) | [Claude Code](https://claude.com/claude-code) | [Codex](https://openai.com/codex) | [Hermes](https://hermes-agent.nousresearch.com) | [OpenClaw](https://openclaw.ai) | [Medialyst](https://medialyst.ai) |
@@ -71,7 +81,7 @@ or locally-saved monitoring state — those work best in a local agent.
 | reactive-comment | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | fact-check | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | journalist-fit-check | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| voice-extractor | ⚠️ | ⚠️ | ⚠️ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| voice-extractor | ⚠️ | ⚠️ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | find-journalists | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 | ✅ |
 | **Detect** | | | | | | | | |
 | news-search | ✅ | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 | ✅ |
@@ -92,9 +102,10 @@ Legend:
 - **🔜 Coming soon** — not available here yet.
 - **❌ Not supported** — the two setup skills (`newsjack-monitor-setup`, `coverage-tracker-setup`) only save a profile or config and schedule it, so they need a local agent.
 
-### With a local agent (Claude Code, Codex, OpenClaw, Hermes)
+### macOS & Linux
 
-Use the curl installer when your agent can reach GitHub Release assets:
+Works with any local agent — Claude Code, Codex, Hermes, or OpenClaw. Use the
+curl installer when your agent can reach GitHub Release assets:
 
 ```bash
 curl -fsSL newsjack.sh | bash
@@ -144,7 +155,7 @@ guided setup as macOS/Linux — including installing Claude Code through its
 own native Windows installer if you don't have it yet. Updates are automatic,
 same as the curl install.
 
-### In a chat app (Claude.ai, ChatGPT, Cowork)
+### Chat apps (Claude.ai, ChatGPT, Cowork)
 
 No install, no CLI — paste your startup URL or your news and you get a real PR
 operator on the spot.
@@ -152,9 +163,9 @@ operator on the spot.
 **Nearly every skill runs right in the chat:** PR strategy, newsworthiness
 scoring, story angles, pitch drafting and honest critique, journalist-fit
 reasoning, media lists, reactive source-query responses, voice fingerprinting,
-and fact-checking against pasted or searchable evidence. Connect the
-[Medialyst](https://medialyst.ai) MCP for the live news index and fit-checked
-media lists (the 🔧 skills above).
+and fact-checking against pasted or searchable evidence. Want the live news
+index and fit-checked lists (the 🔧 skills)? See [Connect
+Medialyst](#connect-medialyst-optional) below.
 
 Both always-on monitors run in chat as ⚠️ Limited Mode — a best-effort, one-shot
 scan you trigger by hand. **Newsjack monitoring** surfaces opportunities but
@@ -162,6 +173,8 @@ can't track them over time, and **coverage tracking** does a one-off check but
 can't suppress repeats or flag only what's *new since last time* without saved
 seen-state. Want them saved, scheduled, and running on autopilot? Use a local
 agent (above), or [Medialyst](https://medialyst.ai) (coming soon).
+
+### Claude.ai plugin
 
 For Claude.ai plugin-style setup:
 
@@ -183,6 +196,14 @@ Then install the Newsjack plugin from that marketplace:
 
 A community marketplace plugin (`newsjack@claude-community`) is pending review
 and will be added soon.
+
+### Connect Medialyst (optional)
+
+Connecting [Medialyst](https://medialyst.ai) unlocks the 🔧 skills — the curated
+news index, the journalist database, and fit-checked, shareable media lists — in
+any chat app or local agent. It connects over **MCP** (no CLI required) or its
+API. Without it, those skills still run, but fall back to host web search and
+hand-built lists.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -121,20 +121,29 @@ help me setup https://newsjack.sh
 It reads the [guide](docs/getting-started.md) and handles the rest — npm
 fallback, Windows, credentials — on any platform.
 
-### Claude.ai & Cowork
+### Claude.ai & Cowork - Install as a Claude Plugin
 
 No install, no CLI — paste your startup URL or your news and you get a real PR
-operator on the spot. Two steps in the app:
+operator on the spot.
 
-1. **Install the Newsjack plugin.** Open **Customize → Personal plugins → Create
-   plugin → Add marketplace → Add from a repository**, enter `elvisun/newsjack`,
-   then install **`newsjack@newsjack`** from the **`elvisun/newsjack`**
-   marketplace. (A community marketplace plugin, `newsjack@claude-community`, is
-   pending review.)
-2. **Connect Medialyst (optional).** Add the [Medialyst](https://medialyst.ai)
-   MCP and authorize it over **OAuth** to unlock the 🔧 skills — the curated news
-   index, journalist database, and fit-checked, shareable lists. Without it those
-   skills fall back to host web search and hand-built lists.
+**Install the Newsjack plugin:**
+
+1. Open **Customize**.
+2. Go to **Personal plugins**.
+3. Click **Create plugin**.
+4. Choose **Add marketplace**.
+5. Choose **Add from a repository**.
+6. In the **repository URL** field, enter `elvisun/newsjack` and confirm.
+7. Open the new **`elvisun/newsjack`** marketplace, find the **`newsjack@newsjack`**
+   plugin, and click **Install**.
+
+A community marketplace plugin, `newsjack@claude-community`, is pending review
+and will be added soon.
+
+**Connect Medialyst (optional):** Add the [Medialyst](https://medialyst.ai) MCP
+and authorize it over **OAuth** to unlock the 🔧 skills — the curated news index,
+journalist database, and fit-checked, shareable lists. Without it those skills
+fall back to host web search and hand-built lists.
 
 The two always-on monitors run here in ⚠️ Limited Mode — a best-effort, one-shot
 scan with nothing saved. **Newsjack monitoring** surfaces opportunities but can't

--- a/README.md
+++ b/README.md
@@ -106,35 +106,20 @@ paste them by hand), and there's no local CLI or saved state either way.
 
 ### Local agents (Claude Code, Codex, Hermes, OpenClaw)
 
-**Technical? Use the one-liner (the default on macOS / Linux):**
+**Technical?** One line on macOS / Linux (review [`install.sh`](install.sh) first if you like):
 
 ```bash
 curl -fsSL newsjack.sh | bash
 ```
 
-Prefer to read it first? `curl -fsSL https://newsjack.sh` prints the exact,
-unminified [`install.sh`](install.sh) this repo ships — `newsjack.sh` serves
-that same file and every release bundles it unchanged. The routing is open too:
-[`apps/site/proxy.ts`](apps/site/proxy.ts) rewrites installer user-agents to
-`install.sh` and 308-redirects everyone else here.
+**Not technical?** 📋 **Copy this prompt to your agent:**
 
-If shell installers or GitHub Releases are blocked, use npm:
-
-```bash
-npm i -g newsjack
-newsjack install
+```text
+help me setup https://newsjack.sh
 ```
 
-After install, agents and skills call the CLI as `newsjack`. The installer can
-also connect [Medialyst](https://medialyst.ai) (optional) to unlock the 🔧
-skills.
-
-**Not technical? Let the agent set it up — on any platform.** Tell your agent:
-
-> help me setup https://newsjack.sh
-
-It reads that page, installs the CLI, and wires up the skills — handling the
-platform details (Windows included) for you.
+It reads the [guide](docs/getting-started.md) and handles the rest — npm
+fallback, Windows, credentials — on any platform.
 
 ### Claude.ai & Cowork
 

--- a/README.md
+++ b/README.md
@@ -58,36 +58,28 @@ reads — plus a small open-source CLI. Most skills run anywhere your agent runs
 A few reach for a live news index, a media database, real journalist contacts,
 or locally-saved monitoring state — those work best in a local agent.
 
-**Pick your setup:**
-
-- **[macOS / Linux](#macos--linux)** — one `curl` (or `npm`) command, for any local agent
-- **[Windows](#windows)** — one PowerShell line; no git or Node
-- **[Chat apps](#chat-apps-claudeai-chatgpt-cowork)** — Claude.ai, ChatGPT, Cowork; no install
-- **[Claude.ai plugin](#claudeai-plugin)** — install Newsjack from the marketplace
-- **[Connect Medialyst](#connect-medialyst-optional)** — optional; unlocks the 🔧 skills in any agent
-
 ### What runs where
 
 | Skill | [Claude.ai](https://claude.ai) | [ChatGPT](https://chatgpt.com) | [Cowork](https://claude.com/product/cowork) | [Claude Code](https://claude.com/claude-code) | [Codex](https://openai.com/codex) | [Hermes](https://hermes-agent.nousresearch.com) | [OpenClaw](https://openclaw.ai) | [Medialyst](https://medialyst.ai) |
 | --- | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
 | **Strategize** | | | | | | | | |
-| pr-strategist | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| newsworthiness-check | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| pr-strategist | ✅ | ⚠️ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| newsworthiness-check | ✅ | ⚠️ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | **Act** | | | | | | | | |
-| angle-generator | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| headline-generator | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| meanest-editor | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| crisis-holding | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| reactive-comment | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| fact-check | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| journalist-fit-check | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| angle-generator | ✅ | ⚠️ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| headline-generator | ✅ | ⚠️ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| meanest-editor | ✅ | ⚠️ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| crisis-holding | ✅ | ⚠️ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| reactive-comment | ✅ | ⚠️ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| fact-check | ✅ | ⚠️ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| journalist-fit-check | ✅ | ⚠️ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | voice-extractor | ⚠️ | ⚠️ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| find-journalists | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 | ✅ |
+| find-journalists | 🔧 | ⚠️ | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 | ✅ |
 | **Detect** | | | | | | | | |
-| news-search | ✅ | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 | ✅ |
-| story-origin-check | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 | ✅ |
-| relevance-coarse-filter | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| newsjack-triage | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| news-search | ✅ | ⚠️ | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 | ✅ |
+| story-origin-check | 🔧 | ⚠️ | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 | ✅ |
+| relevance-coarse-filter | ✅ | ⚠️ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| newsjack-triage | ✅ | ⚠️ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | newsjack-detector | ⚠️ | ⚠️ | ⚠️ | 🔧 | 🔧 | 🔧 | 🔧 | 🔜 |
 | newsjack-monitor-setup | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ | 🔜 |
 | coverage-tracker | ⚠️ | ⚠️ | ⚠️ | ✅ | ✅ | ✅ | ✅ | 🔜 |
@@ -102,108 +94,87 @@ Legend:
 - **🔜 Coming soon** — not available here yet.
 - **❌ Not supported** — the two setup skills (`newsjack-monitor-setup`, `coverage-tracker-setup`) only save a profile or config and schedule it, so they need a local agent.
 
-### macOS & Linux
+**ChatGPT** is ⚠️ across the board: Skills are in beta for **ChatGPT Business
+and Enterprise** only, so other tiers can't load Newsjack skills natively (you
+paste them by hand), and there's no local CLI or saved state either way.
 
-Works with any local agent — Claude Code, Codex, Hermes, or OpenClaw. Use the
-curl installer when your agent can reach GitHub Release assets:
+**Set up your agent:**
+
+- **[Local agents](#local-agents-claude-code-codex-hermes-openclaw)** — Claude Code, Codex, Hermes, OpenClaw
+- **[Claude.ai & Cowork](#claudeai--cowork)** — Anthropic plugin + Medialyst MCP
+- **[ChatGPT](#chatgpt)** — Skills beta (ChatGPT Business / Enterprise)
+
+### Local agents (Claude Code, Codex, Hermes, OpenClaw)
+
+**Easiest — let the agent do it (any OS, including Windows).** Tell your agent:
+
+> help me setup https://newsjack.sh
+
+It fetches the installer, runs it, and wires up the skills. This is the best
+path for non-developers, and the only thing most Windows users need.
+
+**One-liner (developers, macOS / Linux):**
 
 ```bash
 curl -fsSL newsjack.sh | bash
 ```
 
-Or review the script before running it:
+Prefer to read it first? `curl -fsSL https://newsjack.sh` prints the exact,
+unminified [`install.sh`](install.sh) this repo ships — `newsjack.sh` serves
+that same file and every release bundles it unchanged. The routing is open too:
+[`apps/site/proxy.ts`](apps/site/proxy.ts) rewrites installer user-agents to
+`install.sh` and 308-redirects everyone else here.
 
-```bash
-curl -fsSL https://newsjack.sh
-```
-
-No surprises: that's the exact, unminified [`install.sh`](install.sh) in this
-repo — `newsjack.sh` serves this file and every release bundles it unchanged, so
-what you read here is what runs. Read it before you pipe it to a shell.
-
-The routing is open too: [`apps/site/proxy.ts`](apps/site/proxy.ts) is the
-Next.js handler behind `newsjack.sh` — it rewrites installer user-agents
-(curl/wget) to `install.sh` and 308-redirects everyone else to this repo.
-
-The installer detects your agent runtime and installs the CLI-backed skills
-automatically.
-
-If shell installers or GitHub Release assets are blocked, use npm instead:
+If shell installers or GitHub Releases are blocked, use npm:
 
 ```bash
 npm i -g newsjack
 newsjack install
 ```
 
-After install, agents and skills should call the CLI as `newsjack`.
+After install, agents and skills call the CLI as `newsjack`. The installer can
+also connect [Medialyst](https://medialyst.ai) (optional) to unlock the 🔧
+skills.
 
-### Windows
-
-No script, no git, no Node. One PowerShell line downloads the CLI and runs
-setup (requires v0.1.10 or later):
+**Windows, by hand (no agent yet).** If you don't have a local agent to prompt,
+one PowerShell line installs the CLI and walks through setup — including
+installing Claude Code for you — and needs v0.1.10 or later:
 
 ```powershell
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; iwr https://github.com/elvisun/newsjack/releases/latest/download/newsjack_windows_amd64.exe -OutFile newsjack.exe; Unblock-File newsjack.exe; .\newsjack.exe setup
 ```
 
-The TLS line makes the download work on stock Windows PowerShell 5.1 (it's a
-no-op on PowerShell 7).
+The TLS line makes the download work on stock PowerShell 5.1 (a no-op on 7).
 
-`newsjack setup` downloads the skills bundle, verifies its checksum, installs
-the CLI to `%USERPROFILE%\.newsjack\bin`, and walks you through the same
-guided setup as macOS/Linux — including installing Claude Code through its
-own native Windows installer if you don't have it yet. Updates are automatic,
-same as the curl install.
-
-### Chat apps (Claude.ai, ChatGPT, Cowork)
+### Claude.ai & Cowork
 
 No install, no CLI — paste your startup URL or your news and you get a real PR
-operator on the spot.
+operator on the spot. Two steps in the app:
 
-**Nearly every skill runs right in the chat:** PR strategy, newsworthiness
-scoring, story angles, pitch drafting and honest critique, journalist-fit
-reasoning, media lists, reactive source-query responses, voice fingerprinting,
-and fact-checking against pasted or searchable evidence. Want the live news
-index and fit-checked lists (the 🔧 skills)? See [Connect
-Medialyst](#connect-medialyst-optional) below.
+1. **Install the Newsjack plugin.** Open **Customize → Personal plugins → Create
+   plugin → Add marketplace → Add from a repository**, enter `elvisun/newsjack`,
+   then install **`newsjack@newsjack`** from the **`elvisun/newsjack`**
+   marketplace. (A community marketplace plugin, `newsjack@claude-community`, is
+   pending review.)
+2. **Connect Medialyst (optional).** Add the [Medialyst](https://medialyst.ai)
+   MCP and authorize it over **OAuth** to unlock the 🔧 skills — the curated news
+   index, journalist database, and fit-checked, shareable lists. Without it those
+   skills fall back to host web search and hand-built lists.
 
-Both always-on monitors run in chat as ⚠️ Limited Mode — a best-effort, one-shot
-scan you trigger by hand. **Newsjack monitoring** surfaces opportunities but
-can't track them over time, and **coverage tracking** does a one-off check but
-can't suppress repeats or flag only what's *new since last time* without saved
-seen-state. Want them saved, scheduled, and running on autopilot? Use a local
-agent (above), or [Medialyst](https://medialyst.ai) (coming soon).
+The two always-on monitors run here in ⚠️ Limited Mode — a best-effort, one-shot
+scan with nothing saved. **Newsjack monitoring** surfaces opportunities but can't
+track them over time, and **coverage tracking** can't suppress repeats or flag
+only what's *new since last time* without saved seen-state. For saved, scheduled
+monitoring, use a local agent.
 
-### Claude.ai plugin
+### ChatGPT
 
-For Claude.ai plugin-style setup:
-
-1. Open **Customize**.
-2. Go to **Personal plugins**.
-3. Click **Create plugin**.
-4. Choose **Add marketplace**.
-5. Choose **Add from a repository**.
-6. In the repository URL field, enter:
-
-```text
-elvisun/newsjack
-```
-
-Then install the Newsjack plugin from that marketplace:
-
-- Marketplace: `elvisun/newsjack`
-- Plugin: `newsjack@newsjack`
-
-A community marketplace plugin (`newsjack@claude-community`) is pending review
-and will be added soon.
-
-### Connect Medialyst (optional)
-
-Connecting [Medialyst](https://medialyst.ai) unlocks the 🔧 skills — the curated
-news index, the journalist database, and fit-checked, shareable media lists — in
-any chat app or local agent. It connects over **MCP** (no CLI required) or its
-API. Without it, those skills still run, but fall back to host web search and
-hand-built lists.
+ChatGPT runs Newsjack only in a degraded ⚠️ form. Skills aren't available to most
+accounts — *"Skills [are] in beta for ChatGPT Business and Enterprise"* — so on
+those plans you can add Newsjack as a Skill, and on every other tier you paste a
+skill's instructions into the chat by hand. Either way there's no local CLI or
+saved state, so the monitors and persistence-backed skills don't apply. For the
+full toolkit, use a local agent or Claude.ai.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -53,14 +53,10 @@ Three problems, separate lanes.
 
 Newsjack is a set of **open skills** — plain-Markdown instructions your agent
 reads — plus a small open-source CLI. Most skills run anywhere your agent runs.
-A few reach for a live news index, real journalist contacts, or saved monitoring
-state; those get sharper when you connect [Medialyst](https://medialyst.ai) or
-run a local agent. Nothing is locked behind a runtime — pick whichever row
-below matches where your agent lives.
+A few reach for a live news index, a media database, real journalist contacts,
+or locally-saved monitoring state — those work best in a local agent.
 
 ### What runs where
-
-✅ runs out of the box · 🔧 needs an external API / MCP connection (e.g. the X API, or Medialyst over MCP) · ⚠️ Limited Mode (runs in chat, one-shot, nothing saved) · 🔜 coming soon · ❌ not available
 
 | Skill | [Claude.ai](https://claude.ai) | [ChatGPT](https://chatgpt.com) | [Cowork](https://claude.com/product/cowork) | [Claude Code](https://claude.com/claude-code) | [Codex](https://openai.com/codex) | [Hermes](https://hermes-agent.nousresearch.com) | [OpenClaw](https://openclaw.ai) | [Medialyst](https://medialyst.ai) |
 | --- | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
@@ -87,24 +83,14 @@ below matches where your agent lives.
 | coverage-tracker | ⚠️ | ⚠️ | ⚠️ | ✅ | ✅ | ✅ | ✅ | 🔜 |
 | coverage-tracker-setup | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ | 🔜 |
 
-**🔧 needs an external API / MCP connection** — the skill works on its own, but
-does its best work with an external data source connected. That's usually
-**[Medialyst](https://medialyst.ai)** — the curated news index and journalist
-database, available over MCP (no CLI required) — but it can also be a third-party
-API such as the **X API** for social-trend monitoring, with more sources over
-time. It's optional: without it you get a limited form, like host web search
-instead of the Medialyst news index, or a hand-built list instead of a
-fit-checked one.
 
-**⚠️ Limited Mode** — the skill still runs in a chat app, but as a one-shot with
-nothing saved between sessions: `voice-extractor` can't store a reusable voice
-fingerprint, `newsjack-detector` does a best-effort scan instead of canonical
-scheduled monitoring, and `coverage-tracker` does a one-off coverage check with
-no repeat-suppression. Connect a local agent for the saved, scheduled versions.
+Legend:
 
-The two **setup** skills (`newsjack-monitor-setup`, `coverage-tracker-setup`)
-exist only to save a profile or config and schedule it, so they need a local
-agent — ❌ in chat apps.
+- **✅ Runs out of the box** — no setup; works anywhere your agent does.
+- **🔧 May need an external connection** — works on its own, but does its best work with an external data source connected (e.g. the X API, or the Medialyst API / MCP).
+- **⚠️ Limited Mode** — runs in a chat app, but as a best-effort, one-shot pass with nothing saved between sessions: no stored voice fingerprint, no scheduled monitoring, no repeat-suppression. Connect a local agent for the saved, scheduled version.
+- **🔜 Coming soon** — not available here yet.
+- **❌ Not supported** — the two setup skills (`newsjack-monitor-setup`, `coverage-tracker-setup`) only save a profile or config and schedule it, so they need a local agent.
 
 ### With a local agent (Claude Code, Codex, OpenClaw, Hermes)
 

--- a/README.md
+++ b/README.md
@@ -51,24 +51,52 @@ Three problems, separate lanes.
 
 ## Install
 
-Pick the path for the harness you're using.
+Newsjack is a set of **open skills** — plain-Markdown instructions your agent
+reads — plus a small open-source CLI. Most skills run anywhere your agent runs.
+A few reach for a live news index, real journalist contacts, or saved monitoring
+state; those get sharper when you connect [Medialyst](https://medialyst.ai) or
+run a local agent. Nothing is locked behind a runtime — pick whichever row
+below matches where your agent lives.
 
-### Supported runtimes
+### What runs where
 
-| Runtime             | Status       | Experience   | Install path |
-| ------------------- | ------------ | ------------ | ------------ |
-| Claude Code         | Recommended  | Full Mode    | curl, npm, or plugin |
-| Codex               | Recommended  | Full Mode    | curl or npm |
-| OpenClaw            | Recommended  | Full Mode    | curl or npm |
-| Hermes              | Recommended  | Full Mode    | curl or npm |
-| Claude.ai chat      | Limited only | Limited Mode | plugin/upload/manual skills |
-| ChatGPT chat        | Limited only | Limited Mode | manual skills |
-| Claude Cowork       | Limited only | Limited Mode | plugin/upload/manual skills |
+✅ runs out of the box · 🔧 needs setup for full results · 🔜 coming soon · ❌ not available
 
-### Full Mode: Claude Code, Codex, OpenClaw, Hermes
+| Skill | [Claude.ai](https://claude.ai) | [ChatGPT](https://chatgpt.com) | [Cowork](https://claude.com/product/cowork) | [Claude Code](https://claude.com/claude-code) | [Codex](https://openai.com/codex) | [Hermes](https://hermes-agent.nousresearch.com) | [OpenClaw](https://openclaw.ai) | [Medialyst](https://medialyst.ai) |
+| --- | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
+| **Strategize** | | | | | | | | |
+| pr-strategist | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| newsworthiness-check | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| **Act** | | | | | | | | |
+| angle-generator | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| headline-generator | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| meanest-editor | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| crisis-holding | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| reactive-comment | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| fact-check | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| journalist-fit-check | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| voice-extractor | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| find-journalists | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 | ✅ |
+| **Detect** | | | | | | | | |
+| news-search | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 | ✅ |
+| story-origin-check | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 | ✅ |
+| relevance-coarse-filter | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| newsjack-triage | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| newsjack-detector | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 | 🔜 |
+| newsjack-monitor-setup | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ | 🔜 |
+| coverage-tracker | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 | 🔜 |
+| coverage-tracker-setup | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ | 🔜 |
 
-Use the curl installer when your full agent harness can reach GitHub Release
-assets:
+**🔧 needs setup** — the skill works on its own, but does its best work with the
+**[Medialyst](https://medialyst.ai) MCP** connected (or, in a chat app, a local
+CLI). It's optional: without it you get a limited form — host web search instead
+of the curated Medialyst news index, a hand-built list instead of a fit-checked
+one, or a one-shot scan instead of a saved, scheduled monitor. The two **setup**
+skills need durable state and a scheduler, so they run only in a local agent.
+
+### With a local agent (Claude Code, Codex, OpenClaw, Hermes)
+
+Use the curl installer when your agent can reach GitHub Release assets:
 
 ```bash
 curl -fsSL newsjack.sh | bash
@@ -118,26 +146,23 @@ guided setup as macOS/Linux — including installing Claude Code through its
 own native Windows installer if you don't have it yet. Updates are automatic,
 same as the curl install.
 
-### Limited mode: Running on Claude.ai, ChatGPT, Claude Cowork
+### In a chat app (Claude.ai, ChatGPT, Cowork)
 
-Newsjack needs a local agent for Full Mode. On Claude.ai, ChatGPT, or Claude
-Cowork it automatically falls back to Limited Mode — no install, no CLI, no
-setup. Paste your startup URL or your news and you get a real PR operator on the
-spot.
+No install, no CLI — paste your startup URL or your news and you get a real PR
+operator on the spot.
 
-**Every skill still works.** PR strategy, newsworthiness scoring, story angles,
-pitch drafting and honest critique, journalist-fit reasoning, fit-checked media
-lists, reactive source-query responses, voice fingerprinting, and fact-checking
-against pasted or searchable evidence all run right in the chat — paste what
-you've got and go.
+**Nearly every skill runs right in the chat:** PR strategy, newsworthiness
+scoring, story angles, pitch drafting and honest critique, journalist-fit
+reasoning, media lists, reactive source-query responses, voice fingerprinting,
+and fact-checking against pasted or searchable evidence. Connect the
+[Medialyst](https://medialyst.ai) MCP for the live news index and fit-checked
+media lists (the 🔧 skills above).
 
-The only things that change are the two always-on monitors — **newsjack
-monitoring** (watching your space for newsjacking opportunities) and **coverage
-monitoring** (Google Alerts-style keyword tracking). Without a local agent they
-can't keep saved profiles, run on a schedule, or remember what they've already
-flagged, so they fall back to best-effort, one-shot scans you trigger by hand.
-Want them running on autopilot? Set up Full Mode with the CLI harness and a local
-agent.
+The two always-on monitors — **newsjack monitoring** and **coverage tracking** —
+need saved profiles, a schedule, and memory of what they've already flagged, so
+they want a local agent. In a chat app they run as best-effort, one-shot scans
+you trigger by hand. Want them on autopilot? Run Newsjack in a local agent
+(above), or use [Medialyst](https://medialyst.ai) (coming soon).
 
 For Claude.ai plugin-style setup:
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ below matches where your agent lives.
 | voice-extractor | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | find-journalists | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 | ✅ |
 | **Detect** | | | | | | | | |
-| news-search | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 | ✅ |
+| news-search | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | story-origin-check | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 | ✅ |
 | relevance-coarse-filter | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | newsjack-triage | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ operator on the spot.
 
 **Install the Newsjack plugin:**
 
-1. Open **Customize**.
+1. Open **[Customize](https://claude.ai/customize)**.
 2. Go to **Personal plugins**.
 3. Click **Create plugin**.
 4. Choose **Add marketplace**.

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ below matches where your agent lives.
 
 ### What runs where
 
-✅ runs out of the box · 🔧 needs setup for full results · 🔜 coming soon · ❌ not available
+✅ runs out of the box · 🔧 needs an external API / MCP connection (e.g. the X API, or Medialyst over MCP) · ⚠️ Limited Mode (runs in chat, one-shot, nothing saved) · 🔜 coming soon · ❌ not available
 
 | Skill | [Claude.ai](https://claude.ai) | [ChatGPT](https://chatgpt.com) | [Cowork](https://claude.com/product/cowork) | [Claude Code](https://claude.com/claude-code) | [Codex](https://openai.com/codex) | [Hermes](https://hermes-agent.nousresearch.com) | [OpenClaw](https://openclaw.ai) | [Medialyst](https://medialyst.ai) |
 | --- | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
@@ -75,25 +75,36 @@ below matches where your agent lives.
 | reactive-comment | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | fact-check | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | journalist-fit-check | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| voice-extractor | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| voice-extractor | ⚠️ | ⚠️ | ⚠️ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | find-journalists | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 | ✅ |
 | **Detect** | | | | | | | | |
-| news-search | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| news-search | ✅ | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 | ✅ |
 | story-origin-check | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 | ✅ |
 | relevance-coarse-filter | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | newsjack-triage | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| newsjack-detector | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 | 🔜 |
+| newsjack-detector | ⚠️ | ⚠️ | ⚠️ | 🔧 | 🔧 | 🔧 | 🔧 | 🔜 |
 | newsjack-monitor-setup | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ | 🔜 |
-| coverage-tracker | ❌ | ❌ | ❌ | 🔧 | 🔧 | 🔧 | 🔧 | 🔜 |
+| coverage-tracker | ⚠️ | ⚠️ | ⚠️ | ✅ | ✅ | ✅ | ✅ | 🔜 |
 | coverage-tracker-setup | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ | 🔜 |
 
-**🔧 needs setup** — the skill works on its own, but does its best work with the
-**[Medialyst](https://medialyst.ai) MCP** connected (or, in a chat app, a local
-CLI). It's optional: without it you get a limited form — host web search instead
-of the curated Medialyst news index, a hand-built list instead of a fit-checked
-one, or a one-shot scan instead of a saved, scheduled monitor. Coverage tracking
-and the two **setup** skills depend on durable state and a scheduler, so they
-need a local agent — ❌ in chat apps.
+**🔧 needs an external API / MCP connection** — the skill works on its own, but
+does its best work with an external data source connected. That's usually
+**[Medialyst](https://medialyst.ai)** — the curated news index and journalist
+database, available over MCP (no CLI required) — but it can also be a third-party
+API such as the **X API** for social-trend monitoring, with more sources over
+time. It's optional: without it you get a limited form, like host web search
+instead of the Medialyst news index, or a hand-built list instead of a
+fit-checked one.
+
+**⚠️ Limited Mode** — the skill still runs in a chat app, but as a one-shot with
+nothing saved between sessions: `voice-extractor` can't store a reusable voice
+fingerprint, `newsjack-detector` does a best-effort scan instead of canonical
+scheduled monitoring, and `coverage-tracker` does a one-off coverage check with
+no repeat-suppression. Connect a local agent for the saved, scheduled versions.
+
+The two **setup** skills (`newsjack-monitor-setup`, `coverage-tracker-setup`)
+exist only to save a profile or config and schedule it, so they need a local
+agent — ❌ in chat apps.
 
 ### With a local agent (Claude Code, Codex, OpenClaw, Hermes)
 
@@ -159,11 +170,12 @@ and fact-checking against pasted or searchable evidence. Connect the
 [Medialyst](https://medialyst.ai) MCP for the live news index and fit-checked
 media lists (the 🔧 skills above).
 
-The two always-on monitors want a local agent. **Newsjack monitoring** can still
-run as a best-effort, one-shot scan you trigger by hand in chat; **coverage
-tracking** can't — it only flags coverage that's *new since last time*, which
-needs saved seen-state. Want monitoring on autopilot? Run Newsjack in a local
-agent (above), or use [Medialyst](https://medialyst.ai) (coming soon).
+Both always-on monitors run in chat as ⚠️ Limited Mode — a best-effort, one-shot
+scan you trigger by hand. **Newsjack monitoring** surfaces opportunities but
+can't track them over time, and **coverage tracking** does a one-off check but
+can't suppress repeats or flag only what's *new since last time* without saved
+seen-state. Want them saved, scheduled, and running on autopilot? Use a local
+agent (above), or [Medialyst](https://medialyst.ai) (coming soon).
 
 For Claude.ai plugin-style setup:
 

--- a/README.md
+++ b/README.md
@@ -106,14 +106,15 @@ paste them by hand), and there's no local CLI or saved state either way.
 
 ### Local agents (Claude Code, Codex, Hermes, OpenClaw)
 
-**Easiest — let the agent do it (any OS, including Windows).** Tell your agent:
+**Not technical? Let the agent set it up — on any platform.** Tell your agent:
 
 > help me setup https://newsjack.sh
 
-It fetches the installer, runs it, and wires up the skills. This is the best
-path for non-developers, and the only thing most Windows users need.
+It reads that page, installs the CLI, and wires up the skills — handling the
+platform details (Windows included) for you. This is the path for non-technical
+users.
 
-**One-liner (developers, macOS / Linux):**
+**Technical? Use the one-liner (the default on macOS / Linux):**
 
 ```bash
 curl -fsSL newsjack.sh | bash
@@ -135,16 +136,6 @@ newsjack install
 After install, agents and skills call the CLI as `newsjack`. The installer can
 also connect [Medialyst](https://medialyst.ai) (optional) to unlock the 🔧
 skills.
-
-**Windows, by hand (no agent yet).** If you don't have a local agent to prompt,
-one PowerShell line installs the CLI and walks through setup — including
-installing Claude Code for you — and needs v0.1.10 or later:
-
-```powershell
-[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; iwr https://github.com/elvisun/newsjack/releases/latest/download/newsjack_windows_amd64.exe -OutFile newsjack.exe; Unblock-File newsjack.exe; .\newsjack.exe setup
-```
-
-The TLS line makes the download work on stock PowerShell 5.1 (a no-op on 7).
 
 ### Claude.ai & Cowork
 
@@ -186,20 +177,17 @@ full toolkit, use a local agent or Claude.ai.
 └── newsjack/             # managed bundle
 
 skills installed to your detected runtime(s):
-  newsjack-monitor-setup  create a company monitoring profile
-  newsjack-detector       find newsworthy moments before the wave breaks
   newsworthiness-check    score whether your news clears the bar
-  angle-generator         turn one update into ten pitchable hooks
   headline-generator      headlines and subject lines from raw story facts
   find-journalists        build small, fit-checked media lists
-  …and more
+  ...and more
 ```
 
 The npm package bundles the same CLI and skills, with the `newsjack` command installed on `PATH`.
 
 Curl-installed Newsjack auto-updates from the latest GitHub Release before each run. Set `NEWSJACK_AUTO_UPDATE=0` to disable.
 
-Npm-installed Newsjack uses npm for CLI updates:
+You can also install the CLI byitself using npm:
 
 ```bash
 npm i -g newsjack@latest

--- a/README.md
+++ b/README.md
@@ -136,14 +136,15 @@ operator on the spot.
 6. In the **repository URL** field, enter `elvisun/newsjack` and confirm.
 7. Open the new **`elvisun/newsjack`** marketplace, find the **`newsjack@newsjack`**
    plugin, and click **Install**.
+8. *(Optional)* Create a [Medialyst](https://medialyst.ai) account to unlock the
+   🔧 skills — the curated news index, journalist database, and fit-checked,
+   shareable lists.
+9. *(Optional)* Back in Claude, click **Connect** on the Medialyst connector and
+   authorize it over **OAuth**. Without it, those skills fall back to host web
+   search and hand-built lists.
 
 A community marketplace plugin, `newsjack@claude-community`, is pending review
 and will be added soon.
-
-**Connect Medialyst (optional):** Add the [Medialyst](https://medialyst.ai) MCP
-and authorize it over **OAuth** to unlock the 🔧 skills — the curated news index,
-journalist database, and fit-checked, shareable lists. Without it those skills
-fall back to host web search and hand-built lists.
 
 The two always-on monitors run here in ⚠️ Limited Mode — a best-effort, one-shot
 scan with nothing saved. **Newsjack monitoring** surfaces opportunities but can't

--- a/README.md
+++ b/README.md
@@ -84,15 +84,16 @@ below matches where your agent lives.
 | newsjack-triage | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | newsjack-detector | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 | 🔜 |
 | newsjack-monitor-setup | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ | 🔜 |
-| coverage-tracker | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 | 🔜 |
+| coverage-tracker | ❌ | ❌ | ❌ | 🔧 | 🔧 | 🔧 | 🔧 | 🔜 |
 | coverage-tracker-setup | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ | 🔜 |
 
 **🔧 needs setup** — the skill works on its own, but does its best work with the
 **[Medialyst](https://medialyst.ai) MCP** connected (or, in a chat app, a local
 CLI). It's optional: without it you get a limited form — host web search instead
 of the curated Medialyst news index, a hand-built list instead of a fit-checked
-one, or a one-shot scan instead of a saved, scheduled monitor. The two **setup**
-skills need durable state and a scheduler, so they run only in a local agent.
+one, or a one-shot scan instead of a saved, scheduled monitor. Coverage tracking
+and the two **setup** skills depend on durable state and a scheduler, so they
+need a local agent — ❌ in chat apps.
 
 ### With a local agent (Claude Code, Codex, OpenClaw, Hermes)
 
@@ -158,11 +159,11 @@ and fact-checking against pasted or searchable evidence. Connect the
 [Medialyst](https://medialyst.ai) MCP for the live news index and fit-checked
 media lists (the 🔧 skills above).
 
-The two always-on monitors — **newsjack monitoring** and **coverage tracking** —
-need saved profiles, a schedule, and memory of what they've already flagged, so
-they want a local agent. In a chat app they run as best-effort, one-shot scans
-you trigger by hand. Want them on autopilot? Run Newsjack in a local agent
-(above), or use [Medialyst](https://medialyst.ai) (coming soon).
+The two always-on monitors want a local agent. **Newsjack monitoring** can still
+run as a best-effort, one-shot scan you trigger by hand in chat; **coverage
+tracking** can't — it only flags coverage that's *new since last time*, which
+needs saved seen-state. Want monitoring on autopilot? Run Newsjack in a local
+agent (above), or use [Medialyst](https://medialyst.ai) (coming soon).
 
 For Claude.ai plugin-style setup:
 

--- a/README.md
+++ b/README.md
@@ -106,14 +106,6 @@ paste them by hand), and there's no local CLI or saved state either way.
 
 ### Local agents (Claude Code, Codex, Hermes, OpenClaw)
 
-**Not technical? Let the agent set it up — on any platform.** Tell your agent:
-
-> help me setup https://newsjack.sh
-
-It reads that page, installs the CLI, and wires up the skills — handling the
-platform details (Windows included) for you. This is the path for non-technical
-users.
-
 **Technical? Use the one-liner (the default on macOS / Linux):**
 
 ```bash
@@ -136,6 +128,13 @@ newsjack install
 After install, agents and skills call the CLI as `newsjack`. The installer can
 also connect [Medialyst](https://medialyst.ai) (optional) to unlock the 🔧
 skills.
+
+**Not technical? Let the agent set it up — on any platform.** Tell your agent:
+
+> help me setup https://newsjack.sh
+
+It reads that page, installs the CLI, and wires up the skills — handling the
+platform details (Windows included) for you.
 
 ### Claude.ai & Cowork
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ paste them by hand), and there's no local CLI or saved state either way.
 curl -fsSL newsjack.sh | bash
 ```
 
-**Not technical?** 📋 **Copy this prompt to your agent:**
+**Not technical?** 📋 **Copy this prompt to any AI:**
 
 ```text
 help me setup https://newsjack.sh

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -46,6 +46,18 @@ npm i -g newsjack
 newsjack install
 ```
 
+On Windows there is no `curl | bash`. When the user is on Windows, download and
+run the setup binary instead (requires v0.1.10 or later):
+
+```powershell
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; iwr https://github.com/elvisun/newsjack/releases/latest/download/newsjack_windows_amd64.exe -OutFile newsjack.exe; Unblock-File newsjack.exe; .\newsjack.exe setup
+```
+
+`newsjack setup` fetches the skills bundle, verifies its checksum, installs the
+CLI to `%USERPROFILE%\.newsjack\bin`, and runs the same guided setup as
+macOS/Linux — including installing Claude Code via its native Windows installer
+if it is missing.
+
 Skill instructions assume the command is available as `newsjack` only in Full
 Mode. In Limited Mode, do not try to install the CLI inside chat; use the
 Limited Mode workflow and label detector-style output as reduced coverage.


### PR DESCRIPTION
## What

Replaces the **Supported runtimes** table in the README with a **skills × harness matrix**, and reframes the install section around the open-source story rather than the "Full Mode vs Limited Mode" split.

The old table answered "which mode am I in?" — a concept readers had to learn before it helped them. The new one answers the question they actually have: **"will _this_ skill work in _my_ agent, and what do I need to set up?"**

## The matrix

One row per skill, one column per place an agent can live — each header linked to its home:

[Claude.ai](https://claude.ai) · [ChatGPT](https://chatgpt.com) · [Cowork](https://claude.com/product/cowork) · [Claude Code](https://claude.com/claude-code) · [Codex](https://openai.com/codex) · [Hermes](https://hermes-agent.nousresearch.com) · [OpenClaw](https://openclaw.ai) · [Medialyst](https://medialyst.ai)

Legend: ✅ runs out of the box · 🔧 needs setup for full results · 🔜 coming soon · ❌ not available

- **Most skills are ✅ everywhere** — they're plain-Markdown reasoning skills, so they run wherever the agent runs.
- **🔧** marks skills that work on their own but do their best work with the **Medialyst MCP** connected (or, in a chat app, a local CLI): `find-journalists`, `news-search`, `story-origin-check`, `newsjack-detector`, `coverage-tracker`. Optional — without it you get host web search instead of the curated news index, a hand-built list instead of a fit-checked one, or a one-shot scan instead of a saved monitor.
- **The two `*-setup` skills** need durable state and a scheduler, so they're ❌ in chat apps and ✅ in local agents.
- **Medialyst** runs every skill today; **newsjack monitoring** and **coverage tracking** are 🔜.

## Also

- Drops "Full Mode" / "Limited Mode" terminology from the section headers (`### With a local agent`, `### In a chat app`) and prose — the matrix now carries that meaning.
- No CLI, installer, or skill behavior changes. README-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded README installation docs to describe Newsjack as open “skills” plus an open-source CLI.
  * Replaced “Supported runtimes” with a “What runs where” matrix across multiple agent platforms and environments.
  * Added setup guidance for skill-specific requirements, including Medialyst MCP (or local agent alternatives).
  * Updated chat-app-only instructions, clarifying best-effort monitoring/coverage behavior and one-shot scan mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->