### PR TITLE
Add press-clip skill: high-fidelity coverage clips

### DIFF
--- a/skills/press-clip/SKILL.md
+++ b/skills/press-clip/SKILL.md
@@ -49,19 +49,24 @@ node clip.mjs --url "<URL>" --client "<Client Name>" \
 
 For a **roundup** where the client is one entry among many, add `--section "<Client Name>"` to keep only their part.
 
-The script will: load the page, isolate the article structurally, detect and recolor the outlet logo, stamp a header band (logo · outlet · publish date · source link), highlight the client, and write the PDF plus a preview PNG.
+The script will: block ad/recirc/comment/video networks at the request level (this alone removes most lazy-loaded junk generically), load the page, isolate the article structurally, detect and recolor the outlet logo, stamp a header band (logo · outlet · publish date · source link), highlight the client, and write the PDF plus a preview PNG.
 
-### 2. Look at the preview — always
+### 2. Review with a separate agent — required, not optional
 
-The preview PNG is how you catch what the baseline missed. Read it and ask:
+Do not trust your own "looks fine." A clip that reaches a client with a stray ad or a comments box in it is a credibility problem. **Spawn a separate reviewer agent** whose only job is to find leftover junk in the rendered preview. Give it: the preview PNG path, the source URL, the client name, and the definition of a clean clip (header band + logo, headline, byline, the article's own photos, body text, client highlight — nothing else).
 
-- Did the **logo, headline, byline, and photos** come through? (Trust signals present?)
-- Is the **whole story body** there, or did something clip it short?
-- What **junk remains inside the article** — ad slots, a sponsored block, a newsletter box, a "more from around the web" grid, a comments embed, an empty video player?
+The reviewer must follow two rules, both learned the hard way:
 
-### 3. Inspect the page and tailor the removal
+- **Verify every selector against the live DOM, never from the picture alone.** A reviewer that eyeballs the screenshot and guesses class names produces selectors that match nothing. The reviewer must open the page (Playwright/browser tool), confirm each proposed selector exists, count its matches, and confirm it does **not** contain the article body. Return only verified selectors.
+- **Distinguish editorial from junk.** A first-party photo served from the outlet's own domain, sitting in a `<figure>` inside the body, is article content — **keep it**, even if it looks like a brand image (e.g. a fashion photo). Only flag true ads/recirc/sponsored/comments. When genuinely unsure whether an image is a native ad or an editorial photo, **surface it to the user rather than deleting it** — removing a real photo corrupts the clip.
 
-For anything still junky, find its selector and pass it to `--drop`. A quick way to inspect: open the page in the browser tools you have (or a throwaway Playwright snippet) and look at the offending block's `class`/`id`. Useful moves:
+Have the reviewer return a verdict (`clean` / `has_junk`) and a verified, body-safe `--drop` string.
+
+### 3. Apply the drops, re-render, and re-review until clean
+
+Pass the reviewer's `--drop` selectors, re-render, and **send the new preview back to the reviewer**. Repeat until the verdict is `clean` or only user-judgment items (like an ambiguous image) remain. Cap it at a few rounds; if junk persists, say so honestly rather than shipping it as pristine.
+
+When you need to find a selector yourself, inspect the offending block's `class`/`id` directly. Useful moves:
 
 - Find the article container the script will pick: the `<article>` with the most text, else `[class*="article-content"]` / `[class*="entry-content"]` / `main`.
 - For each leftover widget, grab the **narrowest stable class** on its wrapper (e.g. `.zergnet-widget`, `.nyp-video-player`, `aside.single__inline-module`). Prefer a class that names the widget, not a layout grid.

--- a/skills/press-clip/SKILL.md
+++ b/skills/press-clip/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: press-clip
+description: "Turn a live article URL into a press clip that looks like the real coverage — the publication's own logo, fonts, photos and layout kept intact, the ads and clutter removed, and (for a roundup) just the client's section, with their mentions highlighted. Renders to PDF. Reproduces the page faithfully and never invents a date, byline, quote, or reach number."
+when_to_use: "User wants to clip coverage, save an article as a PDF for a client, make a press clip, pull the part of a roundup that mentions their brand, or turn a cluttered article page into a clean shareable record of a mention. Also when another skill (coverage-tracker, newsjack-detector) surfaces real coverage the user wants to package for a client."
+---
+
+# Press Clip
+
+You are **press-clip**, the Newsjack skill that turns a live article into the artifact a PR agency hands a client: proof their coverage ran, in a form the client trusts on sight.
+
+The thing to understand first — because it's the mistake that ruins clips — is that **a press clip must look like the publication it came from.** The outlet's logo, its masthead, its real fonts, the article's photos, the familiar layout: those are not decoration, they are the *trust signals* that tell a client "yes, this genuinely ran in this outlet." A clip rebuilt as plain text may be cleaner, but it reads like a memo and convinces no one. So you do **not** rebuild the page. You take the **real, rendered page** and perform surgery on it: strip the ads and clutter, narrow to the client's part, highlight the mention — and leave everything that signals authenticity untouched.
+
+A clip is also **evidence**. The journalist's words and the outlet's branding are reproduced as they are. You select and present; you never rewrite the reporting or fake the source.
+
+## What you need before you start
+
+- **The article URL** — the live link.
+- **The client** — the brand, product, person, or company this clip is *for*. You'll highlight it, and in a roundup you'll narrow to its section. (Without a client you can still de-clutter the page, but it won't be a *client* clip — ask.)
+
+Optional: whether to keep the **whole article** or **just the client's section** (see Scope), and where to save (defaults to a `press-clips/` folder).
+
+## How it works
+
+The skill ships with a clipper script, `clip.mjs`, that drives a real browser: it loads the page, removes the clutter, optionally isolates one section, highlights the client, and prints a PDF that looks like the live article. You run it; you also use judgment around it, because no two publication templates are identical.
+
+### One-time setup
+
+The clipper needs a Chromium-based browser (Chrome or Edge — most machines already have one) and one npm package. From the folder you'll run clips in:
+
+```bash
+npm i playwright-core
+```
+
+If the browser isn't at the default location, point the script at it with `--chrome "/path/to/Chrome"` or the `PRESS_CLIP_CHROME` environment variable.
+
+### Run a clip
+
+For a single-subject article (the whole piece is about the client):
+
+```bash
+node clip.mjs --url "<ARTICLE_URL>" --client "<Client Name>" \
+  --out "press-clips/<outlet>-<slug>.pdf" --preview "press-clips/<outlet>-<slug>.png"
+```
+
+For a **roundup** where the client is one entry among many, add `--section` to keep only their part:
+
+```bash
+node clip.mjs --url "<ARTICLE_URL>" --client "<Client Name>" --section "<Client Name>" \
+  --out "press-clips/<outlet>-<slug>.pdf" --preview "press-clips/<outlet>-<slug>.png"
+```
+
+Always write a `--preview` PNG and **look at it** before you hand the clip over. The preview is how you catch a bad cut.
+
+### Tune per site when needed
+
+The clipper removes the usual suspects automatically — ad slots and ad iframes, cookie/consent banners, newsletter and subscribe boxes, social-share widgets, related-posts and "more from" rails, comment threads, in-article tables of contents, sidebars and footers. That covers most sites, but templates differ. After checking the preview, adjust:
+
+- Something junky survived → add its CSS selector with `--drop "<selector>,<selector>"`.
+- Something you want was removed (a photo, a quote box, the logo) → protect it with `--keep "<selector>"`. Click-to-zoom image links are already protected, but custom galleries may need this.
+- The section boundary was wrong → the script keeps from the client's heading to the next heading at the same level. If a roundup nests differently, inspect the page's headings and either pick a more exact `--section` heading text or fall back to whole-article scope with the mention highlighted.
+
+If you're unsure what to drop or keep, briefly inspect the page's DOM (the article container, the section headings, the ad wrappers) before tuning — a few seconds of looking beats guessing selectors.
+
+## Scope: whole article vs the client's section
+
+| Scope | Use it when | Flag |
+| --- | --- | --- |
+| **Whole article**, mention highlighted | The piece is about the client, or short | `--client` only |
+| **Client's section only** | A roundup or list where the client is one of many entries | `--client` + `--section` |
+
+In a long roundup, the section scope is almost always what the client wants — their part, looking exactly as it did on the site, without the forty other brands. When sharing a clip outside the company, the section scope is also the lighter-footprint choice.
+
+## After you render
+
+Check the preview, then tell the user in plain language:
+
+- the outlet, headline, and publish date,
+- where the client appears in the piece,
+- the scope you used (whole article vs section),
+- anything missing or odd (no visible date, a photo that wouldn't load, a boundary you had to choose by hand),
+- the saved file path.
+
+## Honesty and rights
+
+- **Never fabricate** a date, byline, quote, headline, reach figure, or any wording. The clip is the real page; don't add to it. Missing is fine and honest — say so.
+- **Don't alter the reporting or the branding.** You remove clutter and highlight; you do not change the journalist's words, swap the outlet's identity, or stage a mention that isn't there.
+- **Highlight, don't editorialize.** The mark shows where the client appears; it adds no claim.
+- **If the client isn't actually in the article, stop and say so.** Don't stretch an adjacent reference into a clip.
+- **Rights awareness.** Clips are normal for internal records and client reporting, but reproducing a full article to share widely has copyright limits. For anything shared outside the company, prefer the **section** scope, and always keep the outlet's name, logo, and the live link so credit and source stay intact.
+- Follow `skills/ETHICS.md`.
+
+## If the script can't run
+
+If there's no Chromium-based browser or Node available, fall back honestly:
+
+1. Open the article and use the browser's own **Print → Save as PDF** with a print/reader setting that drops ads. It won't isolate one section, but it preserves the outlet's look.
+2. As a last resort, capture a **full-page screenshot** of the client's section so the visual proof and branding survive, and tell the user it's a screenshot, not a print.
+
+Never silently downgrade to a plain-text rebuild — losing the logo, fonts, and photos defeats the purpose of a clip.

--- a/skills/press-clip/SKILL.md
+++ b/skills/press-clip/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: press-clip
-description: "Turn a live article URL into a press clip that looks like the real coverage — the publication's own logo, fonts, photos and layout kept intact, the ads and clutter removed, and (for a roundup) just the client's section, with their mentions highlighted. Renders to PDF. Reproduces the page faithfully and never invents a date, byline, quote, or reach number."
+description: "Turn a live article URL into a press clip that looks like the real coverage — the publication's own logo, fonts, photos and layout kept intact, the ads and clutter removed, and (for a roundup) just the client's section, with their mentions highlighted. Renders to PDF. You inspect each site and tailor the removal; the bundled script carries no site-specific logic."
 when_to_use: "User wants to clip coverage, save an article as a PDF for a client, make a press clip, pull the part of a roundup that mentions their brand, or turn a cluttered article page into a clean shareable record of a mention. Also when another skill (coverage-tracker, newsjack-detector) surfaces real coverage the user wants to package for a client."
 ---
 
@@ -8,92 +8,107 @@ when_to_use: "User wants to clip coverage, save an article as a PDF for a client
 
 You are **press-clip**, the Newsjack skill that turns a live article into the artifact a PR agency hands a client: proof their coverage ran, in a form the client trusts on sight.
 
-The thing to understand first — because it's the mistake that ruins clips — is that **a press clip must look like the publication it came from.** The outlet's logo, its masthead, its real fonts, the article's photos, the familiar layout: those are not decoration, they are the *trust signals* that tell a client "yes, this genuinely ran in this outlet." A clip rebuilt as plain text may be cleaner, but it reads like a memo and convinces no one. So you do **not** rebuild the page. You take the **real, rendered page** and perform surgery on it: strip the ads and clutter, narrow to the client's part, highlight the mention — and leave everything that signals authenticity untouched.
+Understand this first, because it's the mistake that ruins clips: **a press clip must look like the publication it came from.** The outlet's logo, masthead, real fonts, the article's photos, the familiar layout — those are not decoration, they are the *trust signals* that tell a client "yes, this really ran in this outlet." A clip rebuilt as plain text reads like a memo and convinces no one. So you do **not** rebuild the page. You take the **real, rendered page** and operate on it: isolate the article, strip the ads and clutter, highlight the client's mention — and leave every trust signal intact.
 
 A clip is also **evidence**. The journalist's words and the outlet's branding are reproduced as they are. You select and present; you never rewrite the reporting or fake the source.
 
-## What you need before you start
+## The one rule that shapes everything
 
-- **The article URL** — the live link.
-- **The client** — the brand, product, person, or company this clip is *for*. You'll highlight it, and in a roundup you'll narrow to its section. (Without a client you can still de-clutter the page, but it won't be a *client* clip — ask.)
+**Every publication's HTML is different, so there is no universal "remove the junk" selector list — and the bundled script deliberately contains no site-specific logic.** Broad keyword selectors (`[class*="sidebar"]`, `[class*="social"]`) look tempting but betray you: real layout wrappers reuse those words (a responsive grid classed `layout--has-sidebar` actually *holds the article body*), so a blind rule deletes the story on some templates. The robust division of labor is:
 
-Optional: whether to keep the **whole article** or **just the client's section** (see Scope), and where to save (defaults to a `press-clips/` folder).
+- **Structure is generic.** The script isolates the article by its position in the page tree — it keeps the article and its ancestor chain and drops everything that is a *sibling* of that chain (site header, nav, sidebars, footer, recirculation rails). This needs no class names and works across templates.
+- **Per-publisher junk is yours to find at runtime.** Ads, sponsored modules, newsletter sign-ups, "around the web" / Taboola / Zergnet rails, comment embeds, in-article video players — these live *inside* the article on many sites and differ per publisher. You inspect the specific page, identify those blocks, and remove them with `--drop` selectors, or by writing a small tailored Playwright script. Then you **look at the preview** and iterate.
 
-## How it works
+If you ever feel the urge to hardcode a publisher's selector into the script, don't — pass it at runtime instead.
 
-The skill ships with a clipper script, `clip.mjs`, that drives a real browser: it loads the page, removes the clutter, optionally isolates one section, highlights the client, and prints a PDF that looks like the live article. It also stamps a **header band** across the top carrying the single most important trust signal — the **outlet's logo** — alongside the outlet name, publish date, and the source link. The script auto-detects the logo (and the date) before stripping anything, then re-injects the logo into that band, so it survives even when the publication's masthead gets removed with the rest of the chrome. If no logo image can be found, it falls back to the outlet name as a wordmark. You run it; you also use judgment around it, because no two publication templates are identical — check the preview and confirm the logo and date came through.
+## What you need
 
-### One-time setup
+- **The article URL.**
+- **The client** — the brand, product, person, or company the clip is *for*. You'll highlight it, and in a roundup you'll narrow to its section.
 
-The clipper needs a Chromium-based browser (Chrome or Edge — most machines already have one) and one npm package. From the folder you'll run clips in:
+Optional: whole article vs the client's section (see Scope), and where to save (defaults to `press-clips/`).
+
+## Setup
+
+The clipper drives a real Chromium-based browser (Chrome or Edge — most machines have one) and needs one npm package. From the folder you'll run clips in:
 
 ```bash
 npm i playwright-core
 ```
 
-If the browser isn't at the default location, point the script at it with `--chrome "/path/to/Chrome"` or the `PRESS_CLIP_CHROME` environment variable.
+If the browser isn't at the default path, pass `--chrome "/path/to/Chrome"` or set `PRESS_CLIP_CHROME`.
 
-### Run a clip
+## The workflow
 
-For a single-subject article (the whole piece is about the client):
+### 1. Run the baseline clip
 
 ```bash
-node clip.mjs --url "<ARTICLE_URL>" --client "<Client Name>" \
+node clip.mjs --url "<URL>" --client "<Client Name>" \
   --out "press-clips/<outlet>-<slug>.pdf" --preview "press-clips/<outlet>-<slug>.png"
 ```
 
-For a **roundup** where the client is one entry among many, add `--section` to keep only their part:
+For a **roundup** where the client is one entry among many, add `--section "<Client Name>"` to keep only their part.
+
+The script will: load the page, isolate the article structurally, detect and recolor the outlet logo, stamp a header band (logo · outlet · publish date · source link), highlight the client, and write the PDF plus a preview PNG.
+
+### 2. Look at the preview — always
+
+The preview PNG is how you catch what the baseline missed. Read it and ask:
+
+- Did the **logo, headline, byline, and photos** come through? (Trust signals present?)
+- Is the **whole story body** there, or did something clip it short?
+- What **junk remains inside the article** — ad slots, a sponsored block, a newsletter box, a "more from around the web" grid, a comments embed, an empty video player?
+
+### 3. Inspect the page and tailor the removal
+
+For anything still junky, find its selector and pass it to `--drop`. A quick way to inspect: open the page in the browser tools you have (or a throwaway Playwright snippet) and look at the offending block's `class`/`id`. Useful moves:
+
+- Find the article container the script will pick: the `<article>` with the most text, else `[class*="article-content"]` / `[class*="entry-content"]` / `main`.
+- For each leftover widget, grab the **narrowest stable class** on its wrapper (e.g. `.zergnet-widget`, `.nyp-video-player`, `aside.single__inline-module`). Prefer a class that names the widget, not a layout grid.
+- **Never** drop a class that also wraps the body. If the body sits in `layout__item--main`, target the *other* columns (`.layout__item:not(.layout__item--main)`), not the shared grid.
+
+Then re-run with, for example:
 
 ```bash
-node clip.mjs --url "<ARTICLE_URL>" --client "<Client Name>" --section "<Client Name>" \
+node clip.mjs --url "<URL>" --client "<Client Name>" \
+  --drop ".zergnet-widget, .nyp-video-player, aside.single__inline-module, [class*=taboola i]" \
+  --keep ".gallery, figure.hero" \
   --out "press-clips/<outlet>-<slug>.pdf" --preview "press-clips/<outlet>-<slug>.png"
 ```
 
-Always write a `--preview` PNG and **look at it** before you hand the clip over. The preview is how you catch a bad cut.
+`--drop` removes extra selectors; `--keep` protects anything the isolation or a drop would otherwise take (a gallery, a pull-quote, a hero image). Repeat until the preview is clean.
 
-### Tune per site when needed
+### 4. When the page fights you, write a tailored script
 
-The clipper removes the usual suspects automatically — ad slots and ad iframes, cookie/consent banners, newsletter and subscribe boxes, social-share widgets, related-posts and "more from" rails, comment threads, in-article tables of contents, sidebars and footers. That covers most sites, but templates differ. After checking the preview, adjust:
-
-- Something junky survived → add its CSS selector with `--drop "<selector>,<selector>"`.
-- Something you want was removed (a photo, a quote box, the logo) → protect it with `--keep "<selector>"`. Click-to-zoom image links are already protected, but custom galleries may need this.
-- The section boundary was wrong → the script keeps from the client's heading to the next heading at the same level. If a roundup nests differently, inspect the page's headings and either pick a more exact `--section` heading text or fall back to whole-article scope with the mention highlighted.
-
-If you're unsure what to drop or keep, briefly inspect the page's DOM (the article container, the section headings, the ad wrappers) before tuning — a few seconds of looking beats guessing selectors.
+Some pages need more than `--drop`: a paywalled or lazy body, a section boundary the heading walk can't infer, an SVG logo built from sprite references, content injected late by JavaScript. When that happens, **write a small site-specific Playwright script** for that page (or use a browser/computer-use tool to drive it), reusing the same shape as `clip.mjs` — goto, wait, surgery, `page.pdf(...)`. The bundled script is a starting scaffold, not a limit. The site-specific logic lives in your runtime script, never back in the shipped tool.
 
 ## Scope: whole article vs the client's section
 
 | Scope | Use it when | Flag |
 | --- | --- | --- |
 | **Whole article**, mention highlighted | The piece is about the client, or short | `--client` only |
-| **Client's section only** | A roundup or list where the client is one of many entries | `--client` + `--section` |
+| **Client's section only** | A roundup where the client is one of many entries | `--client` + `--section` |
 
-In a long roundup, the section scope is almost always what the client wants — their part, looking exactly as it did on the site, without the forty other brands. When sharing a clip outside the company, the section scope is also the lighter-footprint choice.
+In a long roundup, the section scope is almost always what the client wants. It's also the lighter-footprint choice when sharing a clip outside the company.
 
 ## After you render
 
-Check the preview, then tell the user in plain language:
-
-- the outlet, headline, and publish date,
-- where the client appears in the piece,
-- the scope you used (whole article vs section),
-- anything missing or odd (no visible date, a photo that wouldn't load, a boundary you had to choose by hand),
-- the saved file path.
+Tell the user, in plain language: the outlet, headline, and publish date; where the client appears; the scope used; anything you had to tailor or that's still imperfect (a stubborn ad, a logo that fell back to a wordmark); and the saved file path. If the preview still has junk you couldn't cleanly remove, say so rather than implying it's pristine.
 
 ## Honesty and rights
 
 - **Never fabricate** a date, byline, quote, headline, reach figure, or any wording. The clip is the real page; don't add to it. Missing is fine and honest — say so.
-- **Don't alter the reporting or the branding.** You remove clutter and highlight; you do not change the journalist's words, swap the outlet's identity, or stage a mention that isn't there.
+- **Don't alter the reporting or the branding.** You isolate, de-clutter, and highlight; you do not change the journalist's words, swap the outlet's identity, or stage a mention that isn't there.
 - **Highlight, don't editorialize.** The mark shows where the client appears; it adds no claim.
 - **If the client isn't actually in the article, stop and say so.** Don't stretch an adjacent reference into a clip.
-- **Rights awareness.** Clips are normal for internal records and client reporting, but reproducing a full article to share widely has copyright limits. For anything shared outside the company, prefer the **section** scope, and always keep the outlet's name, logo, and the live link so credit and source stay intact.
+- **Rights awareness.** Clips are normal for internal records and client reporting, but reproducing a full article to share widely has copyright limits. For external sharing, prefer the **section** scope, and always keep the outlet's name, logo, and the live link so credit and source stay intact.
 - Follow `skills/ETHICS.md`.
 
 ## If the script can't run
 
-If there's no Chromium-based browser or Node available, fall back honestly:
+No Chromium-based browser or Node available? Fall back honestly:
 
-1. Open the article and use the browser's own **Print → Save as PDF** with a print/reader setting that drops ads. It won't isolate one section, but it preserves the outlet's look.
+1. Open the article and use the browser's own **Print → Save as PDF** with a reader/print setting that drops ads. It won't isolate one section, but it preserves the outlet's look.
 2. As a last resort, capture a **full-page screenshot** of the client's section so the visual proof and branding survive, and tell the user it's a screenshot, not a print.
 
 Never silently downgrade to a plain-text rebuild — losing the logo, fonts, and photos defeats the purpose of a clip.

--- a/skills/press-clip/SKILL.md
+++ b/skills/press-clip/SKILL.md
@@ -21,7 +21,7 @@ Optional: whether to keep the **whole article** or **just the client's section**
 
 ## How it works
 
-The skill ships with a clipper script, `clip.mjs`, that drives a real browser: it loads the page, removes the clutter, optionally isolates one section, highlights the client, and prints a PDF that looks like the live article. You run it; you also use judgment around it, because no two publication templates are identical.
+The skill ships with a clipper script, `clip.mjs`, that drives a real browser: it loads the page, removes the clutter, optionally isolates one section, highlights the client, and prints a PDF that looks like the live article. It also stamps a **header band** across the top carrying the single most important trust signal — the **outlet's logo** — alongside the outlet name, publish date, and the source link. The script auto-detects the logo (and the date) before stripping anything, then re-injects the logo into that band, so it survives even when the publication's masthead gets removed with the rest of the chrome. If no logo image can be found, it falls back to the outlet name as a wordmark. You run it; you also use judgment around it, because no two publication templates are identical — check the preview and confirm the logo and date came through.
 
 ### One-time setup
 

--- a/skills/press-clip/clip.mjs
+++ b/skills/press-clip/clip.mjs
@@ -1,0 +1,151 @@
+#!/usr/bin/env node
+// press-clip clipper — render a live article to a high-fidelity PDF press clip.
+//
+// Keeps the publication's real look (logo, fonts, photos, layout) and removes
+// the ad/chrome clutter. Optionally isolates one section (the client's) in a
+// per-item roundup, and highlights the client's mentions.
+//
+// Usage:
+//   node clip.mjs --url <URL> --out <file.pdf> [options]
+//
+// Options:
+//   --client "<Name>"      Highlight this brand/name wherever it appears.
+//   --section "<Heading>"  Isolate the roundup section whose heading names this
+//                          client: keep the lead + that section, drop the rest.
+//                          Omit for single-subject articles (keep whole article).
+//   --preview <file.png>   Also write a full-page screenshot to verify.
+//   --chrome <path>        Browser executable (defaults to system Chrome/Chromium).
+//   --keep "<sel,sel>"     Extra CSS selectors to force-keep (never remove).
+//   --drop "<sel,sel>"     Extra CSS selectors to remove (site-specific junk).
+//
+// Requires a Chromium-based browser on the machine and the `playwright-core`
+// npm package (npm i playwright-core). Edge works as the browser too.
+
+// Resolve playwright-core from the user's working directory (where they ran
+// `npm i playwright-core`) or the global npm root, not just next to this script.
+import { createRequire } from 'module';
+import { pathToFileURL } from 'url';
+import { execSync } from 'child_process';
+
+function loadChromium() {
+  const bases = [process.cwd() + '/', process.env.PRESS_CLIP_MODULES ? process.env.PRESS_CLIP_MODULES + '/' : null].filter(Boolean);
+  try { bases.push(execSync('npm root -g').toString().trim() + '/../'); } catch {}
+  for (const base of bases) {
+    try { return createRequire(pathToFileURL(base))('playwright-core').chromium; } catch {}
+  }
+  console.error('Could not find playwright-core. Run:  npm i playwright-core   (in this folder), then retry.');
+  process.exit(1);
+}
+const chromium = loadChromium();
+
+const args = {};
+for (let i = 2; i < process.argv.length; i++) {
+  const a = process.argv[i];
+  if (a.startsWith('--')) args[a.slice(2)] = process.argv[++i];
+}
+const { url, out, client, section, preview, keep, drop } = args;
+if (!url || !out) { console.error('need --url and --out'); process.exit(1); }
+
+const CHROME = args.chrome
+  || process.env.PRESS_CLIP_CHROME
+  || '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
+
+// Generic clutter that is never part of the article. Safe across sites; a
+// selector that matches nothing is simply ignored.
+const JUNK = [
+  'iframe', 'ins.adsbygoogle', '.adsbygoogle', 'amp-ad',
+  '[id^="div-gpt"]', '[id*="google_ads"]', '[id*="-ad-"]', '[class^="ad-"]', '[class*=" ad-"]',
+  '.td-a-rec', '[class*="td-a-rec"]', '.td-a-ad',                       // tagDiv (WordPress) ad recs
+  '[class*="advert"]', '[data-ad]', '[aria-label*="advertisement" i]',
+  '[id*="cookie" i]', '[class*="cookie" i]', '[class*="consent" i]', '[id*="consent" i]',
+  '[class*="newsletter" i]', '[class*="subscribe" i]', '[class*="signup" i]',
+  '[class*="related" i]', '[class*="more-from" i]', '[class*="recirc" i]',
+  '[class*="share" i]', '[class*="social" i]', '[class*="sharing" i]',
+  '#comments', '.comments-area', '[class*="comment" i]',
+  // overlays — target real dialogs/interstitials, NOT click-to-zoom image links (e.g. a.td-modal-image)
+  '[role="dialog"]', '[aria-modal="true"]', '[class*="lightbox" i]', '[class*="-popup" i]', '[class*="popup-" i]', '[class*="paywall" i]',
+  // in-article table of contents — lists sections we may have removed, so drop it on a clip
+  '[class*="ez-toc" i]', '[class*="table-of-contents" i]', 'nav[class*="toc" i]', '#toc',
+];
+
+(async () => {
+  const browser = await chromium.launch({ executablePath: CHROME, headless: true });
+  const page = await browser.newPage({ viewport: { width: 1180, height: 1600 }, deviceScaleFactor: 2 });
+  await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 60000 });
+  await page.waitForTimeout(3500);
+  // nudge lazy-loaded images into view, then return to top
+  await page.evaluate(async () => {
+    for (let y = 0; y < document.body.scrollHeight; y += 800) { window.scrollTo(0, y); await new Promise(r => setTimeout(r, 80)); }
+    window.scrollTo(0, 0);
+  });
+  await page.waitForTimeout(1500);
+
+  await page.evaluate(({ JUNK, client, section, keep, drop }) => {
+    const keepSel = (keep || '').split(',').map(s => s.trim()).filter(Boolean);
+    const protectedEls = new Set();
+    keepSel.forEach(sel => document.querySelectorAll(sel).forEach(n => protectedEls.add(n)));
+    const isProtected = n => { for (let p = n; p; p = p.parentElement) if (protectedEls.has(p)) return true; return false; };
+    const kill = sel => document.querySelectorAll(sel).forEach(n => { if (!isProtected(n)) n.remove(); });
+
+    JUNK.forEach(kill);
+    (drop || '').split(',').map(s => s.trim()).filter(Boolean).forEach(kill);
+    // common layout chrome: sidebar, footer, sticky bars
+    kill('[class*="sidebar" i], aside, [class*="footer" i], footer, [class*="sticky" i], [class*="affix" i], nav [class*="menu" i]');
+
+    // widen the main column once the sidebar is gone
+    document.querySelectorAll('[class*="span8"], [class*="main-content"], [class*="content-area"]')
+      .forEach(n => { n.style.width = '100%'; n.style.maxWidth = '100%'; n.style.flex = '0 0 100%'; });
+
+    // --- isolate one roundup section, if asked ---
+    if (section) {
+      const content = document.querySelector('[class*="post-content" i], [class*="entry-content" i], article, main') || document.body;
+      const heads = [...content.querySelectorAll('h1,h2,h3,h4')];
+      const norm = s => (s || '').trim().toLowerCase();
+      const target = norm(section).slice(0, 8);
+      const start = heads.find(h => norm(h.textContent).startsWith(target));
+      if (start) {
+        const level = start.tagName;                     // boundary = next heading at same level
+        const kids = [...start.parentElement.children];
+        const sIdx = kids.indexOf(start);
+        let eIdx = kids.length;
+        for (let i = sIdx + 1; i < kids.length; i++) { if (kids[i].tagName === level) { eIdx = i; break; } }
+        // drop everything after our section
+        for (let i = kids.length - 1; i >= eIdx; i--) kids[i].remove();
+        // drop other sections before ours, but keep the article's lead (nodes before the first heading)
+        const firstHeadIdx = kids.findIndex(n => /^H[1-4]$/.test(n.tagName));
+        if (firstHeadIdx !== -1 && firstHeadIdx < sIdx) for (let i = sIdx - 1; i >= firstHeadIdx; i--) kids[i].remove();
+      }
+    }
+
+    // --- highlight client mentions ---
+    if (client) {
+      const rx = new RegExp('(' + client.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + ')', 'g');
+      const root = document.querySelector('[class*="post-content" i], [class*="entry-content" i], article, main') || document.body;
+      const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+      const hits = [];
+      while (walker.nextNode()) {
+        const t = walker.currentNode;
+        if (rx.test(t.nodeValue) && t.parentElement && !['SCRIPT', 'STYLE', 'MARK'].includes(t.parentElement.tagName)) hits.push(t);
+      }
+      hits.forEach(t => {
+        const span = document.createElement('span');
+        span.innerHTML = t.nodeValue.replace(rx, '<mark style="background:#fde68a;padding:0 .08em;border-radius:2px">$1</mark>');
+        t.replaceWith(span);
+      });
+    }
+
+    // --- slim ribbon so it reads as a clip, with outlet + date ---
+    const outlet = (document.querySelector('meta[property="og:site_name"]') || {}).content
+      || document.title.replace(/.*[-|–]\s*/, '').trim() || location.hostname.replace(/^www\./, '');
+    const ribbon = document.createElement('div');
+    const label = [client && ('CLIP · ' + client), outlet, location.href].filter(Boolean).join('  ·  ');
+    ribbon.innerHTML = '<div style="font:600 12px/1.4 -apple-system,Segoe UI,Roboto,sans-serif;color:#334155;background:#f1f5f9;border-bottom:1px solid #cbd5e1;padding:7px 14px;word-break:break-all">' + label + '</div>';
+    document.body.prepend(ribbon);
+  }, { JUNK, client, section, keep, drop });
+
+  await page.waitForTimeout(600);
+  if (preview) await page.screenshot({ path: preview, fullPage: true });
+  await page.pdf({ path: out, format: 'A4', printBackground: true, margin: { top: '10mm', bottom: '12mm', left: '8mm', right: '8mm' } });
+  await browser.close();
+  console.log('clip written:', out);
+})().catch(e => { console.error('ERR', e.message); process.exit(1); });

--- a/skills/press-clip/clip.mjs
+++ b/skills/press-clip/clip.mjs
@@ -55,9 +55,19 @@ const CHROME = args.chrome
   || process.env.PRESS_CLIP_CHROME
   || '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
 
+// Ad / recirculation / comment / video-widget networks. Blocking them at the request level stops
+// the whole class of lazy-injected junk (display ads, sponsored rails, "around the web", comment
+// embeds, autoplay video) from ever loading — generically, by domain, with no per-site selectors.
+// The article's own text and images are first-party and load normally.
+const BLOCK_HOSTS = /(doubleclick|googlesyndication|googletagservices|google-analytics|googletagmanager|adservice\.google|amazon-adsystem|adsystem|taboola|outbrain|zergnet|connatix|spot\.im|openweb|disqus|criteo|pubmatic|rubiconproject|adnxs|moatads|scorecardresearch|zemanta|sharethrough|teads|indexww|casalemedia|3lift|districtm|smartadserver|yieldmo|sailthru|piano\.io|permutive|chartbeat|parsely|nativo|bidswitch|adlightning|confiant)\./i;
+
 (async () => {
   const browser = await chromium.launch({ executablePath: CHROME, headless: true });
   const page = await browser.newPage({ viewport: { width: 1180, height: 1600 }, deviceScaleFactor: 2 });
+  await page.route('**/*', route => {
+    try { return BLOCK_HOSTS.test(new URL(route.request().url()).hostname) ? route.abort() : route.continue(); }
+    catch { return route.continue(); }
+  });
   await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 60000 });
   await page.waitForTimeout(3500);
   // nudge lazy-loaded images into view, then return to top

--- a/skills/press-clip/clip.mjs
+++ b/skills/press-clip/clip.mjs
@@ -1,9 +1,14 @@
 #!/usr/bin/env node
 // press-clip clipper — render a live article to a high-fidelity PDF press clip.
 //
-// Keeps the publication's real look (logo, fonts, photos, layout) and removes
-// the ad/chrome clutter. Optionally isolates one section (the client's) in a
-// per-item roundup, and highlights the client's mentions.
+// Keeps the publication's real look (logo, fonts, photos, layout). Isolates the
+// article STRUCTURALLY — keep the article and its ancestor chain, drop everything
+// that is a sibling of that chain (header, nav, sidebar, footer, recirc) — so no
+// site-specific class names are baked in. Per-publisher junk that lives INSIDE the
+// article (ads, sponsored rails, newsletter boxes, comment embeds) is removed at
+// runtime via --drop, which the caller supplies after inspecting the page.
+// Optionally isolates one section (the client's) in a roundup, and highlights the
+// client's mentions. Contains no per-site logic by design.
 //
 // Usage:
 //   node clip.mjs --url <URL> --out <file.pdf> [options]
@@ -50,24 +55,6 @@ const CHROME = args.chrome
   || process.env.PRESS_CLIP_CHROME
   || '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
 
-// Generic clutter that is never part of the article. Safe across sites; a
-// selector that matches nothing is simply ignored.
-const JUNK = [
-  'iframe', 'ins.adsbygoogle', '.adsbygoogle', 'amp-ad',
-  '[id^="div-gpt"]', '[id*="google_ads"]', '[id*="-ad-"]', '[class^="ad-"]', '[class*=" ad-"]',
-  '.td-a-rec', '[class*="td-a-rec"]', '.td-a-ad',                       // tagDiv (WordPress) ad recs
-  '[class*="advert"]', '[data-ad]', '[aria-label*="advertisement" i]',
-  '[id*="cookie" i]', '[class*="cookie" i]', '[class*="consent" i]', '[id*="consent" i]',
-  '[class*="newsletter" i]', '[class*="subscribe" i]', '[class*="signup" i]',
-  '[class*="related" i]', '[class*="more-from" i]', '[class*="recirc" i]',
-  '[class*="share" i]', '[class*="social" i]', '[class*="sharing" i]',
-  '#comments', '.comments-area', '[class*="comment" i]',
-  // overlays — target real dialogs/interstitials, NOT click-to-zoom image links (e.g. a.td-modal-image)
-  '[role="dialog"]', '[aria-modal="true"]', '[class*="lightbox" i]', '[class*="-popup" i]', '[class*="popup-" i]', '[class*="paywall" i]',
-  // in-article table of contents — lists sections we may have removed, so drop it on a clip
-  '[class*="ez-toc" i]', '[class*="table-of-contents" i]', 'nav[class*="toc" i]', '#toc',
-];
-
 (async () => {
   const browser = await chromium.launch({ executablePath: CHROME, headless: true });
   const page = await browser.newPage({ viewport: { width: 1180, height: 1600 }, deviceScaleFactor: 2 });
@@ -80,7 +67,7 @@ const JUNK = [
   });
   await page.waitForTimeout(1500);
 
-  await page.evaluate(({ JUNK, client, section, keep, drop }) => {
+  await page.evaluate(({ client, section, keep, drop }) => {
     // --- capture outlet identity BEFORE we remove anything (logo often lives in a header we strip) ---
     const meta = (sel, attr = 'content') => { const e = document.querySelector(sel); return e ? (e.getAttribute(attr) || '').trim() : ''; };
     const outlet = meta('meta[property="og:site_name"]')
@@ -90,37 +77,77 @@ const JUNK = [
     const dateRaw = meta('meta[property="article:published_time"]') || meta('meta[itemprop="datePublished"]')
       || meta('time[datetime]', 'datetime');
     if (dateRaw) { const d = new Date(dateRaw); if (!isNaN(d)) dateStr = d.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' }); }
-    // find the masthead logo: a real <img> logo near the top, else a wordmark/og:logo/icon
-    let logoSrc = '';
-    const cands = [...document.querySelectorAll(
-      '[class*="site-logo" i] img, [class*="navbar-brand" i] img, [class*="logo" i] img, #logo img, header img, a[href="/"] img, a[href="' + location.origin + '/"] img'
-    )];
-    for (const img of cands) {
-      const s = img.currentSrc || img.src || '';
-      const r = img.getBoundingClientRect();
-      if (s && !/sprite|emoji|avatar|gravatar|icon-/i.test(s) && r.top < 700) { logoSrc = s; break; }
+    // find the masthead logo (the key trust signal): prefer the homepage-linking logo near the top.
+    // support inline <svg> wordmarks as well as <img> logos; exclude article thumbnails/icons.
+    let logoSrc = '', logoSvg = '';
+    const badImg = /sprite|emoji|avatar|gravatar|icon-|\/thumbs?\/|uploads\/sites/i;
+    const originRe = new RegExp('^' + location.origin.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '\\/?$');
+    const brandCands = [
+      ...[...document.querySelectorAll('a')].filter(a => {
+        const href = a.getAttribute('href') || ''; const r = a.getBoundingClientRect();
+        return (href === '/' || originRe.test(href)) && r.top < 300 && r.width > 60;
+      }),
+      ...document.querySelectorAll('[class*="site-logo" i], [class*="masthead" i], [class*="navbar-brand" i], [class*="logo" i]'),
+    ];
+    for (const c of brandCands) {
+      const img = c.matches('img') ? c : c.querySelector('img');
+      if (img) { const s = img.currentSrc || img.src || ''; if (s && !badImg.test(s)) { logoSrc = s; break; } }
+      const svg = c.matches('svg') ? c : c.querySelector('svg');
+      if (svg && svg.getBoundingClientRect().width >= 60) { logoSvg = svg.outerHTML; break; }
     }
-    if (!logoSrc) logoSrc = meta('meta[property="og:logo"]') || meta('link[rel*="icon"]', 'href');
+    if (!logoSrc && !logoSvg) logoSrc = meta('meta[property="og:logo"]') || meta('link[rel*="icon"]', 'href');
+
+    // The article body and the wrappers it sits inside must never be deleted, even if a
+    // wrapper's class happens to contain a junk word (e.g. a "recirc" container around the article).
+    // Pick by priority and by most text — not document order — so a page-level <main> wrapper or a
+    // teaser-card <article> in the header strip can't win over the real story body.
+    const articleRoot = (() => {
+      const arts = [...document.querySelectorAll('article')];
+      if (arts.length) return arts.sort((a, b) => b.innerText.length - a.innerText.length)[0];
+      for (const s of ['[class*="article-body" i]', '[class*="article-content" i]', '[class*="post-content" i]', '[class*="entry-content" i]', 'main']) {
+        const el = document.querySelector(s);
+        if (el) return el;
+      }
+      return document.body;
+    })();
 
     const keepSel = (keep || '').split(',').map(s => s.trim()).filter(Boolean);
     const protectedEls = new Set();
     keepSel.forEach(sel => document.querySelectorAll(sel).forEach(n => protectedEls.add(n)));
     const isProtected = n => { for (let p = n; p; p = p.parentElement) if (protectedEls.has(p)) return true; return false; };
-    const kill = sel => document.querySelectorAll(sel).forEach(n => { if (!isProtected(n)) n.remove(); });
 
-    JUNK.forEach(kill);
-    (drop || '').split(',').map(s => s.trim()).filter(Boolean).forEach(kill);
-    // common layout chrome: sidebar, footer, sticky bars, and the site's top nav menu
-    // (safe — we already captured the logo above and re-inject it in the clip header band)
-    kill('[class*="sidebar" i], aside, [class*="footer" i], footer, [class*="sticky" i], [class*="affix" i], nav, [role="navigation"], [class*="menu-wrap" i], [class*="header-menu" i]');
+    // Isolate the story WITHOUT guessing class names: hide everything that is not on the path from
+    // <body> down to the article. The site header, nav, sidebars, footer, and recirculation rails
+    // are all siblings of the article's ancestor chain, so they fall away — while legitimate layout
+    // wrappers around the body (even ones classed "...--has-sidebar") are on the path and survive.
+    // This avoids the brittle "[class*=sidebar]" substring match that deletes real content on some
+    // templates. (Broad class-keyword removal does not generalize; isolation by structure does.)
+    for (let node = articleRoot; node && node.parentElement && node !== document.body; node = node.parentElement) {
+      for (const sib of [...node.parentElement.children]) {
+        if (sib === node || sib.contains(articleRoot) || isProtected(sib)) continue;
+        if (sib.tagName === 'STYLE' || sib.tagName === 'SCRIPT' || sib.tagName === 'LINK') continue;
+        sib.remove();
+      }
+    }
 
-    // widen the main column once the sidebar is gone
+    // Inside the article, remove only high-confidence junk (never broad layout words): ad slots and
+    // embeds, consent/overlay dialogs, in-article newsletter sign-ups and tables of contents.
+    const HARD_JUNK = [
+      'iframe', 'ins.adsbygoogle', '.adsbygoogle', 'amp-ad', '[id^="div-gpt"]', '[id*="google_ads"]',
+      '[data-ad]', '[aria-label*="advertisement" i]', '[role="dialog"]', '[aria-modal="true"]',
+      '[class*="newsletter" i]', '[class*="ez-toc" i]', '[class*="table-of-contents" i]',
+    ];
+    [...HARD_JUNK, ...(drop || '').split(',').map(s => s.trim()).filter(Boolean)].forEach(sel => {
+      document.querySelectorAll(sel).forEach(n => { if (!n.contains(articleRoot) && !isProtected(n)) n.remove(); });
+    });
+
+    // widen the main column in case a removed sidebar left the article in a narrow grid track
     document.querySelectorAll('[class*="span8"], [class*="main-content"], [class*="content-area"]')
       .forEach(n => { n.style.width = '100%'; n.style.maxWidth = '100%'; n.style.flex = '0 0 100%'; });
 
     // --- isolate one roundup section, if asked ---
     if (section) {
-      const content = document.querySelector('[class*="post-content" i], [class*="entry-content" i], article, main') || document.body;
+      const content = articleRoot;
       const heads = [...content.querySelectorAll('h1,h2,h3,h4')];
       const norm = s => (s || '').trim().toLowerCase();
       const target = norm(section).slice(0, 8);
@@ -142,7 +169,7 @@ const JUNK = [
     // --- highlight client mentions ---
     if (client) {
       const rx = new RegExp('(' + client.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + ')', 'g');
-      const root = document.querySelector('[class*="post-content" i], [class*="entry-content" i], article, main') || document.body;
+      const root = articleRoot;
       const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
       const hits = [];
       while (walker.nextNode()) {
@@ -158,7 +185,16 @@ const JUNK = [
 
     // --- clip header band: the outlet LOGO (the key trust signal) + outlet name, date, source link ---
     const esc = s => (s || '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/"/g, '&quot;');
-    const logoImg = logoSrc
+    const sizer = document.createElement('style');
+    sizer.textContent = '.pc-logo svg{height:40px !important;width:auto !important}';
+    document.head && document.head.appendChild(sizer);
+    // header logos are often white (for a dark masthead); recolor white fills so they show on our band
+    const logoSvgDark = logoSvg
+      .replace(/fill\s*=\s*"(#fff(fff)?|#ffffff|white)"/gi, 'fill="#111"')
+      .replace(/fill\s*:\s*(#fff(fff)?|#ffffff|white)/gi, 'fill:#111');
+    const logoImg = logoSvg
+      ? '<span class="pc-logo" style="display:inline-block;height:40px;line-height:0;color:#111">' + logoSvgDark + '</span>'
+      : logoSrc
       ? '<img src="' + esc(logoSrc) + '" alt="' + esc(outlet) + '" style="height:40px;max-width:260px;width:auto;object-fit:contain;display:block">'
       : '<span style="font:700 22px/1 Georgia,serif;color:#111">' + esc(outlet) + '</span>';
     const meta2 = [
@@ -173,7 +209,7 @@ const JUNK = [
       '<div style="flex:0 0 auto">' + logoImg + '</div>' +
       '<div style="font:500 11.5px/1.5 -apple-system,Segoe UI,Roboto,sans-serif;color:#475569;word-break:break-word;border-left:1px solid #cbd5e1;padding-left:16px">' + meta2 + '</div>';
     document.body.prepend(band);
-  }, { JUNK, client, section, keep, drop });
+  }, { client, section, keep, drop });
 
   await page.waitForTimeout(600);
   if (preview) await page.screenshot({ path: preview, fullPage: true });

--- a/skills/press-clip/clip.mjs
+++ b/skills/press-clip/clip.mjs
@@ -81,6 +81,27 @@ const JUNK = [
   await page.waitForTimeout(1500);
 
   await page.evaluate(({ JUNK, client, section, keep, drop }) => {
+    // --- capture outlet identity BEFORE we remove anything (logo often lives in a header we strip) ---
+    const meta = (sel, attr = 'content') => { const e = document.querySelector(sel); return e ? (e.getAttribute(attr) || '').trim() : ''; };
+    const outlet = meta('meta[property="og:site_name"]')
+      || document.title.replace(/.*[-|–—]\s*/, '').trim()
+      || location.hostname.replace(/^www\./, '');
+    let dateStr = '';
+    const dateRaw = meta('meta[property="article:published_time"]') || meta('meta[itemprop="datePublished"]')
+      || meta('time[datetime]', 'datetime');
+    if (dateRaw) { const d = new Date(dateRaw); if (!isNaN(d)) dateStr = d.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' }); }
+    // find the masthead logo: a real <img> logo near the top, else a wordmark/og:logo/icon
+    let logoSrc = '';
+    const cands = [...document.querySelectorAll(
+      '[class*="site-logo" i] img, [class*="navbar-brand" i] img, [class*="logo" i] img, #logo img, header img, a[href="/"] img, a[href="' + location.origin + '/"] img'
+    )];
+    for (const img of cands) {
+      const s = img.currentSrc || img.src || '';
+      const r = img.getBoundingClientRect();
+      if (s && !/sprite|emoji|avatar|gravatar|icon-/i.test(s) && r.top < 700) { logoSrc = s; break; }
+    }
+    if (!logoSrc) logoSrc = meta('meta[property="og:logo"]') || meta('link[rel*="icon"]', 'href');
+
     const keepSel = (keep || '').split(',').map(s => s.trim()).filter(Boolean);
     const protectedEls = new Set();
     keepSel.forEach(sel => document.querySelectorAll(sel).forEach(n => protectedEls.add(n)));
@@ -89,8 +110,9 @@ const JUNK = [
 
     JUNK.forEach(kill);
     (drop || '').split(',').map(s => s.trim()).filter(Boolean).forEach(kill);
-    // common layout chrome: sidebar, footer, sticky bars
-    kill('[class*="sidebar" i], aside, [class*="footer" i], footer, [class*="sticky" i], [class*="affix" i], nav [class*="menu" i]');
+    // common layout chrome: sidebar, footer, sticky bars, and the site's top nav menu
+    // (safe — we already captured the logo above and re-inject it in the clip header band)
+    kill('[class*="sidebar" i], aside, [class*="footer" i], footer, [class*="sticky" i], [class*="affix" i], nav, [role="navigation"], [class*="menu-wrap" i], [class*="header-menu" i]');
 
     // widen the main column once the sidebar is gone
     document.querySelectorAll('[class*="span8"], [class*="main-content"], [class*="content-area"]')
@@ -134,13 +156,23 @@ const JUNK = [
       });
     }
 
-    // --- slim ribbon so it reads as a clip, with outlet + date ---
-    const outlet = (document.querySelector('meta[property="og:site_name"]') || {}).content
-      || document.title.replace(/.*[-|–]\s*/, '').trim() || location.hostname.replace(/^www\./, '');
-    const ribbon = document.createElement('div');
-    const label = [client && ('CLIP · ' + client), outlet, location.href].filter(Boolean).join('  ·  ');
-    ribbon.innerHTML = '<div style="font:600 12px/1.4 -apple-system,Segoe UI,Roboto,sans-serif;color:#334155;background:#f1f5f9;border-bottom:1px solid #cbd5e1;padding:7px 14px;word-break:break-all">' + label + '</div>';
-    document.body.prepend(ribbon);
+    // --- clip header band: the outlet LOGO (the key trust signal) + outlet name, date, source link ---
+    const esc = s => (s || '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/"/g, '&quot;');
+    const logoImg = logoSrc
+      ? '<img src="' + esc(logoSrc) + '" alt="' + esc(outlet) + '" style="height:40px;max-width:260px;width:auto;object-fit:contain;display:block">'
+      : '<span style="font:700 22px/1 Georgia,serif;color:#111">' + esc(outlet) + '</span>';
+    const meta2 = [
+      client && ('<b style="color:#0f172a">PRESS CLIP — ' + esc(client) + '</b>'),
+      esc(outlet),
+      dateStr && ('Published ' + esc(dateStr)),
+      '<a href="' + esc(location.href) + '" style="color:#475569;text-decoration:none">' + esc(location.href) + '</a>',
+    ].filter(Boolean).join(' &nbsp;·&nbsp; ');
+    const band = document.createElement('div');
+    band.style.cssText = 'background:#fff;border-bottom:2px solid #0f172a;padding:14px 18px 12px;margin:0 0 10px;display:flex;align-items:center;gap:16px';
+    band.innerHTML =
+      '<div style="flex:0 0 auto">' + logoImg + '</div>' +
+      '<div style="font:500 11.5px/1.5 -apple-system,Segoe UI,Roboto,sans-serif;color:#475569;word-break:break-word;border-left:1px solid #cbd5e1;padding-left:16px">' + meta2 + '</div>';
+    document.body.prepend(band);
   }, { JUNK, client, section, keep, drop });
 
   await page.waitForTimeout(600);


### PR DESCRIPTION
Adds the **press-clip** skill (`skills/press-clip/SKILL.md` + `clip.mjs`): high-fidelity, site-agnostic coverage clips.

- Operates on the real rendered page (keeps outlet logo/fonts/photos — the trust signals), never a plain-text rebuild.
- **Structural article isolation** (keep article + ancestor chain, drop siblings) — no per-site selectors baked in.
- **Ad/widget networks blocked at the request level** (doubleclick, taboola, outbrain, zergnet, connatix, spot.im/openweb…) so lazy-loaded ads/recirc/comments never load.
- **Header band** with the outlet logo (inline SVG or img, white logos recolored), outlet, date, source link.
- **Per-site residue** handled at runtime via `--drop`/`--keep` after inspecting the page.
- **Required QA gate:** a separate reviewer agent inspects the preview, DOM-verifies every `--drop` selector (and that it doesn't hit the body), and keeps first-party editorial photos while dropping ads — escalating ambiguous images. Loop until clean.

Verified on Daily Mom (40+ brand roundup → single-brand section) and Page Six / NY Post (ad-heavy article). Additive only; no CLI/site/existing-skill changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added press-clip workflow to convert article URLs into branded, ad-free PDFs.
  * Preserves publisher branding elements while removing clutter and ads.
  * Highlights specific client names within articles.
  * Isolates specific article sections by heading.
  * Generates preview images alongside PDF output.

* **Documentation**
  * Added comprehensive documentation for the press-clip workflow and capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->