### PR TITLE
fix(cli): SSRF guard + body cap on feed fetches, native-only implicit auto-update, CI input hardening

### DIFF
--- a/.github/workflows/agent-harness-integration.yml
+++ b/.github/workflows/agent-harness-integration.yml
@@ -44,9 +44,11 @@ jobs:
 
       - name: Build harness image
         shell: bash
+        env:
+          INPUT_HARNESSES: ${{ inputs.harnesses }}
         run: |
           build_args=()
-          IFS=',' read -ra harnesses <<< "${{ inputs.harnesses }}"
+          IFS=',' read -ra harnesses <<< "$INPUT_HARNESSES"
           for harness in "${harnesses[@]}"; do
             harness="$(echo "$harness" | xargs)"
             if [ -n "$harness" ]; then
@@ -57,14 +59,17 @@ jobs:
 
       - name: Run installer harness
         shell: bash
+        env:
+          INPUT_PRODUCTION_PATH: ${{ inputs.production_path }}
+          INPUT_RUNTIME: ${{ inputs.runtime }}
         run: |
           source_flag="--local-source"
-          if [ "${{ inputs.production_path }}" = "true" ]; then
+          if [ "$INPUT_PRODUCTION_PATH" = "true" ]; then
             source_flag="--production-path"
           fi
 
           harness/scripts/run-ci-installer.sh \
-            --runtime "${{ inputs.runtime }}" \
+            --runtime "$INPUT_RUNTIME" \
             "$source_flag"
 
   windows-build-dist:

--- a/.github/workflows/post-release-smoke.yml
+++ b/.github/workflows/post-release-smoke.yml
@@ -16,6 +16,9 @@ jobs:
     steps:
       - name: Install Newsjack from GitHub Release
         shell: bash
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          GH_REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
           export HOME=/tmp/newsjack-release-smoke
@@ -23,14 +26,14 @@ jobs:
           export NEWSJACK_NO_AUTO_UPDATE=1
           rm -rf "$HOME"
 
-          if [ -n "${{ inputs.version }}" ]; then
-            base="https://github.com/${{ github.repository }}/releases/download/${{ inputs.version }}"
+          if [ -n "$INPUT_VERSION" ]; then
+            base="https://github.com/$GH_REPOSITORY/releases/download/$INPUT_VERSION"
           else
-            base="https://github.com/${{ github.repository }}/releases/latest/download"
+            base="https://github.com/$GH_REPOSITORY/releases/latest/download"
           fi
 
           curl -fsSL "$base/install.sh" | \
-            NEWSJACK_REPO="${{ github.repository }}" \
+            NEWSJACK_REPO="$GH_REPOSITORY" \
             NEWSJACK_RELEASE_BASE="$base" \
             NEWSJACK_RUNTIMES=codex \
             bash
@@ -46,9 +49,11 @@ jobs:
     steps:
       - name: Install from newsjack.sh in Docker
         shell: bash
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
-          version="${{ inputs.version }}"
+          version="$INPUT_VERSION"
           env_args=()
           if [ -n "$version" ]; then
             env_args+=(-e "NEWSJACK_VERSION=$version")
@@ -94,13 +99,16 @@ jobs:
     steps:
       - name: Bootstrap from GitHub Release and smoke the CLI
         shell: pwsh
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          GH_REPOSITORY: ${{ github.repository }}
         run: |
           $ErrorActionPreference = 'Stop'
-          $version = '${{ inputs.version }}'
+          $version = $env:INPUT_VERSION
           $base = if ($version) {
-            "https://github.com/${{ github.repository }}/releases/download/$version"
+            "https://github.com/$env:GH_REPOSITORY/releases/download/$version"
           } else {
-            "https://github.com/${{ github.repository }}/releases/latest/download"
+            "https://github.com/$env:GH_REPOSITORY/releases/latest/download"
           }
 
           $scratch = Join-Path $env:RUNNER_TEMP 'newsjack-release-smoke'

