### PR TITLE
Reduce site HSTS and document SSL audit

### DIFF
--- a/apps/site/app/connection-help/page.tsx
+++ b/apps/site/app/connection-help/page.tsx
@@ -1,0 +1,70 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Connection help | newsjack.sh",
+  description:
+    "Fixes for Chrome ERR_SSL_PROTOCOL_ERROR and other connection problems with newsjack.sh.",
+};
+
+export default function ConnectionHelp() {
+  return (
+    <main className="min-h-screen bg-zinc-950 px-5 py-12 text-zinc-100 sm:px-8">
+      <div className="mx-auto max-w-3xl">
+        <p className="font-mono text-xs uppercase tracking-[0.22em] text-emerald-300">
+          newsjack.sh
+        </p>
+        <h1 className="mt-5 text-4xl font-semibold tracking-tight text-white sm:text-5xl">
+          Connection help
+        </h1>
+        <p className="mt-5 text-lg leading-8 text-zinc-300">
+          If Chrome shows <code>ERR_SSL_PROTOCOL_ERROR</code>, the most common
+          causes are a corporate or antivirus TLS proxy, an old browser or
+          operating system, or local HSTS state left behind after a failed
+          connection.
+        </p>
+
+        <section className="mt-10 space-y-8">
+          <div>
+            <h2 className="text-xl font-semibold text-white">
+              Quick recovery steps
+            </h2>
+            <ol className="mt-4 list-decimal space-y-4 pl-5 text-zinc-300">
+              <li>
+                Try a personal network or mobile hotspot. If that works, ask
+                IT or your security vendor to allow <code>newsjack.sh</code>{" "}
+                and <code>www.newsjack.sh</code>.
+              </li>
+              <li>
+                In Chrome, open <code>chrome://net-internals/#hsts</code>.
+                Under <strong>Delete domain security policies</strong>, delete{" "}
+                <code>newsjack.sh</code> and <code>www.newsjack.sh</code>, then
+                try the site again.
+              </li>
+              <li>
+                Update Chrome and the operating system. The site requires TLS
+                1.2 or newer, which very old clients do not support by default.
+              </li>
+            </ol>
+          </div>
+
+          <div>
+            <h2 className="text-xl font-semibold text-white">
+              Still blocked?
+            </h2>
+            <p className="mt-4 text-zinc-300">
+              Install from GitHub or share the error with your network
+              administrator:
+            </p>
+            <a
+              className="mt-5 inline-flex rounded-md border border-white/15 bg-white/[0.04] px-4 py-2.5 font-mono text-sm text-zinc-100 transition hover:border-emerald-300/50 hover:bg-emerald-300/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-emerald-300"
+              href="https://github.com/elvisun/newsjack"
+              rel="noreferrer"
+            >
+              github.com/elvisun/newsjack
+            </a>
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/apps/site/app/install.sh/route.ts
+++ b/apps/site/app/install.sh/route.ts
@@ -1,6 +1,8 @@
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 
+import { applySecurityHeaders } from "@/lib/security-headers";
+
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
@@ -22,5 +24,5 @@ export async function GET() {
     "content-type": "text/x-shellscript; charset=utf-8",
   });
 
-  return new Response(body, { headers });
+  return new Response(body, { headers: applySecurityHeaders(headers) });
 }

--- a/apps/site/lib/security-headers.ts
+++ b/apps/site/lib/security-headers.ts
@@ -1,0 +1,7 @@
+export const HSTS_HEADER_NAME = "Strict-Transport-Security";
+export const HSTS_HEADER_VALUE = "max-age=300";
+
+export function applySecurityHeaders(headers: Headers) {
+  headers.set(HSTS_HEADER_NAME, HSTS_HEADER_VALUE);
+  return headers;
+}

--- a/apps/site/next.config.ts
+++ b/apps/site/next.config.ts
@@ -1,5 +1,21 @@
 import type { NextConfig } from "next";
 
-const nextConfig: NextConfig = {};
+import { HSTS_HEADER_NAME, HSTS_HEADER_VALUE } from "./lib/security-headers";
+
+const nextConfig: NextConfig = {
+  async headers() {
+    return [
+      {
+        source: "/:path*",
+        headers: [
+          {
+            key: HSTS_HEADER_NAME,
+            value: HSTS_HEADER_VALUE,
+          },
+        ],
+      },
+    ];
+  },
+};
 
 export default nextConfig;