--- a/.github/workflows/post-release-smoke.yml
+++ b/.github/workflows/post-release-smoke.yml
@@ -129,7 +129,7 @@ jobs:
           if ($expected -ne $actual) { throw "checksum mismatch: $expected vs $actual" }
 
           $env:NEWSJACK_HOME = Join-Path $scratch '.newsjack'
-          $env:NEWSJACK_REPO = '${{ github.repository }}'
+          $env:NEWSJACK_REPO = $env:GH_REPOSITORY
           if ($version) { $env:NEWSJACK_RELEASE_BASE = $base }
           $env:NEWSJACK_RUNTIMES = 'claude'
           $env:NEWSJACK_NO_AUTO_UPDATE = '1'

--- a/apps/cli/cmd/newsjack/detector_sources.go
+++ b/apps/cli/cmd/newsjack/detector_sources.go
@@ -96,7 +96,7 @@ func isNewsSearchSyndicationPublication(metadata, item map[string]any) bool {
 func collectFeed(urlOrPath string, limit int) ([]map[string]any, string) {
 	var text string
 	if regexp.MustCompile(`(?i)^https?://`).MatchString(urlOrPath) {
-		resp, err := httpGetRaw(urlOrPath, map[string]string{"Accept": "application/rss+xml, application/atom+xml, text/xml, */*"}, 20*time.Second)
+		resp, err := httpGetRawExternal(urlOrPath, map[string]string{"Accept": "application/rss+xml, application/atom+xml, text/xml, */*"}, 20*time.Second)
 		if err != nil {
 			return nil, fmt.Sprintf("%T: %v", err, err)
 		}
@@ -513,7 +513,10 @@ func mapHackerNews(item map[string]any) map[string]any {
 
 func apiGet(path, bearer string) map[string]any {
 	base := strings.TrimRight(getenv("NEWSJACK_X_API_BASE", "https://api.x.com"), "/")
-	req, _ := http.NewRequest("GET", base+path, nil)
+	req, err := http.NewRequest("GET", base+path, nil)
+	if err != nil {
+		return map[string]any{"error": fmt.Sprintf("%T: %v", err, err)}
+	}
 	req.Header.Set("Authorization", "Bearer "+bearer)
 	req.Header.Set("Accept", "application/json")
 	client := &http.Client{Timeout: 30 * time.Second}
@@ -522,7 +525,10 @@ func apiGet(path, bearer string) map[string]any {
 		return map[string]any{"error": fmt.Sprintf("%T: %v", err, err)}
 	}
 	defer resp.Body.Close()
-	data, _ := io.ReadAll(resp.Body)
+	data, err := readBodyLimited(resp.Body, maxHTTPBodyBytes)
+	if err != nil {
+		return map[string]any{"error": fmt.Sprintf("%T: %v", err, err)}
+	}
 	var payload map[string]any
 	if json.Unmarshal(data, &payload) != nil {
 		return map[string]any{"error": "Invalid JSON from X API"}

--- a/apps/cli/cmd/newsjack/hardening_test.go
+++ b/apps/cli/cmd/newsjack/hardening_test.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestDateHelpersTolerateShortInput(t *testing.T) {
+	// These previously sliced date[:10] and panicked on short strings.
+	for _, in := range []string{"", "2026", "2026-08", "bad", "   "} {
+		if got := dateToUnix(in); got != 0 {
+			t.Errorf("dateToUnix(%q) = %d, want 0", in, got)
+		}
+		if got := lookbackHours(in, "2026-08-18"); got != 168 {
+			t.Errorf("lookbackHours(%q, ...) = %d, want fallback 168", in, got)
+		}
+		if got := tbsForRange("2026-08-01", in); got != "qdr:w" {
+			t.Errorf("tbsForRange(..., %q) = %q, want fallback qdr:w", in, got)
+		}
+	}
+	if got := datePrefix("2026-08-18T12:34:56Z"); got != "2026-08-18" {
+		t.Fatalf("datePrefix = %q", got)
+	}
+	if got := lookbackHours("2026-08-11", "2026-08-18T09:00:00Z"); got != 8*24 {
+		t.Fatalf("lookbackHours = %d, want %d", got, 8*24)
+	}
+	if got := dateToUnix("2026-08-18T00:00:00Z"); got == 0 {
+		t.Fatal("dateToUnix should parse a datetime prefix")
+	}
+}
+
+func TestAutoUpdateForcedParsing(t *testing.T) {
+	cases := map[string]bool{"": false, "0": false, "false": false, "1": true, "true": true, "ON": true, "yes": true}
+	for value, want := range cases {
+		withTempEnv(t, map[string]string{"NEWSJACK_AUTO_UPDATE": value}, func() {
+			if got := autoUpdateForced(); got != want {
+				t.Errorf("NEWSJACK_AUTO_UPDATE=%q forced=%v want %v", value, got, want)
+			}
+		})
+	}
+}
+
+func TestShouldAutoUpdateSkipsNonInteractiveRuns(t *testing.T) {
+	// go test never has a TTY on stdin, so implicit auto-update must be off here
+	// regardless of the other preconditions.
+	withTempEnv(t, map[string]string{"NEWSJACK_AUTO_UPDATE": "", "NEWSJACK_NO_AUTO_UPDATE": ""}, func() {
+		if stdinIsTerminal() {
+			t.Skip("stdin is a terminal; cannot exercise the non-interactive gate")
+		}
+		if shouldAutoUpdate([]string{"detector"}) {
+			t.Fatal("non-interactive invocation must not auto-update")
+		}
+	})
+}
+
+func TestDetectorStoreRoundTrip(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "monitor.db")
+	if err := initDB(dbPath); err != nil {
+		t.Fatalf("initDB: %v", err)
+	}
+	signals := []map[string]any{{"id": "s1", "title": "Fogo de Chão opens in Costa Rica", "url": "https://example.com/a"}}
+	seen := []string{"https://example.com/a", "https://example.com/b", "https://example.com/a"}
+	runID, err := recordRun("adega", map[string]any{"topics": []string{"churrascaria"}}, []string{"q1"}, signals, seen, dbPath)
+	if err != nil {
+		t.Fatalf("recordRun: %v", err)
+	}
+	if runID <= 0 {
+		t.Fatalf("unexpected run id %d", runID)
+	}
+	status, err := seenStatus([]string{"https://example.com/a", "https://example.com/zzz"}, dbPath)
+	if err != nil {
+		t.Fatalf("seenStatus: %v", err)
+	}
+	if _, ok := status["https://example.com/a"]; !ok {
+		t.Fatal("recorded URL should be reported as seen")
+	}
+	if _, ok := status["https://example.com/zzz"]; ok {
+		t.Fatal("unknown URL should not be reported as seen")
+	}
+	if got := status["https://example.com/a"]["sighting_count"]; got != 1 {
+		t.Fatalf("duplicate seen URLs within one run must count once, got %v", got)
+	}
+	// Second run bumps the sighting count.
+	if _, err := recordRun("adega", nil, nil, nil, []string{"https://example.com/a"}, dbPath); err != nil {
+		t.Fatalf("recordRun #2: %v", err)
+	}
+	status, _ = seenStatus([]string{"https://example.com/a"}, dbPath)
+	if got := status["https://example.com/a"]["sighting_count"]; got != 2 {
+		t.Fatalf("sighting_count after second run = %v, want 2", got)
+	}
+	runs, err := recentRuns(5, dbPath)
+	if err != nil {
+		t.Fatalf("recentRuns: %v", err)
+	}
+	if len(runs) != 2 || runs[0]["signal_count"] != 0 || runs[1]["signal_count"] != 1 {
+		t.Fatalf("unexpected recentRuns: %+v", runs)
+	}
+}

--- a/apps/cli/cmd/newsjack/http.go
+++ b/apps/cli/cmd/newsjack/http.go
@@ -71,7 +71,9 @@ func externalHTTPClient(timeout time.Duration) *http.Client {
 	}
 	dialer := &net.Dialer{Timeout: 10 * time.Second}
 	transport := &http.Transport{
-		Proxy:               http.ProxyFromEnvironment,
+		// No environment proxy: HTTP(S)_PROXY would let the proxy fetch a private URL on
+		// our behalf and bypass the destination check below.
+		Proxy:               nil,
 		TLSHandshakeTimeout: 10 * time.Second,
 		ForceAttemptHTTP2:   true,
 		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {

--- a/apps/cli/cmd/newsjack/http.go
+++ b/apps/cli/cmd/newsjack/http.go
@@ -2,12 +2,108 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"os"
 	"time"
 )
+
+// maxHTTPBodyBytes caps how much of any HTTP response body newsjack will read
+// (feeds, manifests, API replies). Larger bodies fail instead of exhausting memory.
+const maxHTTPBodyBytes = 10 << 20 // 10 MiB
+
+var errBodyTooLarge = errors.New("response body exceeds size limit")
+
+// readBodyLimited reads at most limit bytes and fails if the body is larger.
+func readBodyLimited(r io.Reader, limit int64) ([]byte, error) {
+	data, err := io.ReadAll(io.LimitReader(r, limit+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) > limit {
+		return nil, fmt.Errorf("%w (> %d bytes)", errBodyTooLarge, limit)
+	}
+	return data, nil
+}
+
+// allowPrivateURLs disables the SSRF guard for local development and tests
+// (feeds served from 127.0.0.1, etc.). Never set it on a server.
+func allowPrivateURLs() bool {
+	return os.Getenv("NEWSJACK_ALLOW_PRIVATE_URLS") == "1"
+}
+
+// isDisallowedIP reports whether an address must not be contacted on behalf of a
+// user-supplied URL: loopback, link-local (incl. cloud metadata 169.254.169.254),
+// RFC 1918 / ULA private ranges, CGNAT, multicast, and unspecified addresses.
+func isDisallowedIP(ip net.IP) bool {
+	if ip == nil {
+		return true
+	}
+	if ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() ||
+		ip.IsInterfaceLocalMulticast() || ip.IsMulticast() || ip.IsUnspecified() || ip.IsPrivate() {
+		return true
+	}
+	if ip4 := ip.To4(); ip4 != nil {
+		// 100.64.0.0/10 (carrier-grade NAT) and 0.0.0.0/8
+		if ip4[0] == 100 && ip4[1]&0xc0 == 64 {
+			return true
+		}
+		if ip4[0] == 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// externalHTTPClient returns a client for URLs that come from user data (feed URLs
+// in monitor profiles). It resolves the host itself, refuses non-public addresses,
+// and dials the vetted IP directly, so redirects and DNS tricks cannot reach
+// internal services or cloud metadata endpoints. NEWSJACK_ALLOW_PRIVATE_URLS=1
+// turns the guard off for local development.
+func externalHTTPClient(timeout time.Duration) *http.Client {
+	if allowPrivateURLs() {
+		return &http.Client{Timeout: timeout}
+	}
+	dialer := &net.Dialer{Timeout: 10 * time.Second}
+	transport := &http.Transport{
+		Proxy:               http.ProxyFromEnvironment,
+		TLSHandshakeTimeout: 10 * time.Second,
+		ForceAttemptHTTP2:   true,
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			host, port, err := net.SplitHostPort(addr)
+			if err != nil {
+				return nil, err
+			}
+			ips, err := net.DefaultResolver.LookupIPAddr(ctx, host)
+			if err != nil {
+				return nil, err
+			}
+			if len(ips) == 0 {
+				return nil, fmt.Errorf("no addresses for %s", host)
+			}
+			for _, ip := range ips {
+				if isDisallowedIP(ip.IP) {
+					return nil, fmt.Errorf("refusing to connect to non-public address %s for host %s", ip.IP, host)
+				}
+			}
+			var lastErr error
+			for _, ip := range ips {
+				conn, err := dialer.DialContext(ctx, network, net.JoinHostPort(ip.IP.String(), port))
+				if err == nil {
+					return conn, nil
+				}
+				lastErr = err
+			}
+			return nil, lastErr
+		},
+	}
+	return &http.Client{Timeout: timeout, Transport: transport}
+}
 
 func httpJSON(method, rawURL string, headers map[string]string, body any, timeout time.Duration) (map[string]any, error) {
 	var reader io.Reader
@@ -31,7 +127,10 @@ func httpJSON(method, rawURL string, headers map[string]string, body any, timeou
 		return nil, err
 	}
 	defer resp.Body.Close()
-	data, _ := io.ReadAll(resp.Body)
+	data, err := readBodyLimited(resp.Body, maxHTTPBodyBytes)
+	if err != nil {
+		return nil, err
+	}
 	if resp.StatusCode >= 400 {
 		return nil, fmt.Errorf("HTTP %d: %s", resp.StatusCode, truncate(string(data), 300))
 	}
@@ -42,7 +141,18 @@ func httpJSON(method, rawURL string, headers map[string]string, body any, timeou
 	return payload, nil
 }
 
+// httpGetRaw fetches operator-configured URLs (release manifests, API bases).
 func httpGetRaw(rawURL string, headers map[string]string, timeout time.Duration) (string, error) {
+	return httpGetRawWith(&http.Client{Timeout: timeout}, rawURL, headers)
+}
+
+// httpGetRawExternal fetches URLs that originate from user data (profile feed URLs):
+// same as httpGetRaw but through the SSRF-guarded client.
+func httpGetRawExternal(rawURL string, headers map[string]string, timeout time.Duration) (string, error) {
+	return httpGetRawWith(externalHTTPClient(timeout), rawURL, headers)
+}
+
+func httpGetRawWith(client *http.Client, rawURL string, headers map[string]string) (string, error) {
 	req, err := http.NewRequest("GET", rawURL, nil)
 	if err != nil {
 		return "", err
@@ -50,13 +160,15 @@ func httpGetRaw(rawURL string, headers map[string]string, timeout time.Duration)
 	for k, v := range headers {
 		req.Header.Set(k, v)
 	}
-	client := &http.Client{Timeout: timeout}
 	resp, err := client.Do(req)
 	if err != nil {
 		return "", err
 	}
 	defer resp.Body.Close()
-	data, _ := io.ReadAll(resp.Body)
+	data, err := readBodyLimited(resp.Body, maxHTTPBodyBytes)
+	if err != nil {
+		return "", err
+	}
 	if resp.StatusCode >= 400 {
 		return "", fmt.Errorf("HTTP %d: %s", resp.StatusCode, truncate(string(data), 300))
 	}

--- a/apps/cli/cmd/newsjack/http_guard_test.go
+++ b/apps/cli/cmd/newsjack/http_guard_test.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"errors"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestIsDisallowedIP(t *testing.T) {
+	blocked := []string{
+		"127.0.0.1", "127.8.8.8", "::1",
+		"10.0.0.1", "172.16.0.1", "172.31.255.255", "192.168.1.1", // RFC 1918
+		"169.254.169.254", "169.254.0.1", "fe80::1", // link-local incl. cloud metadata
+		"fc00::1", "fd12::1", // ULA
+		"100.64.0.1", "100.127.255.254", // CGNAT
+		"0.0.0.0", "0.1.2.3", "::",
+		"224.0.0.1", "ff02::1",
+	}
+	for _, s := range blocked {
+		if !isDisallowedIP(net.ParseIP(s)) {
+			t.Errorf("%s should be disallowed", s)
+		}
+	}
+	allowed := []string{"8.8.8.8", "1.1.1.1", "140.82.112.3", "172.32.0.1", "100.128.0.1", "2606:4700:4700::1111"}
+	for _, s := range allowed {
+		if isDisallowedIP(net.ParseIP(s)) {
+			t.Errorf("%s should be allowed", s)
+		}
+	}
+	if !isDisallowedIP(nil) {
+		t.Error("nil IP should be disallowed")
+	}
+}
+
+func TestExternalClientRefusesLoopback(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("<rss/>"))
+	}))
+	defer srv.Close()
+
+	withTempEnv(t, map[string]string{"NEWSJACK_ALLOW_PRIVATE_URLS": ""}, func() {
+		_, err := httpGetRawExternal(srv.URL, nil, 5*time.Second)
+		if err == nil {
+			t.Fatal("expected the SSRF guard to refuse a loopback URL")
+		}
+		if !strings.Contains(err.Error(), "non-public address") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	// The guard is off only with the explicit development override.
+	withTempEnv(t, map[string]string{"NEWSJACK_ALLOW_PRIVATE_URLS": "1"}, func() {
+		body, err := httpGetRawExternal(srv.URL, nil, 5*time.Second)
+		if err != nil {
+			t.Fatalf("override should allow loopback: %v", err)
+		}
+		if body != "<rss/>" {
+			t.Fatalf("unexpected body %q", body)
+		}
+	})
+}
+
+func TestCollectFeedRefusesPrivateURL(t *testing.T) {
+	withTempEnv(t, map[string]string{"NEWSJACK_ALLOW_PRIVATE_URLS": ""}, func() {
+		items, errText := collectFeed("http://169.254.169.254/latest/meta-data/", 5)
+		if len(items) != 0 || errText == "" {
+			t.Fatalf("expected a guarded error, got items=%d err=%q", len(items), errText)
+		}
+	})
+}
+
+func TestReadBodyLimited(t *testing.T) {
+	data, err := readBodyLimited(strings.NewReader("hello"), 5)
+	if err != nil || string(data) != "hello" {
+		t.Fatalf("exact-size body should pass: %v %q", err, data)
+	}
+	_, err = readBodyLimited(strings.NewReader("hello!"), 5)
+	if !errors.Is(err, errBodyTooLarge) {
+		t.Fatalf("oversize body should fail with errBodyTooLarge, got %v", err)
+	}
+}
+
+func TestHTTPGetRawCapsBodySize(t *testing.T) {
+	big := strings.Repeat("x", maxHTTPBodyBytes+1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(big))
+	}))
+	defer srv.Close()
+	_, err := httpGetRaw(srv.URL, nil, 10*time.Second)
+	if !errors.Is(err, errBodyTooLarge) {
+		t.Fatalf("expected body-size error, got %v", err)
+	}
+}

--- a/apps/cli/cmd/newsjack/http_guard_test.go
+++ b/apps/cli/cmd/newsjack/http_guard_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -62,6 +63,25 @@ func TestExternalClientRefusesLoopback(t *testing.T) {
 			t.Fatalf("unexpected body %q", body)
 		}
 	})
+}
+
+func TestExternalClientIgnoresEnvironmentProxy(t *testing.T) {
+	// A proxy in the environment must not be used to reach a blocked destination.
+	var proxied int32
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&proxied, 1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer proxy.Close()
+	withTempEnv(t, map[string]string{"NEWSJACK_ALLOW_PRIVATE_URLS": "", "HTTP_PROXY": proxy.URL, "http_proxy": proxy.URL, "HTTPS_PROXY": proxy.URL, "https_proxy": proxy.URL, "NO_PROXY": "", "no_proxy": ""}, func() {
+		_, err := httpGetRawExternal("http://10.0.0.1/feed.xml", nil, 5*time.Second)
+		if err == nil || !strings.Contains(err.Error(), "non-public address") {
+			t.Fatalf("expected the guard to refuse 10.0.0.1 directly, got %v", err)
+		}
+	})
+	if n := atomic.LoadInt32(&proxied); n != 0 {
+		t.Fatalf("guarded client used the environment proxy (%d requests)", n)
+	}
 }
 
 func TestCollectFeedRefusesPrivateURL(t *testing.T) {

--- a/apps/cli/cmd/newsjack/monitor.go
+++ b/apps/cli/cmd/newsjack/monitor.go
@@ -1212,10 +1212,6 @@ func runMonitor(slug string, mock, test bool, limit int) (map[string]any, error)
 	if err := os.WriteFile(paths["detector_summary"], marshalJSON(summary), 0o644); err != nil {
 		return nil, err
 	}
-	summary = summarizeRunAt(payload, paths["candidates"], 25, summaryGeneratedAt)
-	if err := os.WriteFile(paths["detector_summary"], marshalJSON(summary), 0o644); err != nil {
-		return nil, err
-	}
 	return map[string]any{
 		"slug":          slug,
 		"mock":          mock,

--- a/apps/cli/cmd/newsjack/update.go
+++ b/apps/cli/cmd/newsjack/update.go
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/mattn/go-isatty"
 )
 
 const autoUpdateGuard = "NEWSJACK_AUTO_UPDATE_RUNNING"
@@ -105,12 +107,10 @@ func maybeAutoUpdate(args []string, stderr io.Writer) (int, bool) {
 		logf(stderr, "auto-updating from %s to %s", current, latest)
 	}
 
-	if useNativeUpdate() {
-		if err := runNativeUpdate(os.Stderr, os.Stderr); err != nil {
-			warn(stderr, "auto-update failed: %v", err)
-			return 0, false
-		}
-	} else if err := runHostedInstaller(os.Stderr, os.Stderr); err != nil {
+	// Implicit (background) auto-updates always take the in-process native path:
+	// checksum-verified release bundle, no `curl | sh` of a URL read from install.json.
+	// The hosted installer remains available for an explicit `newsjack update`.
+	if err := runNativeUpdate(os.Stderr, os.Stderr); err != nil {
 		warn(stderr, "auto-update failed: %v", err)
 		return 0, false
 	}
@@ -127,6 +127,12 @@ func shouldAutoUpdate(args []string) bool {
 		return false
 	}
 	if os.Getenv(autoUpdateGuard) == "1" {
+		return false
+	}
+	// Non-interactive invocations (cron, CI, agent harnesses, pipes) never self-update
+	// unless NEWSJACK_AUTO_UPDATE is explicitly turned on: an unattended run must stay
+	// deterministic and must not swap its own binary mid-pipeline.
+	if !autoUpdateForced() && !stdinIsTerminal() {
 		return false
 	}
 	if !runningInstalledBinary() {
@@ -158,6 +164,20 @@ func autoUpdateDisabled() bool {
 		return true
 	}
 	return os.Getenv("NEWSJACK_NO_AUTO_UPDATE") == "1"
+}
+
+// autoUpdateForced reports an explicit NEWSJACK_AUTO_UPDATE=1/true/on/yes opt-in,
+// which re-enables implicit auto-update even for non-interactive invocations.
+func autoUpdateForced() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("NEWSJACK_AUTO_UPDATE"))) {
+	case "1", "true", "on", "yes":
+		return true
+	}
+	return false
+}
+
+func stdinIsTerminal() bool {
+	return isatty.IsTerminal(os.Stdin.Fd()) || isatty.IsCygwinTerminal(os.Stdin.Fd())
 }
 
 func runningInstalledBinary() bool {

--- a/apps/cli/cmd/newsjack/util.go
+++ b/apps/cli/cmd/newsjack/util.go
@@ -395,14 +395,27 @@ func envFloat(key string, fallback float64) float64 {
 	return fallback
 }
 
+// datePrefix returns the leading YYYY-MM-DD portion of a date/datetime string
+// without panicking on short or empty input (time.Parse then reports the error).
+func datePrefix(date string) string {
+	date = strings.TrimSpace(date)
+	if len(date) > 10 {
+		return date[:10]
+	}
+	return date
+}
+
 func dateToUnix(date string) int64 {
-	t, _ := time.Parse("2006-01-02", date[:10])
+	t, err := time.Parse("2006-01-02", datePrefix(date))
+	if err != nil {
+		return 0
+	}
 	return t.Unix()
 }
 
 func lookbackHours(fromDate, toDate string) int {
-	start, err1 := time.Parse("2006-01-02", fromDate[:10])
-	end, err2 := time.Parse("2006-01-02", toDate[:10])
+	start, err1 := time.Parse("2006-01-02", datePrefix(fromDate))
+	end, err2 := time.Parse("2006-01-02", datePrefix(toDate))
 	if err1 != nil || err2 != nil {
 		return 168
 	}
@@ -414,8 +427,8 @@ func lookbackHours(fromDate, toDate string) int {
 }
 
 func tbsForRange(fromDate, toDate string) string {
-	start, err1 := time.Parse("2006-01-02", fromDate[:10])
-	end, err2 := time.Parse("2006-01-02", toDate[:10])
+	start, err1 := time.Parse("2006-01-02", datePrefix(fromDate))
+	end, err2 := time.Parse("2006-01-02", datePrefix(toDate))
 	if err1 != nil || err2 != nil {
 		return "qdr:w"
 	}


### PR DESCRIPTION
## Summary

Hardens the CLI's outbound HTTP (SSRF guard + 10 MiB body cap on profile-supplied feed URLs), makes implicit auto-update use the checksum-verified native path (never `curl | sh`) and skip non-interactive runs, fixes a few latent panics/nil-derefs, and moves `workflow_dispatch` inputs out of inline `run:` shell in two workflows.

## Motivation

We self-host newsjack on a server (daily cron + read-only Claude Code agent) and ran a security review of the CLI before deploying. Findings we wanted fixed at the source rather than only mitigated on the box:

- **SSRF via `feed_urls`.** A monitor profile is user data; `collectFeed` fetched whatever URL it contained with a plain client, so a profile (or a redirect from a feed host) could reach `169.254.169.254`, RFC 1918 services, or localhost. Bodies were also read unbounded.
- **Implicit auto-update piped a remote script into `sh`** (`runHostedInstaller`) using an install URL read from a world-readable `install.json`, and it could fire in the middle of an unattended cron/agent run and swap the binary.
- Latent panics: `date[:10]` on short strings in `util.go`; discarded `http.NewRequest` error in `apiGet`; a duplicated summary write in `monitor.go`.
- Script-injection surface: `${{ inputs.* }}` interpolated directly into `run:` blocks in `post-release-smoke.yml` / `agent-harness-integration.yml`.

## Implementation notes

- `http.go`: `externalHTTPClient` resolves the host in `DialContext`, rejects non-public IPs (loopback, link-local incl. metadata, RFC 1918/ULA, CGNAT 100.64/10, 0/8, multicast, unspecified) and dials the vetted IP directly, so redirects and DNS rebinding are covered; TLS still verifies against the original hostname. `NEWSJACK_ALLOW_PRIVATE_URLS=1` disables it for local dev/tests. Only `collectFeed` uses it — operator-configured URLs (release manifest, `NEWSJACK_X_API_BASE`, Medialyst) keep the plain client, so `update_test.go`'s httptest fixtures are unaffected. `readBodyLimited` (10 MiB) applies to all raw/JSON reads.
- `update.go`: `maybeAutoUpdate` now always calls `runNativeUpdate` (already checksum-verified via `bundle.go`); `shouldAutoUpdate` returns false when stdin isn't a TTY unless `NEWSJACK_AUTO_UPDATE=1/true/on/yes` (new `autoUpdateForced`). Explicit `newsjack update` behaviour is unchanged (hosted installer still default outside Windows). Reviewers: this is the one behavioural change worth a look — it removes background self-updates from cron/CI/agent invocations by default.
- `util.go`: `datePrefix` helper; `dateToUnix` returns 0 on unparsable input instead of a zero-time Unix value from a partial slice.
- Tests added in `http_guard_test.go` / `hardening_test.go` (9 tests incl. a `detector_store` round-trip); full suite green on linux, `go vet` clean, cross-builds for windows/amd64, darwin/arm64+amd64, linux/arm64 OK.

## Checklist

- [x] Commit messages follow conventional commits (`feat:`, `fix:`, `docs:`, etc.)
- [x] No secrets or credentials committed (gitleaks runs in CI; please also review the diff)
- [x] New skills follow the structure established by `skills/meanest-editor/` (n/a — no skills touched)
- [x] Positioning copy is consistent with **agentic PR** as the product category (n/a — no copy touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Blocked requests to private or reserved network addresses.
  - Limited downloaded response sizes and improved error handling.

- **Bug Fixes**
  - Prevented crashes from short or malformed dates.
  - Improved external feed and API reliability.
  - Fixed detector history and duplicate URL tracking.

- **Updates**
  - Improved automatic update behavior across interactive and non-interactive environments.
  - Explicit updates continue using hosted installation flows.

- **Reliability**
  - Improved release smoke tests and installer handling across supported environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->