--- a/apps/site/proxy.ts
+++ b/apps/site/proxy.ts
@@ -7,6 +7,7 @@ import {
   recordTrafficEvent,
   type TrafficEventType,
 } from "./lib/install-telemetry";
+import { applySecurityHeaders } from "./lib/security-headers";
 
 const repoURL = "https://github.com/elvisun/newsjack";
 
@@ -18,11 +19,15 @@ export function proxy(request: NextRequest, event: NextFetchEvent) {
     const url = request.nextUrl.clone();
     url.pathname = "/install.sh";
     recordRequest(event, request, "install_request", installerKind);
-    return NextResponse.rewrite(url);
+    const response = NextResponse.rewrite(url);
+    applySecurityHeaders(response.headers);
+    return response;
   }
 
   recordRequest(event, request, "site_visit", getClientKind(userAgent));
-  return NextResponse.redirect(repoURL, 308);
+  const response = NextResponse.redirect(repoURL, 308);
+  applySecurityHeaders(response.headers);
+  return response;
 }
 
 function recordRequest(

--- a/docs/INVESTIGATION-SSL.md
+++ b/docs/INVESTIGATION-SSL.md
@@ -1,0 +1,214 @@
+# newsjack.sh SSL Investigation
+
+Verified on June 23, 2026 from Toronto/Canada network vantage points.
+
+## Summary
+
+The live Vercel deployment is healthy for modern clients. `www.newsjack.sh`
+serves a valid Let's Encrypt certificate and accepts TLS 1.2 and TLS 1.3.
+Clients limited to TLS 1.0 or 1.1 fail during the TLS handshake with a protocol
+version alert, which can surface in Chrome as `ERR_SSL_PROTOCOL_ERROR`.
+
+The biggest site-side risk was Vercel's default 2-year HSTS header. This PR
+adds a project-level override for app-served responses:
+
+```http
+Strict-Transport-Security: max-age=300
+```
+
+It deliberately does not add `includeSubDomains` or `preload`.
+
+## Repo Configuration Audit
+
+Domain and host references found in this repo:
+
+| File | Purpose | Finding |
+| --- | --- | --- |
+| `apps/site/next.config.ts` | Next.js project config | Now sets `Strict-Transport-Security: max-age=300` for all app paths. |
+| `apps/site/proxy.ts` | Root route behavior | Installer-style user agents on `/` are rewritten to `/install.sh`; browser-style user agents are redirected to GitHub with 308. No apex/www redirect logic lives here. |
+| `apps/site/app/install.sh/route.ts` | Installer response | Serves the bundled shell installer and now sets the same HSTS header. |
+| `apps/site/app/layout.tsx` | Metadata | Uses `https://newsjack.sh` as `metadataBase` and Open Graph URL. |
+| `apps/cli/cmd/newsjack/config.go` | CLI default install URL | Uses `https://newsjack.sh`. |
+| `install.sh` | Installer default URL | Uses `https://newsjack.sh`. |
+| `README.md`, `docs/*`, `harness/*` | Documentation and smoke paths | Mostly use `newsjack.sh` as the short install URL. |
+
+No `vercel.json`, Wrangler config, Cloudflare config, Terraform, or DNS-as-code
+was found in this checkout.
+
+## Live DNS
+
+Observed DNS:
+
+| Host | Records |
+| --- | --- |
+| `newsjack.sh` | Vercel-managed IPv4 A records. Local resolver returned `216.150.1.1` and `216.150.16.1`. No AAAA record observed. |
+| `www.newsjack.sh` | CNAME to `74fcbc460025be37.vercel-dns-016.com.`. IPv4-only Vercel target; no AAAA record observed. |
+
+Different public resolvers may return nearby Vercel anycast addresses, but the
+shape is the same: Vercel-managed IPv4, no IPv6.
+
+## Live Certificate
+
+Observed on `www.newsjack.sh:443`:
+
+| Field | Value |
+| --- | --- |
+| Subject | `CN=www.newsjack.sh` |
+| SAN | `DNS:www.newsjack.sh` |
+| Issuer | Let's Encrypt R12 |
+| Validity | May 25, 2026 01:41:53 GMT to August 23, 2026 01:41:52 GMT |
+
+## Live Redirects
+
+Observed redirects:
+
+| Request | Result |
+| --- | --- |
+| `http://newsjack.sh/` | 308 to `https://newsjack.sh/` |
+| `http://www.newsjack.sh/` | 308 to `https://www.newsjack.sh/` |
+| `https://newsjack.sh/` | 307 to `https://www.newsjack.sh/` |
+| `https://www.newsjack.sh/` with browser UA | 308 to `https://github.com/elvisun/newsjack` |
+| `https://www.newsjack.sh/` with installer UA | 200 installer shell script |
+
+Canonical host decision:
+
+- The live Vercel domain configuration currently treats `www.newsjack.sh` as the
+  canonical custom domain and redirects the apex to `www`.
+- Repo metadata and install documentation mostly use the shorter apex
+  `https://newsjack.sh`.
+- This PR does not change canonical host behavior. Elvis should decide whether
+  to keep apex to `www`, or switch to apex as canonical. The modern norm for
+  small product/install sites is often `www` to apex, but the current setup may
+  have been chosen for Vercel domain management.
+
+Redirect chain risk:
+
+- Browser root load currently has two hops from apex:
+  `https://newsjack.sh/` -> `https://www.newsjack.sh/` -> GitHub.
+- Installer root load from apex has one host-canonicalization hop:
+  `https://newsjack.sh/` -> `https://www.newsjack.sh/` -> installer response.
+- There is no apex/www loop.
+- The apex to `www` hop is a Vercel/domain-layer 307, not repo code. A 308 would
+  be more semantically correct for a permanent canonical redirect, but this PR
+  leaves it unchanged.
+
+## Live HSTS
+
+Before this PR, both `newsjack.sh` and `www.newsjack.sh` returned:
+
+```http
+Strict-Transport-Security: max-age=63072000
+```
+
+No `includeSubDomains` and no `preload` directive were observed.
+
+Vercel documents `strict-transport-security: max-age=63072000` as the default
+for custom domains and says projects can modify it with custom response
+headers:
+
+- https://vercel.com/docs/cdn-security/encryption
+- https://vercel.com/docs/headers/response-headers
+
+This PR changes the app response header to:
+
+```http
+Strict-Transport-Security: max-age=300
+```
+
+Caveat: because the apex to `www` redirect appears to be Vercel domain-layer
+behavior, Elvis should verify after deploy that `https://newsjack.sh/` also
+returns `max-age=300`. If Vercel applies its default before project headers on
+that redirect, the dashboard/domain setting may need a matching change.
+
+Recommended rollout:
+
+| Phase | HSTS value | Timing |
+| --- | --- | --- |
+| 1 | `max-age=300` | Now, while reliability is still being validated. |
+| 2 | `max-age=86400` | After a couple weeks of cross-network validation. |
+| 3 | `max-age=31536000` | Only after confidence is high and without preload. |
+
+Do not add `includeSubDomains` or `preload` without explicit approval.
+
+## HSTS Preload Status
+
+Checked with:
+
+```bash
+curl 'https://hstspreload.org/api/v2/status?domain=newsjack.sh'
+curl 'https://hstspreload.org/api/v2/preloadable?domain=newsjack.sh'
+```
+
+Result:
+
+- Status: `unknown`
+- Preloaded domain: empty
+- Preloadability errors: missing `includeSubDomains` and missing `preload`
+
+That means `newsjack.sh` is not currently on the preload list.
+
+## TLS Support
+
+Observed behavior:
+
+| Client mode | Result |
+| --- | --- |
+| TLS 1.0 | Fails with TLS protocol-version alert. |
+| TLS 1.1 | Fails with TLS protocol-version alert. |
+| TLS 1.2 | Succeeds. |
+| TLS 1.3 | Succeeds. |
+
+Reproduction commands:
+
+```bash
+curl --tlsv1.0 --tls-max 1.0 -I https://www.newsjack.sh/
+curl --tlsv1.1 --tls-max 1.1 -I https://www.newsjack.sh/
+curl --tlsv1.2 --tls-max 1.2 -I https://www.newsjack.sh/
+openssl s_client -tls1_3 -servername www.newsjack.sh -connect www.newsjack.sh:443 </dev/null
+```
+
+Expected:
+
+- TLS 1.0 and 1.1 fail.
+- TLS 1.2 and 1.3 connect.
+
+## Likely User-Side Failure Modes
+
+Most likely causes of `ERR_SSL_PROTOCOL_ERROR` on one Windows Chrome machine:
+
+1. Corporate or antivirus TLS interception. Common products include Zscaler,
+   Cisco Umbrella, Kaspersky, ESET, Bitdefender, and Sophos. The `.sh` TLD is
+   often treated as suspicious or uncategorized.
+2. Old client stack that does not support TLS 1.2 by default.
+3. ISP or DPI filtering of `.sh` domains.
+4. Stale edge state during certificate rotation. This is less likely now because
+   the current certificate is valid and serving correctly.
+
+## User Recovery Path Added
+
+This PR adds:
+
+- `apps/site/app/connection-help/page.tsx`
+- `docs/connection-help.md`
+
+The recovery guidance tells users to try a personal network, clear Chrome HSTS
+state for both `newsjack.sh` and `www.newsjack.sh`, update Chrome/OS, and ask IT
+to allow both hosts.
+
+## Older Client Sanity Check
+
+The marketing/root app is server-rendered and does not require client-side
+application JavaScript for the basic content. The CSS uses modern niceties like
+`text-wrap: balance` through Tailwind utilities; unsupported browsers should
+ignore those declarations rather than fail the page. The larger compatibility
+gate is TLS 1.2, which is controlled by Vercel's edge and cannot be relaxed from
+this repo.
+
+## Left For Elvis To Decide
+
+- Whether the canonical host should remain apex to `www`, or switch to `www` to
+  apex.
+- Whether the apex/domain-layer redirect can be changed from 307 to 308 in
+  Vercel.
+- Whether a public status page is worth adding. This PR does not add one.
+- When to move HSTS from 5 minutes to 1 day, then later to 1 year.

--- a/docs/connection-help.md
+++ b/docs/connection-help.md
@@ -1,0 +1,28 @@
+# Connection Help
+
+Use this when `newsjack.sh` or `www.newsjack.sh` fails with
+`ERR_SSL_PROTOCOL_ERROR` in Chrome.
+
+## Quick Recovery
+
+1. Try a non-corporate network or mobile hotspot. If that works, the likely
+   cause is corporate, antivirus, or ISP filtering of the `.sh` domain.
+2. Clear Chrome's HSTS state:
+   - Open `chrome://net-internals/#hsts`.
+   - Under "Delete domain security policies", delete `newsjack.sh`.
+   - Delete `www.newsjack.sh` too, then try the site again.
+3. Update Chrome and the operating system. `newsjack.sh` requires TLS 1.2 or
+   newer.
+4. If you are on a managed device, ask IT or the security vendor to allow both
+   `newsjack.sh` and `www.newsjack.sh`.
+
+## Useful Diagnostic Commands
+
+```bash
+curl -I https://www.newsjack.sh/
+curl --tls-max 1.1 -I https://www.newsjack.sh/
+```
+
+The first command should connect. The second command should fail with a TLS
+protocol-version error, which confirms that clients older than TLS 1.2 cannot
+connect.


### PR DESCRIPTION
## Summary

- Override Vercel's default HSTS for app-served responses from `max-age=63072000` to `max-age=300`
- Add `/connection-help` plus `docs/connection-help.md` for Chrome `ERR_SSL_PROTOCOL_ERROR` recovery steps
- Add `docs/INVESTIGATION-SSL.md` with verified DNS, TLS, cert, redirect, HSTS, preload, and client-failure findings

## Notes for Elvis

The HSTS reduction is intentional and conservative for Phase 1. It does not add `includeSubDomains` or `preload`.

The apex to `www` redirect appears to be Vercel domain-layer behavior, not repo code. After deploy, verify that `https://newsjack.sh/` also returns `Strict-Transport-Security: max-age=300`; if Vercel applies its default before project headers on that redirect, the matching fix may need to happen in Vercel settings.

## Validation

- `pnpm lint`
- `pnpm test`
- `pnpm build`
- Local header smoke checks on `localhost:3050` for `/`, `/install.sh`, and `/connection-help`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new connection help page to guide users through SSL/TLS troubleshooting steps and common recovery solutions.
  * Enabled HSTS (HTTP Strict-Transport-Security) headers across all pages to enhance security.

* **Documentation**
  * Added SSL/TLS investigation documentation covering technical details and rollout status.
  * Added user recovery guide with quick troubleshooting checklist for connection issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->